### PR TITLE
fix(api): do not assume that dir produces attributes that exist

### DIFF
--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -134,6 +134,31 @@ jobs:
       - name: check shapely and duckdb imports
         run: uv run --extra duckdb --extra geospatial python -c 'import shapely.geometry, duckdb'
 
+  test_scrapy_import:
+    name: Test import with twisted
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: install python
+        uses: actions/setup-python@v5
+        id: install_python
+        with:
+          python-version: "3.13"
+
+      - name: install uv
+        uses: astral-sh/setup-uv@v6.4.3
+
+      - name: check scrapy import
+        run: uv run --with scrapy python -c 'import scrapy; import ibis'
+
+      - name: remove virtual env
+        run: rm -rf .venv
+
+      - name: check twisted import
+        run: uv run --with scrapy python -c 'import twisted.internet.ssl; import ibis'
+
   test_doctests:
     name: Doctests
     runs-on: ubuntu-latest

--- a/ibis/common/typing.py
+++ b/ibis/common/typing.py
@@ -67,7 +67,16 @@ def get_type_hints(
 
     if include_properties:
         for name in dir(obj):
-            attr = getattr(obj, name)
+            # https://docs.python.org/3/library/functions.html#dir
+            # it's entirely possible for attributes to come out of `dir(obj)`
+            # that don't exist on the `obj`
+            #
+            # dir is designed to inform interactive use, not to consistently or
+            # rigorously defined
+            #
+            # https://github.com/great-expectations/great_expectations/issues/9698#issuecomment-2051252373
+            # is another in-the-wild example of this
+            attr = getattr(obj, name, None)
             if isinstance(attr, property):
                 annots = _get_type_hints(attr.fget, include_extras=include_extras)
                 if return_annot := annots.get("return"):


### PR DESCRIPTION
Ignore attribute errors when using `getattr` on the output `dir`. Apparently the output of `dir` is not guaranteed to contain names of attributes that exist. Closes #11495.