### PR TITLE
fix: lazily import packaging so we don't depend on it in a base install

### DIFF
--- a/ibis/util.py
+++ b/ibis/util.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
 from uuid import uuid4
 
 import toolz
-from packaging.version import parse as vparse
 
 from ibis.common.typing import Coercible
 
@@ -730,6 +729,8 @@ else:
 
 
 def version(package: str) -> Version:
+    from packaging.version import parse as vparse
+
     try:
         version_info = importlib.metadata.version(package)
     except importlib.metadata.PackageNotFoundError:


### PR DESCRIPTION
Fixes https://github.com/ibis-project/ibis/issues/11597

I also could have added it as a dep in our pyproject.toml as a base dep, but I wanted to avoid that.

This does mean that a user can't call `ibis.version()` with a base install, but I think that's fine, I don't think that is a documented API.