### PR TITLE
feat: Replacing list_table_metadata with get_table_metadata in athena backend _get_schema_with_query. 

### DIFF
--- a/ibis/backends/athena/__init__.py
+++ b/ibis/backends/athena/__init__.py
@@ -574,11 +574,10 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
         catalog_name = self.current_catalog
         schema_name = self.current_database
         with self._safe_raw_sql(create_view, unload=False) as cur:
-            (table_meta,) = cur.list_table_metadata(
+            table_meta = cur.get_table_metadata(
                 catalog_name=catalog_name,
                 schema_name=schema_name,
-                expression=view_name,
-                max_results=1,
+                table_name=view_name
             )
             cur.execute(drop_view)
 


### PR DESCRIPTION

## Description of changes

<!--
In the `_get_schema_with_query` function of the Athena backend, this PR replaces the use of pyathena's `list_table_metadata` with the `get_table_metadata` function. 

`list_table_metadata` is meant for searching over all tables that match an expression, and returning a list where each element is the metadata of a matching table. It becomes slower with the more tables in a glue catalog. In cases with thousands of tables, it sometimes hangs indefinitely.

`get_table_metadata` immediately finds and returns only the metadata associated with the exact table name provided.

In the `_get_schema_with_query` function, a temporary 'view' table is created and given a unique name, and then its metadata is queried using the `list_table_metadata`, but `get_table_metadata` would be more suitable since we don't need to search over all tables to find a matching expression because we know the exact table name. 


-->

## Issues closed

<!--
Resolves #11572 


-->
