### PR TITLE
refactor(sqlite): move sqlite3 imports local to avoid pyodide import issues with non-sqlite backends

### DIFF
--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -504,3 +504,23 @@ def test_basic_enum_schema_inference(con, converter):
     t = con.table(name)
     assert t.e.type() == dt.string
     assert set(converter(t.e)) == {"a", "b"}
+
+
+def test_connect_does_not_load_sqlite3():
+    script = """\
+import sys
+import ibis
+
+# not loaded by default
+assert "sqlite3" not in sys.modules
+
+ibis.duckdb.connect()
+
+# still not loaded once duckdb connects
+assert "sqlite3" not in sys.modules
+
+# loads when sqlite3 is connected
+ibis.sqlite.connect()
+
+assert "sqlite3" in sys.modules"""
+    subprocess.run([sys.executable, "-c", script], check=True)

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import functools
-import sqlite3
 from typing import TYPE_CHECKING, Any
 
 import sqlglot as sg
@@ -23,6 +22,9 @@ from ibis.backends.sqlite.converter import SQLitePandasData
 from ibis.backends.sqlite.udf import ignore_nulls, register_all
 
 if TYPE_CHECKING:
+    # pyodide doesn't ship with sqlite3 in the stdlib, which causes import
+    # errors when trying to import it at the top level inside tools like marimo
+    import sqlite3
     from collections.abc import Iterator, Mapping
     from pathlib import Path
 
@@ -33,10 +35,15 @@ if TYPE_CHECKING:
 
 @functools.cache
 def _init_sqlite3():
+    # pyodide doesn't ship with sqlite3 in the stdlib, which causes import
+    # errors when trying to import it at the top level inside tools like marimo
+    import sqlite3
+
     import pandas as pd
 
     # required to support pandas Timestamp's from user input
     sqlite3.register_adapter(pd.Timestamp, pd.Timestamp.isoformat)
+    return sqlite3
 
 
 def _quote(name: str) -> str:
@@ -59,6 +66,11 @@ class Backend(
 
     @property
     def version(self) -> str:
+        # pyodide doesn't ship with sqlite3 in the stdlib, which causes import
+        # errors when trying to import it at the top level inside tools like
+        # marimo
+        import sqlite3
+
         return sqlite3.sqlite_version
 
     def do_connect(
@@ -94,7 +106,7 @@ class Backend(
            x
         0  1
         """
-        _init_sqlite3()
+        sqlite3 = _init_sqlite3()
 
         self.con = sqlite3.connect(":memory:" if database is None else database)
 


### PR DESCRIPTION
Addresses issues with using marimo and importing sqlite3. xref: https://github.com/marimo-team/marimo/issues/5738