### PR TITLE
feat: allow user to skip "CREATE VOLUME IF NOT EXISTS" by using None as memtable_volume argument

### DIFF
--- a/ibis/backends/databricks/__init__.py
+++ b/ibis/backends/databricks/__init__.py
@@ -440,10 +440,11 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
         new_backend._post_connect(memtable_volume=memtable_volume)
         return new_backend
 
-    def _post_connect(self, *, memtable_volume: str) -> None:
-        sql = f"CREATE VOLUME IF NOT EXISTS `{memtable_volume}` COMMENT 'Ibis memtable storage volume'"
-        with self.con.cursor() as cur:
-            cur.execute(sql)
+    def _post_connect(self, *, memtable_volume: str | None) -> None:
+        if memtable_volume is not None:
+            sql = f"CREATE VOLUME IF NOT EXISTS `{memtable_volume}` COMMENT 'Ibis memtable storage volume'"
+            with self.con.cursor() as cur:
+                cur.execute(sql)
 
     @functools.cached_property
     def _memtable_volume_path(self) -> str:


### PR DESCRIPTION

## Description of changes

The problem fixed is when a user wnat to access data through databrick but only has READ access on the table, which prevents to try any `CREATE VOLUME IF NOT EXISTS` query, always done as of now

## Issues closed

* Resolves #11598