### PR TITLE
feat: allow dtype(Union[T, None])

### DIFF
--- a/ibis/common/typing.py
+++ b/ibis/common/typing.py
@@ -24,7 +24,7 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
-    UnionType = object()
+    UnionType = type(Union[int, str])
     _ClassInfo: TypeAlias = Union[type, tuple["_ClassInfo", ...]]
 
 

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -245,6 +245,17 @@ class DataType(Concrete, Coercible):
 
     @classmethod
     def from_typehint(cls, typ, nullable=True) -> Self:
+        # All types are nullable by default
+        # (eg `ibis.dtype(int)` results in `Int64(nullable=True)`),
+        # so if we are handed Union[None, T], simplify it to T.
+        #
+        # Depending on if you use `Union[A, B]` vs `A | B`, the type differs,
+        # so the most robust way I found to test for union is with `type(typ).__name__`.
+        if "Union" in type(typ).__name__:
+            none_Nones = [t for t in get_args(typ) if t is not type(None)]
+            if len(none_Nones) == 1:
+                typ = none_Nones[0]
+
         origin_type = get_origin(typ)
 
         if origin_type is None:

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -16,6 +16,7 @@ from typing import (
     NamedTuple,
     Optional,
     TypeVar,
+    Union,
     get_type_hints,
     overload,
 )
@@ -30,6 +31,7 @@ from ibis.common.dispatch import lazy_singledispatch
 from ibis.common.grounds import Concrete, Singleton
 from ibis.common.patterns import Between, Coercible, CoercionError
 from ibis.common.temporal import IntervalUnit, TimestampUnit
+from ibis.common.typing import UnionType
 
 if TYPE_CHECKING:
     import numpy as np
@@ -249,12 +251,13 @@ class DataType(Concrete, Coercible):
         # (eg `ibis.dtype(int)` results in `Int64(nullable=True)`),
         # so if we are handed Union[None, T], simplify it to T.
         #
-        # Depending on if you use `Union[A, B]` vs `A | B`, the type differs,
-        # so the most robust way I found to test for union is with `type(typ).__name__`.
-        if "Union" in type(typ).__name__:
-            none_Nones = [t for t in get_args(typ) if t is not type(None)]
-            if len(none_Nones) == 1:
-                typ = none_Nones[0]
+        # Depending on if you use `Union[A, B]` vs `A | B`, the type differs
+        #
+        # with Optional, you get __origin__ and with | syntax you get a UnionType
+        if getattr(typ, "__origin__", None) is Union or isinstance(typ, UnionType):
+            not_nones = [t for t in get_args(typ) if t is not type(None)]
+            if len(not_nones) == 1:
+                typ = not_nones[0]
 
         origin_type = get_origin(typ)
 

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -4,7 +4,7 @@ import datetime  # noqa: TC003
 import decimal  # noqa: TC003
 import uuid  # noqa: TC003
 from dataclasses import dataclass
-from typing import Annotated, NamedTuple
+from typing import Annotated, NamedTuple, Union
 
 import pytest
 from pytest import param
@@ -58,12 +58,19 @@ def test_dtype(spec, expected):
     [
         ((int,), dt.Int64(nullable=True)),
         ((int, False), dt.Int64(nullable=False)),
+        ((Union[int, None],), dt.Int64(nullable=True)),
+        ((Union[int, None], False), dt.Int64(nullable=False)),
         (("!int",), dt.Int64(nullable=False)),
         (("!int", True), dt.Int64(nullable=False)),  # "!" overrides `nullable`
     ],
 )
 def test_nullable_dtype(args, expected):
     assert dt.dtype(*args) == expected
+
+
+def test_bogus_union():
+    with pytest.raises(TypeError):
+        dt.dtype(Union[int, str])
 
 
 @pytest.mark.parametrize(

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import datetime  # noqa: TC003
 import decimal  # noqa: TC003
+import sys
 import uuid  # noqa: TC003
 from dataclasses import dataclass
-from typing import Annotated, NamedTuple, Union
+from typing import Annotated, NamedTuple, Optional, Union
 
 import pytest
 from pytest import param
@@ -56,16 +57,28 @@ def test_dtype(spec, expected):
 @pytest.mark.parametrize(
     ("args", "expected"),
     [
-        ((int,), dt.Int64(nullable=True)),
-        ((int, False), dt.Int64(nullable=False)),
-        ((Union[int, None],), dt.Int64(nullable=True)),
-        ((Union[int, None], False), dt.Int64(nullable=False)),
-        (("!int",), dt.Int64(nullable=False)),
-        (("!int", True), dt.Int64(nullable=False)),  # "!" overrides `nullable`
+        (lambda: (int,), dt.Int64(nullable=True)),
+        (lambda: (int, False), dt.Int64(nullable=False)),
+        (lambda: (Union[int, None],), dt.Int64(nullable=True)),
+        (lambda: (Union[int, None], False), dt.Int64(nullable=False)),
+        (lambda: (Optional[int],), dt.Int64(nullable=True)),
+        (lambda: (Optional[int], False), dt.Int64(nullable=False)),
+        pytest.param(
+            lambda: (int | None,),
+            dt.Int64(nullable=True),
+            marks=pytest.mark.xfail(sys.version_info < (3, 10), reason="python 3.9"),
+        ),
+        pytest.param(
+            lambda: (int | None, False),
+            dt.Int64(nullable=False),
+            marks=pytest.mark.xfail(sys.version_info < (3, 10), reason="python 3.9"),
+        ),
+        (lambda: ("!int",), dt.Int64(nullable=False)),
+        (lambda: ("!int", True), dt.Int64(nullable=False)),  # "!" overrides `nullable`
     ],
 )
 def test_nullable_dtype(args, expected):
-    assert dt.dtype(*args) == expected
+    assert dt.dtype(*args()) == expected
 
 
 def test_bogus_union():

--- a/ibis/tests/expr/test_udf.py
+++ b/ibis/tests/expr/test_udf.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 import pytest
 
 import ibis
@@ -156,7 +158,7 @@ def test_builtin_scalar_noargs():
 
 def test_None_type_hint(table):
     @ibis.udf.scalar.python
-    def claims_to_return_nullable(x: int | None) -> int | None: ...
+    def claims_to_return_nullable(x: Optional[int]) -> Optional[int]: ...
 
     expr = claims_to_return_nullable(table.a)
     assert isinstance(expr, ir.IntegerColumn)


### PR DESCRIPTION
Fixes https://github.com/ibis-project/ibis/issues/11420

I'm not sure if this has other implications, @cpcloud would need to chime in if this messes up the semantics of things. My intention is this mostly just makes thing more lax.