### PR TITLE
docs(contribute): add missing "Install just" in uv set-up guide

### DIFF
--- a/docs/contribute/01_environment.qmd
+++ b/docs/contribute/01_environment.qmd
@@ -260,6 +260,8 @@ For a better development experience see the `conda/mamba` or `nix` setup instruc
 
 1. [Install `gh`](https://cli.github.com/manual/installation)
 
+1. [Install `just`](https://just.systems/man/en/packages.html)
+
 1. Fork and clone the ibis repository:
 
    ```sh


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

`just` is referenced in step 5, but unlike `uv` and `gh`, there's no installation link. This _just_ adds that.

## Issues closed

None