### PR TITLE
perf(binding): only create a dereference map in `Table.bind` when needed

### DIFF
--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -934,6 +934,16 @@ def test_wide_drop_compile(benchmark, wide_table, cols_to_drop):
     )
 
 
+def test_bind_on_wide_table(benchmark, wide_table):
+    # use a chain of select expressions on a wide table to test performance of Table.bind (internally used by select)
+    def select_chain(wide_table):
+        expr = wide_table.select(wide_table.columns[:-1])
+        expr2 = expr.select(expr.columns[:-1])
+        expr2.select(expr2.columns[:-1])
+
+    benchmark(select_chain, wide_table)
+
+
 @pytest.mark.parametrize(
     "method",
     [


### PR DESCRIPTION

## Description of changes

This PR changes Table.bind to only build a dereference map when at least one expression to be bound is either not a literal or not related to the current Table.

Building dereference maps is relatively expensive for i) wide tables ii) tables formed from chains of multiple expressions, so avoiding building them when possible will improve performance of building ibis expressions

Changes implemented were suggested by @kszucs in this thread: https://github.com/ibis-project/ibis/issues/10956#issuecomment-3090640798

@kszucs you mention adding tests - did you have anything specific in mind?  I've run the "core" test suite locally and that passes and this PR should run wider tests.  We could add a test e.g. that no dereference map is built if an expression that shouldn't need one is used?  LMK and I can add.

Thanks
