### PR TITLE
feat(duckdb,datafusion): implement pandas UDFs by wrapping into pyarrow UDFs

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -33,6 +33,7 @@ from ibis.backends import (
 )
 from ibis.backends.sql import SQLBackend
 from ibis.backends.sql.compilers.base import STAR, AlterTable, C, RenameTable
+from ibis.backends.sql.rewrites import convert_pandas_udf_to_pyarrow
 from ibis.common.dispatch import lazy_singledispatch
 from ibis.expr.operations.udf import InputType
 
@@ -1739,20 +1740,22 @@ class Backend(
             if registration_func is not None:
                 registration_func(con)
 
-    def _register_udf(self, udf_node: ops.ScalarUDF):
+    def _register_udf(
+        self,
+        udf_node: ops.ScalarUDF,
+        *,
+        func: callable | None = None,
+        input_type: InputType | None = None,
+    ):
         type_mapper = self.compiler.type_mapper
-        input_types = [
-            type_mapper.to_string(param.annotation.pattern.dtype)
-            for param in udf_node.__signature__.parameters.values()
-        ]
 
         def register_udf(con):
             return con.create_function(
                 name=type(udf_node).__name__,
-                function=udf_node.__func__,
-                parameters=input_types,
+                function=func or udf_node.__func__,
+                parameters=[type_mapper.to_string(arg.dtype) for arg in udf_node.args],
                 return_type=type_mapper.to_string(udf_node.dtype),
-                type=_UDF_INPUT_TYPE_MAPPING[udf_node.__input_type__],
+                type=_UDF_INPUT_TYPE_MAPPING[input_type or udf_node.__input_type__],
                 **udf_node.__config__,
             )
 
@@ -1760,6 +1763,12 @@ class Backend(
 
     _register_python_udf = _register_udf
     _register_pyarrow_udf = _register_udf
+
+    def _register_pandas_udf(self, pandas_udf_node: ops.ScalarUDF) -> str:
+        pyarrow_function = convert_pandas_udf_to_pyarrow(pandas_udf_node.__func__)
+        return self._register_udf(
+            pandas_udf_node, func=pyarrow_function, input_type=InputType.PYARROW
+        )
 
     def _get_temp_view_definition(self, name: str, definition: str) -> str:
         return sge.Create(

--- a/ibis/backends/sql/compilers/datafusion.py
+++ b/ibis/backends/sql/compilers/datafusion.py
@@ -172,7 +172,7 @@ class DataFusionCompiler(SQLGlotCompiler):
 
     def visit_ScalarUDF(self, op, **kw):
         input_type = op.__input_type__
-        if input_type in (InputType.PYARROW, InputType.BUILTIN):
+        if input_type in (InputType.PYARROW, InputType.BUILTIN, InputType.PANDAS):
             return self.f.anon[op.__func_name__](*kw.values())
         else:
             raise NotImplementedError(

--- a/ibis/backends/tests/test_udf.py
+++ b/ibis/backends/tests/test_udf.py
@@ -171,7 +171,7 @@ def add_one_pyarrow(s: int) -> int:  # s is series, int is the element type
             add_one_pandas,
             marks=[
                 mark.notyet(
-                    ["duckdb", "datafusion", "polars", "sqlite"],
+                    ["polars", "sqlite"],
                     raises=NotImplementedError,
                     reason="backend doesn't support pandas UDFs",
                 ),

--- a/ibis/expr/operations/udf.py
+++ b/ibis/expr/operations/udf.py
@@ -50,8 +50,16 @@ class InputType(enum.Enum):
     PYTHON = enum.auto()
 
 
+class _UDFMixin:
+    __input_type__: InputType
+    __func__: Callable
+    __func_name__: str
+    __config__: FrozenDict
+    __udf_namespace__: ops.Namespace
+
+
 @public
-class ScalarUDF(ops.Impure):
+class ScalarUDF(ops.Impure, _UDFMixin):
     @attribute
     def shape(self):
         if not (args := getattr(self, "args")):  # noqa: B009
@@ -65,7 +73,7 @@ class ScalarUDF(ops.Impure):
 
 
 @public
-class AggUDF(ops.Reduction, ops.Impure):
+class AggUDF(ops.Reduction, ops.Impure, _UDFMixin):
     where: Optional[ops.Value[dt.Boolean]] = None
 
 
@@ -479,7 +487,7 @@ class scalar(_UDF):
         ... def str_cap(x: str) -> str:
         ...     # note usage of pandas `str` method
         ...     return x.str.capitalize()
-        >>> str_cap(t.str_col)  # doctest: +SKIP
+        >>> str_cap(t.str_col)
         ┏━━━━━━━━━━━━━━━━━━━━━━━┓
         ┃ string_cap_0(str_col) ┃
         ┡━━━━━━━━━━━━━━━━━━━━━━━┩


### PR DESCRIPTION
Per https://github.com/ibis-project/ibis/issues/11606#issuecomment-3286561724, it appears that none of our "easy" local backends support pandas UDFs. This should make this a lot more explorable, and for the the example in the docstring to work on a vanilla install.