### PR TITLE
feat(deps): support duckdb 1.4.0

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1378,7 +1378,6 @@ class Backend(
         limit: int | str | None = None,
         **kwargs: Any,
     ) -> pa.Table:
-        import pyarrow as pa
         from ibis.backends.duckdb.converter import DuckDBPyArrowData
 
         table = self._to_duckdb_relation(
@@ -1397,7 +1396,6 @@ class Backend(
     ) -> pd.DataFrame | pd.Series | Any:
         """Execute an expression."""
         import pandas as pd
-        import pyarrow as pa
         import pyarrow.types as pat
         import pyarrow_hotfix  # noqa: F401
 

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1381,13 +1381,9 @@ class Backend(
         import pyarrow as pa
         from ibis.backends.duckdb.converter import DuckDBPyArrowData
 
-        result = self._to_duckdb_relation(
+        table = self._to_duckdb_relation(
             expr, params=params, limit=limit, **kwargs
-        ).arrow()
-        if isinstance(result, pa.RecordBatchReader):
-            table = result.read_all()
-        else:
-            table = result
+        ).to_arrow_table()
         return expr.__pyarrow_result__(table, data_mapper=DuckDBPyArrowData)
 
     def execute(
@@ -1408,11 +1404,7 @@ class Backend(
         from ibis.backends.duckdb.converter import DuckDBPandasData
 
         rel = self._to_duckdb_relation(expr, params=params, limit=limit, **kwargs)
-        result = rel.arrow()
-        if isinstance(result, pa.RecordBatchReader):
-            table = result.read_all()
-        else:
-            table = result
+        table = rel.to_arrow_table()
 
         df = pd.DataFrame(
             {


### PR DESCRIPTION
- use DuckDbPyRelation.to_arrow_table() instead of .arrow() to get a pyarrow.Table result from DuckDbPyRelation
- this is to add compatibility for duckdb 1.4.0 which changed the return type of DuckDbPyRelation.arrow() to RecordBatchReader (from Table)

## Issues closed

* Resolves #11621

