### PR TITLE
Feat/allow read only option for Databricks backend

### DIFF
--- a/ibis/backends/databricks/__init__.py
+++ b/ibis/backends/databricks/__init__.py
@@ -381,7 +381,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
         http_headers: list[tuple[str, str]] | None = None,
         catalog: str | None = None,
         schema: str = "default",
-        use_cloud_fetch: bool = True,
+        use_cloud_fetch: bool = False,
         memtable_volume: str | None = None,
         staging_allowed_local_path: str | None = None,
         allow_read_only: bool = False,

--- a/ibis/backends/databricks/__init__.py
+++ b/ibis/backends/databricks/__init__.py
@@ -440,10 +440,11 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
         new_backend._post_connect(memtable_volume=memtable_volume)
         return new_backend
 
-    def _post_connect(self, *, memtable_volume: str) -> None:
-        sql = f"CREATE VOLUME IF NOT EXISTS `{memtable_volume}` COMMENT 'Ibis memtable storage volume'"
-        with self.con.cursor() as cur:
-            cur.execute(sql)
+    def _post_connect(self, *, memtable_volume: str | None) -> None:
+        if memtable_volume is not None:
+            sql = f"CREATE VOLUME IF NOT EXISTS `{memtable_volume}` COMMENT 'Ibis memtable storage volume'"
+            with self.con.cursor() as cur:
+                cur.execute(sql)
 
     @functools.cached_property
     def _memtable_volume_path(self) -> str:

--- a/ibis/backends/databricks/__init__.py
+++ b/ibis/backends/databricks/__init__.py
@@ -381,7 +381,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
         http_headers: list[tuple[str, str]] | None = None,
         catalog: str | None = None,
         schema: str = "default",
-        use_cloud_fetch: bool = False,
+        use_cloud_fetch: bool = True,
         memtable_volume: str | None = None,
         staging_allowed_local_path: str | None = None,
         **config: Any,


### PR DESCRIPTION
## Description of changes

Allow data access through Databricks with only READ access on the table, by skipping memory table.


## Issues closed

* Resolves #11598