### PR TITLE
fix(duckdb): allow creating tables with columns containing sql keywords

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -220,8 +220,11 @@ class Backend(
         final_table = sg.table(name, catalog=catalog, db=database, quoted=quoted)
         with self._safe_raw_sql(create_stmt) as cur:
             if query is not None:
+                columns = [
+                    sge.to_identifier(col, quoted=quoted) for col in table.columns
+                ]
                 insert_stmt = sge.insert(
-                    query, into=initial_table, columns=table.columns
+                    query, into=initial_table, columns=columns
                 ).sql(dialect)
                 cur.execute(insert_stmt).fetchall()
 

--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -469,6 +469,15 @@ def test_create_temp_table_in_nondefault_schema():
     con.create_table("foo", {"id": [1, 2, 3]}, temp=True)
 
 
+def test_create_table_with_quoted_columns():
+    con = ibis.duckdb.connect()
+    name = gen_name("quoted_columns_table")
+    df = pd.DataFrame(
+        {"group": ["G1"], "value": ["E1"], "id": [1], "date": [datetime(2025, 5, 13)]}
+    )
+    con.create_table(name, df, temp=True)
+
+
 def test_create_table_with_out_of_order_columns(con):
     name = gen_name("out_of_order_columns_table")
     df = pd.DataFrame({"value": ["E1"], "id": [1], "date": [datetime(2025, 5, 13)]})


### PR DESCRIPTION
## Description of Changes

A bug was introduced in #11290 where specifying the `columns` parameter in `sge.insert` (line 226) leads to unquoted column names in the generated SQL query. As a result, if any column name coincides with a SQL keyword, the query fails with the following error:

```
duckdb.duckdb.ParserException: Parser Error: syntax error at or near "SQL_KEYWORD"
```

This change updates the insert logic to ensure all column names are properly quoted.
