### PR TITLE
chore(deps): bump iceberg spark jar to latest version

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -561,7 +561,7 @@ jobs:
             pyspark-minor-version: "3.3"
             tag: local
             deps:
-              - pyspark==3.3.4
+              - pyspark==3.3.3
               - pandas==1.5.3
               - numpy==1.23.5
           - python-version: "3.11"

--- a/compose.yaml
+++ b/compose.yaml
@@ -593,7 +593,7 @@ services:
     image: bitnami/spark:3.5.6
     ports:
       - 15002:15002
-    command: /opt/bitnami/spark/sbin/start-connect-server.sh --name ibis_testing --packages org.apache.spark:spark-connect_2.12:3.5.3,org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.6.1,io.delta:delta-spark_2.12:3.3.0
+    command: /opt/bitnami/spark/sbin/start-connect-server.sh --name ibis_testing --packages org.apache.spark:spark-connect_2.12:3.5.3,org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.2,io.delta:delta-spark_2.12:3.3.0
     healthcheck:
       test:
         - CMD-SHELL

--- a/docker/spark-connect/conf.properties
+++ b/docker/spark-connect/conf.properties
@@ -1,6 +1,6 @@
 spark.driver.extraJavaOptions=-Duser.timezone=GMT
 spark.executor.extraJavaOptions=-Duser.timezone=GMT
-spark.jars.packages=org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.6.1
+spark.jars.packages=org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.2
 spark.sql.catalog.local.type=hadoop
 spark.sql.catalog.local.warehouse=warehouse
 spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog

--- a/justfile
+++ b/justfile
@@ -144,7 +144,7 @@ download-data owner="ibis-project" repo="testing-data" rev="master":
     fi
 
 # download the iceberg jar used for testing pyspark and iceberg integration
-download-iceberg-jar pyspark scala="2.12" iceberg="1.6.1":
+download-iceberg-jar pyspark scala="2.12" iceberg="1.9.2":
     #!/usr/bin/env bash
     set -eo pipefail
 

--- a/nix/pyproject-overrides.nix
+++ b/nix/pyproject-overrides.nix
@@ -128,10 +128,16 @@ in
     let
       pysparkVersion = lib.versions.majorMinor attrs.version;
       jarHashes = {
-        "3.5" = "sha256-h+cYTzHvDKrEFbvfzxvElDNGpYuY10fcg0NPcTnhKss=";
+        "3.5" = "sha256-xArgqOJnO7XAGVG30VquIiSlNPgzH0J0ziCCd2EWoEQ=";
+        "3.4" = "sha256-q/mchG/LvK+S0FVjQz75OzemDzoRefAdLaWoLzNeMco=";
         "3.3" = "sha256-3D++9VCiLoMP7jPvdCtBn7xnxqHnyQowcqdGUe0M3mk=";
       };
-      icebergVersion = "1.6.1";
+      icebergVersions = {
+        "3.5" = "1.9.2";
+        "3.4" = "1.9.2";
+        "3.3" = "1.6.1";
+      };
+      icebergVersion = icebergVersions."${pysparkVersion}";
       scalaVersion = "2.12";
       jarName = "iceberg-spark-runtime-${pysparkVersion}_${scalaVersion}-${icebergVersion}.jar";
       icebergJarUrl = "https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-${pysparkVersion}_${scalaVersion}/${icebergVersion}/${jarName}";


### PR DESCRIPTION
Bump iceberg jar used in testing to the latest release for the given pyspark runtime.