### PR TITLE
test: move test for create_table() with SQL keywords into all backends.

### DIFF
--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -469,15 +469,6 @@ def test_create_temp_table_in_nondefault_schema():
     con.create_table("foo", {"id": [1, 2, 3]}, temp=True)
 
 
-def test_create_table_with_quoted_columns():
-    con = ibis.duckdb.connect()
-    name = gen_name("quoted_columns_table")
-    df = pd.DataFrame(
-        {"group": ["G1"], "value": ["E1"], "id": [1], "date": [datetime(2025, 5, 13)]}
-    )
-    con.create_table(name, df, temp=True)
-
-
 def test_create_table_with_out_of_order_columns(con):
     name = gen_name("out_of_order_columns_table")
     df = pd.DataFrame({"value": ["E1"], "id": [1], "date": [datetime(2025, 5, 13)]})

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -112,6 +112,19 @@ def test_create_table(backend, con, temp_table, func, sch):
 
 
 @pytest.mark.parametrize(
+    "keyword", ["group", "order", "where", "select", "from", "join", "table"]
+)
+def test_create_table_with_keyword(con, keyword):
+    """Test creating tables with a name and coumn name that is a SQL keyword."""
+    t = ibis.memtable({keyword: ["a", "b", "c"]})
+    try:
+        con.create_table(keyword, t, temp=True)
+        assert con.table(keyword).schema() == ibis.schema({keyword: "string"})
+    finally:
+        con.drop_table(keyword, force=True)
+
+
+@pytest.mark.parametrize(
     "temp, overwrite",
     [
         param(


### PR DESCRIPTION
Before, was only in the duckdb client. Now all clients have this test.

Followup to https://github.com/ibis-project/ibis/pull/11532