### PR TITLE
chore(duckdb): properly inherit from `CanListCatalog`

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -24,6 +24,7 @@ import ibis.expr.types as ir
 from ibis import util
 from ibis.backends import (
     CanCreateDatabase,
+    CanListCatalog,
     DirectExampleLoader,
     HasCurrentCatalog,
     HasCurrentDatabase,
@@ -74,6 +75,7 @@ class _Settings:
 
 class Backend(
     SQLBackend,
+    CanListCatalog,
     CanCreateDatabase,
     HasCurrentCatalog,
     HasCurrentDatabase,


### PR DESCRIPTION
Closes #11493.