### PR TITLE
feat: support dtype(ir.Value) and ir.Value[<dtype>]

### DIFF
--- a/ibis/expr/tests/test_schema.py
+++ b/ibis/expr/tests/test_schema.py
@@ -9,6 +9,7 @@ import sqlglot.expressions as sge
 
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
+import ibis.expr.types as ir
 from ibis.common.exceptions import IntegrityError
 from ibis.common.grounds import Annotable
 from ibis.common.patterns import CoercedTo
@@ -602,3 +603,13 @@ def test_schema_from_sqlglot():
     )
 
     assert ibis_schema == expected
+
+
+def test_schema_from_Table_subclass():
+    class MyTable(ir.Table):
+        a: ir.StringValue
+        b: ir.IntegerValue["!int64"]
+
+    expected = sch.Schema({"a": dt.string, "b": dt.Int64(nullable=False)})
+    actual = sch.schema(MyTable)
+    assert actual == expected

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -41,6 +41,8 @@ class ArrayValue(Value):
     └──────────────────────┘
     """
 
+    __dtype_supertype__ = dt.Array
+
     def length(self) -> ir.IntegerValue:
         """Compute the length of an array.
 

--- a/ibis/expr/types/binary.py
+++ b/ibis/expr/types/binary.py
@@ -7,12 +7,15 @@ if TYPE_CHECKING:
 
 from public import public
 
+import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.expr.types.generic import Column, Scalar, Value
 
 
 @public
 class BinaryValue(Value):
+    __dtype__ = dt.binary
+
     def hashbytes(
         self, how: Literal["md5", "sha1", "sha256", "sha512"] = "sha256", /
     ) -> ir.BinaryValue:

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any, Literal, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Union, overload
 
 from public import public
 
@@ -10,6 +10,7 @@ import ibis.common.exceptions as com
 import ibis.expr.builders as bl
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
+from ibis.common.bases import AbstractMeta
 from ibis.common.deferred import Deferred, _, deferrable
 from ibis.common.grounds import Singleton
 from ibis.expr.rewrites import rewrite_window_input
@@ -37,9 +38,45 @@ if TYPE_CHECKING:
 _SENTINEL = object()
 
 
+class ValueMeta(AbstractMeta):
+    def __new__(
+        metacls: type,
+        clsname: str,
+        bases: tuple[type, ...],
+        dct: dict[str, Any],
+        **kwargs: Any,
+    ) -> type:
+        def __class_getitem__(cls: Value, item: type | str) -> type:
+            dtype_supertype = None
+            if cls.__dtype__ is not None:
+                dtype_supertype = cls.__dtype__.__class__
+            if cls.__dtype_supertype__ is not None:
+                dtype_supertype = cls.__dtype_supertype__
+            if dtype_supertype is None:
+                raise TypeError(f"{cls.__name__} does not support type parameters")
+            dtype_obj = dt.dtype(item)
+            if not isinstance(dtype_obj, dtype_supertype):
+                raise TypeError(
+                    f"invalid type parameter {item!r} for {cls.__name__}, "
+                    f"expected a subtype of {dtype_supertype.__name__}"
+                )
+
+            class ParameterizedValue(cls):
+                __dtype__ = dtype_obj
+
+            return ParameterizedValue
+
+        new_dct = {**dct, "__class_getitem__": classmethod(__class_getitem__)}
+        new_type = super().__new__(metacls, clsname, bases, new_dct, **kwargs)
+        return new_type
+
+
 @public
-class Value(Expr):
+class Value(Expr, metaclass=ValueMeta):
     """Base class for a data generating expression having a known type."""
+
+    __dtype__: ClassVar[Union[dt.DataType, None]] = None
+    __dtype_supertype__: ClassVar[Union[type[dt.DataType], None]] = None
 
     def name(self, name: str, /) -> Value:
         """Rename an expression to `name`.
@@ -2937,7 +2974,7 @@ class Column(Value, FixedTextJupyterMixin):
 
 @public
 class UnknownValue(Value):
-    pass
+    __dtype__ = dt.unknown
 
 
 @public
@@ -2952,7 +2989,7 @@ class UnknownColumn(Column):
 
 @public
 class NullValue(Value):
-    pass
+    __dtype__ = dt.null
 
 
 @public

--- a/ibis/expr/types/geospatial.py
+++ b/ibis/expr/types/geospatial.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from public import public
 
+import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.expr.types.numeric import NumericColumn, NumericScalar, NumericValue
 
@@ -13,6 +14,8 @@ if TYPE_CHECKING:
 
 @public
 class GeoSpatialValue(NumericValue):
+    __dtype__ = dt.geometry
+
     def area(self) -> ir.FloatingValue:
         """Compute the area of a geospatial value.
 
@@ -1666,7 +1669,7 @@ class GeoSpatialColumn(NumericColumn, GeoSpatialValue):
 
 @public
 class PointValue(GeoSpatialValue):
-    pass
+    __dtype__ = dt.point
 
 
 @public
@@ -1681,7 +1684,7 @@ class PointColumn(GeoSpatialColumn, PointValue):
 
 @public
 class LineStringValue(GeoSpatialValue):
-    pass
+    __dtype__ = dt.linestring
 
 
 @public
@@ -1696,7 +1699,7 @@ class LineStringColumn(GeoSpatialColumn, LineStringValue):
 
 @public
 class PolygonValue(GeoSpatialValue):
-    pass
+    __dtype__ = dt.polygon
 
 
 @public
@@ -1711,7 +1714,7 @@ class PolygonColumn(GeoSpatialColumn, PolygonValue):
 
 @public
 class MultiLineStringValue(GeoSpatialValue):
-    pass
+    __dtype__ = dt.multilinestring
 
 
 @public
@@ -1726,7 +1729,7 @@ class MultiLineStringColumn(GeoSpatialColumn, MultiLineStringValue):
 
 @public
 class MultiPointValue(GeoSpatialValue):
-    pass
+    __dtype__ = dt.multipoint
 
 
 @public
@@ -1741,7 +1744,7 @@ class MultiPointColumn(GeoSpatialColumn, MultiPointValue):
 
 @public
 class MultiPolygonValue(GeoSpatialValue):
-    pass
+    __dtype__ = dt.multipolygon
 
 
 @public

--- a/ibis/expr/types/inet.py
+++ b/ibis/expr/types/inet.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from public import public
 
+from ibis.expr import datatypes as dt
 from ibis.expr.types.generic import Column, Scalar, Value
 
 
 @public
 class MACADDRValue(Value):
-    pass
+    __dtype__ = dt.macaddr
 
 
 @public
@@ -22,7 +23,7 @@ class MACADDRColumn(Column, MACADDRValue):
 
 @public
 class INETValue(Value):
-    pass
+    __dtype__ = dt.inet
 
 
 @public

--- a/ibis/expr/types/json.py
+++ b/ibis/expr/types/json.py
@@ -86,6 +86,8 @@ class JSONValue(Value):
     └─────────────────────┘
     """
 
+    __dtype__ = dt.json
+
     def __getitem__(
         self, key: str | int | ir.StringValue | ir.IntegerValue
     ) -> JSONValue:

--- a/ibis/expr/types/logical.py
+++ b/ibis/expr/types/logical.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from public import public
 
 import ibis
+import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis import util
 from ibis.expr.types.core import _binop
@@ -16,6 +17,8 @@ if TYPE_CHECKING:
 
 @public
 class BooleanValue(NumericValue):
+    __dtype__ = dt.boolean
+
     def ifelse(self, true_expr: ir.Value, false_expr: ir.Value, /) -> ir.Value:
         """Construct a ternary conditional expression.
 

--- a/ibis/expr/types/maps.py
+++ b/ibis/expr/types/maps.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from public import public
 
+import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.common.deferred import deferrable
 from ibis.expr.types.generic import Column, Scalar, Value
@@ -79,6 +80,8 @@ class MapValue(Value):
     │              NULL │
     └───────────────────┘
     """
+
+    __dtype_supertype__ = dt.Map
 
     def get(self, key: ir.Value, default: ir.Value | None = None, /) -> ir.Value:
         """Return the value for `key` from `expr`.

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Literal
 from public import public
 
 import ibis
+import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.common.exceptions import IbisTypeError
 from ibis.expr.types.core import _binop
@@ -1468,6 +1469,9 @@ class NumericColumn(Column, NumericValue):
 
 @public
 class IntegerValue(NumericValue):
+    __dtype__ = dt.int64
+    __dtype_supertype__ = dt.Integer
+
     def as_timestamp(self, unit: Literal["s", "ms", "us"], /) -> ir.TimestampValue:
         """Convert an integral UNIX timestamp to a timestamp expression.
 
@@ -1693,6 +1697,9 @@ class IntegerColumn(NumericColumn, IntegerValue):
 
 @public
 class FloatingValue(NumericValue):
+    __dtype__ = dt.float64
+    __dtype_supertype__ = dt.Floating
+
     def isnan(self) -> ir.BooleanValue:
         """Return whether the value is NaN. Does NOT detect `NULL` and `inf` values.
 
@@ -1772,7 +1779,8 @@ class FloatingColumn(NumericColumn, FloatingValue):
 
 @public
 class DecimalValue(NumericValue):
-    pass
+    __dtype_supertype__ = dt.Decimal
+    __dtype__ = dt.Decimal(38, 10)
 
 
 @public

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -8,6 +8,7 @@ from public import public
 
 import ibis.expr.operations as ops
 from ibis import util
+from ibis.expr import datatypes as dt
 from ibis.expr.types.core import _binop
 from ibis.expr.types.generic import Column, Scalar, Value
 
@@ -19,6 +20,8 @@ if TYPE_CHECKING:
 
 @public
 class StringValue(Value):
+    __dtype__ = dt.string
+
     def __getitem__(self, key: slice | int | ir.IntegerScalar) -> StringValue:
         """Index or slice a string expression.
 

--- a/ibis/expr/types/structs.py
+++ b/ibis/expr/types/structs.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from public import public
 
+import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.common.deferred import deferrable
 from ibis.common.exceptions import IbisError
@@ -14,7 +15,6 @@ from ibis.expr.types.generic import Column, Scalar, Value, literal
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
 
-    import ibis.expr.datatypes as dt
     import ibis.expr.types as ir
 
 
@@ -139,6 +139,8 @@ class StructValue(Value):
     │  NULL │
     └───────┘
     """
+
+    __dtype_supertype__ = dt.Struct
 
     def __dir__(self):
         out = set(dir(type(self)))

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -329,6 +329,8 @@ class _TimeComponentMixin:
 class TimeValue(_TimeComponentMixin, Value):
     """A time of day from 0:00:00 to 23:59:59.999999999."""
 
+    __dtype__ = dt.time
+
     def strftime(self, format_str: str, /) -> ir.StringValue:
         """Format a time according to `format_str`.
 
@@ -504,6 +506,8 @@ class TimeColumn(Column, TimeValue):
 @public
 class DateValue(Value, _DateComponentMixin):
     """A date (without time), eg 2024-12-31."""
+
+    __dtype__ = dt.date
 
     def strftime(self, format_str: str, /) -> ir.StringValue:
         """Format a date according to `format_str`.
@@ -784,6 +788,8 @@ class DateColumn(Column, DateValue):
 @public
 class TimestampValue(_DateComponentMixin, _TimeComponentMixin, Value):
     """A date and time, eg 2024-12-31 23:59:59.999999."""
+
+    __dtype__ = dt.timestamp
 
     def strftime(self, format_str: str, /) -> ir.StringValue:
         """Format a timestamp according to `format_str`.
@@ -1254,6 +1260,8 @@ class IntervalValue(Value):
     `ibis.timestamp("2020-01-01") + ibis.interval(days=1)`,
     which results in a new timestamp expression.
     """
+
+    __dtype__ = dt.Interval
 
     def as_unit(self, target_unit: str, /) -> IntervalValue:
         """Convert this interval to units of `target_unit`."""

--- a/ibis/expr/types/uuid.py
+++ b/ibis/expr/types/uuid.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from public import public
 
+from ibis.expr import datatypes as dt
 from ibis.expr.types.generic import Column, Scalar, Value
 
 
 @public
 class UUIDValue(Value):
-    pass
+    __dtype__ = dt.uuid
 
 
 @public

--- a/ibis/tests/expr/test_literal.py
+++ b/ibis/tests/expr/test_literal.py
@@ -175,3 +175,8 @@ def test_deferred(table):
     deferred = ibis.literal(expr, type=dtype)
     result = deferred.resolve(table)
     assert result.op().value == "g"
+
+
+def test_literal_from_expr_for_type():
+    expr = ibis.literal(1, ibis.ir.IntegerValue["!int32"])
+    assert expr.type() == dt.Int32(nullable=False)

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1879,6 +1879,16 @@ def test_cast():
     )
 
 
+def test_cast_subclass():
+    class Users(ibis.Table):
+        name: ibis.ir.StringColumn
+        age: ibis.ir.IntegerColumn["uint8"]
+
+    inp = ibis.table(dict(name="string", age="int64"))
+    result = inp.cast(Users)
+    assert result.schema() == ibis.schema(dict(name="string", age="uint8"))
+
+
 def test_pivot_longer():
     diamonds = ibis.table(
         {


### PR DESCRIPTION
This allows for pleasant UX such as
- ibis.dtype(ibis.ir.StringValue)
- ibis.dtype(ibis.ir.IntegerValue["!uint32"])

```python
class Users(ibis.Table):
    name: ibis.ir.StringColumn
    age: ibis.ir.IntegerColumn["uint8"]

def my_api(users: Users):
    # Runtime coercion of types works as expected!
    users = ibis.cast(users, Users)
    # IDE type hints work too!
    reveal_type(users.age) # Its an IntegerColumn!
```

I also adjusted the ibis.dtype() function so that the nullable kwarg defaults to None, which means "Don't mess with the nullability of something that is already a dtype". I can put this into a separate PR if desired, but I think this is a good change to make anyways.
The current behavior of `dtype(nonnullable_dtype, nullable=True)` returning the original input, still nonnullable, is a footgun.