### PR TITLE
fix(pyspark): only register json unwraps if they are being used

### DIFF
--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -408,10 +408,10 @@ class Backend(
             udf_return = PySparkType.from_ibis(udf.dtype)
             if udf.__input_type__ == InputType.PANDAS:
                 udf_func = self._wrap_udf_to_return_pandas(udf.__func__, udf.dtype)
-                spark_udf = F.pandas_udf(udf_func, udf_return)
+                spark_udf = F.pandas_udf(udf_func, returnType=udf_return)
             elif udf.__input_type__ == InputType.PYTHON:
                 udf_func = udf.__func__
-                spark_udf = F.udf(udf_func, udf_return)
+                spark_udf = F.udf(udf_func, returnType=udf_return)
             elif udf.__input_type__ == InputType.PYARROW:
                 # raise not implemented error if running on pyspark < 3.5
                 if PYSPARK_LT_35:
@@ -419,7 +419,7 @@ class Backend(
                         "pyarrow UDFs are only supported in pyspark >= 3.5"
                     )
                 udf_func = udf.__func__
-                spark_udf = F.udf(udf_func, udf_return, useArrow=True)
+                spark_udf = F.udf(udf_func, returnType=udf_return, useArrow=True)
             else:
                 # Builtin functions don't need to be registered
                 continue
@@ -429,7 +429,7 @@ class Backend(
             udf_name = self.compiler.__sql_name__(udf)
             udf_func = self._wrap_udf_to_return_pandas(udf.func, udf.return_type)
             udf_return = PySparkType.from_ibis(udf.return_type)
-            spark_udf = F.pandas_udf(udf_func)
+            spark_udf = F.pandas_udf(udf_func, returnType=udf_return)
             self._session.udf.register(udf_name, spark_udf)
 
         for udf in node.find(ops.ReductionVectorizedUDF):
@@ -437,7 +437,7 @@ class Backend(
             udf_func = self._wrap_udf_to_return_pandas(udf.func, udf.return_type)
             udf_func = udf.func
             udf_return = PySparkType.from_ibis(udf.return_type)
-            spark_udf = F.pandas_udf(udf_func, udf_return)
+            spark_udf = F.pandas_udf(udf_func, returnType=udf_return)
             self._session.udf.register(udf_name, spark_udf)
 
         # only register the JSON unwrap udfs if they exist in the expression

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -226,7 +226,7 @@ demean_struct_udfs = [
 
 
 # reduction multi-column UDF
-def mean_struct(v: pd.Series, w: pd.Series) -> pd.DataFrame:
+def mean_struct(v: pd.Series, w: pd.Series) -> tuple[float, float]:
     assert isinstance(v, (np.ndarray, pd.Series))
     assert isinstance(w, (np.ndarray, pd.Series))
     return v.mean(), w.mean()
@@ -256,7 +256,7 @@ with pytest.warns(FutureWarning, match="v9.0"):
         input_type=[dt.double, dt.int64],
         output_type=dt.Struct({"double_col": dt.double, "mean_weight": dt.double}),
     )
-    def overwrite_struct_reduction(v: pd.Series, w: pd.Series) -> pd.DataFrame:
+    def overwrite_struct_reduction(v: pd.Series, w: pd.Series) -> tuple[float, float]:
         assert isinstance(v, (np.ndarray, pd.Series))
         assert isinstance(w, (np.ndarray, pd.Series))
         return v.mean(), w.mean()

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -50,7 +50,7 @@ def _format_struct_udf_return_type(func, result_formatter):
 
 
 # elementwise UDF
-def add_one(s):
+def add_one(s: pd.Series) -> pd.Series:
     assert isinstance(s, pd.Series), type(s)
     return s + 1
 
@@ -59,7 +59,7 @@ def create_add_one_udf(result_formatter, id):
     with pytest.warns(FutureWarning, match="v9.0"):
 
         @elementwise(input_type=[dt.double], output_type=dt.double)
-        def add_one_legacy(s):
+        def add_one_legacy(s: pd.Series) -> pd.Series:
             return result_formatter(add_one(s))
 
     @ibis.udf.scalar.pandas
@@ -78,7 +78,7 @@ add_one_udfs = [
 
 
 # analytic UDF
-def calc_zscore(s):
+def calc_zscore(s: pd.Series) -> pd.Series:
     assert isinstance(s, pd.Series)
     return (s - s.mean()) / s.std()
 
@@ -99,13 +99,13 @@ calc_zscore_udfs = [
 with pytest.warns(FutureWarning, match="v9.0"):
 
     @reduction(input_type=[dt.double], output_type=dt.double)
-    def calc_mean(s):
+    def calc_mean(s: pd.Series) -> float:
         assert isinstance(s, (np.ndarray, pd.Series))
         return s.mean()
 
 
 # elementwise multi-column UDF
-def add_one_struct(v):
+def add_one_struct(v: pd.Series) -> pd.DataFrame:
     assert isinstance(v, pd.Series)
     return v + 1, v + 2
 
@@ -159,7 +159,7 @@ with pytest.warns(FutureWarning, match="v9.0"):
         input_type=[dt.double],
         output_type=dt.Struct({"double_col": dt.double, "col2": dt.double}),
     )
-    def overwrite_struct_elementwise(v):
+    def overwrite_struct_elementwise(v: pd.Series) -> pd.DataFrame:
         assert isinstance(v, pd.Series)
         return v + 1, v + 2
 
@@ -169,7 +169,7 @@ with pytest.warns(FutureWarning, match="v9.0"):
             {"double_col": dt.double, "col2": dt.double, "float_col": dt.double}
         ),
     )
-    def multiple_overwrite_struct_elementwise(v):
+    def multiple_overwrite_struct_elementwise(v: pd.Series) -> pd.DataFrame:
         assert isinstance(v, pd.Series)
         return v + 1, v + 2, v + 3
 
@@ -180,14 +180,14 @@ with pytest.warns(FutureWarning, match="v9.0"):
         input_type=[dt.double, dt.double],
         output_type=dt.Struct({"double_col": dt.double, "demean_weight": dt.double}),
     )
-    def overwrite_struct_analytic(v, w):
+    def overwrite_struct_analytic(v: pd.Series, w: pd.Series) -> pd.DataFrame:
         assert isinstance(v, pd.Series)
         assert isinstance(w, pd.Series)
         return v - v.mean(), w - w.mean()
 
 
 # analytic multi-column UDF
-def demean_struct(v, w):
+def demean_struct(v: pd.Series, w: pd.Series) -> pd.DataFrame:
     assert isinstance(v, pd.Series)
     assert isinstance(w, pd.Series)
     return v - v.mean(), w - w.mean()
@@ -226,7 +226,7 @@ demean_struct_udfs = [
 
 
 # reduction multi-column UDF
-def mean_struct(v, w):
+def mean_struct(v: pd.Series, w: pd.Series) -> pd.DataFrame:
     assert isinstance(v, (np.ndarray, pd.Series))
     assert isinstance(w, (np.ndarray, pd.Series))
     return v.mean(), w.mean()
@@ -256,16 +256,13 @@ with pytest.warns(FutureWarning, match="v9.0"):
         input_type=[dt.double, dt.int64],
         output_type=dt.Struct({"double_col": dt.double, "mean_weight": dt.double}),
     )
-    def overwrite_struct_reduction(v, w):
+    def overwrite_struct_reduction(v: pd.Series, w: pd.Series) -> pd.DataFrame:
         assert isinstance(v, (np.ndarray, pd.Series))
         assert isinstance(w, (np.ndarray, pd.Series))
         return v.mean(), w.mean()
 
-    @reduction(
-        input_type=[dt.double],
-        output_type=dt.Array(dt.double),
-    )
-    def quantiles(series, *, quantiles):
+    @reduction(input_type=[dt.double], output_type=dt.Array(dt.double))
+    def quantiles(series: pd.Series, *, quantiles: pd.Series) -> list[float]:
         return series.quantile(quantiles)
 
 

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -69,11 +69,11 @@ def pandas_ntile(x, bucket: int):
 with pytest.warns(FutureWarning, match="v9.0"):
 
     @reduction(input_type=[dt.double], output_type=dt.double)
-    def mean_udf(s):
+    def mean_udf(s: pd.Series) -> float:
         return s.mean()
 
     @analytic(input_type=[dt.double], output_type=dt.double)
-    def calc_zscore(s):
+    def calc_zscore(s: pd.Series) -> pd.Series:
         return (s - s.mean()) / s.std()
 
 

--- a/nix/pyproject-overrides.nix
+++ b/nix/pyproject-overrides.nix
@@ -144,7 +144,9 @@ in
     {
       nativeBuildInputs = attrs.nativeBuildInputs or [ ] ++ [ final.setuptools ];
       postInstall = attrs.postInstall or "" + ''
-        cp ${icebergJar} $out/${final.python.sitePackages}/pyspark/jars/${icebergJar.name}
+        cp -v ${icebergJar} $out/${final.python.sitePackages}/pyspark/jars/${icebergJar.name}
+        mkdir -p $out/${final.python.sitePackages}/pyspark/conf
+        cp -v ${../docker/spark-connect/log4j2.properties} $out/${final.python.sitePackages}/pyspark/conf/log4j2.properties
       '';
     }
   );


### PR DESCRIPTION
Closes #11485.

BREAKING CHANGE: Type annotations using `pd.Series`/`pd.DataFrame` are now required per the non-deprecated PySpark Pandas UDF API.