### PR TITLE
fix(typing): harmonize Table.join and Table.*_join type hints

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -443,7 +443,17 @@ def _regular_join_method(
         /,
         predicates: (
             str
-            | Sequence[str | tuple[str | ir.Column, str | ir.Column] | ir.BooleanValue]
+            | Sequence[
+                str
+                | ir.BooleanColumn
+                | Literal[True]
+                | Literal[False]
+                | tuple[
+                    str | ir.Column | ir.Deferred,
+                    str | ir.Column | ir.Deferred,
+                ]
+                | ir.BooleanValue
+            ]
         ) = (),
         *,
         lname: str = "",
@@ -3482,6 +3492,7 @@ class Table(Expr, FixedTextJupyterMixin):
                     str | ir.Column | ir.Deferred,
                     str | ir.Column | ir.Deferred,
                 ]
+                | ir.BooleanValue
             ]
         ) = (),
         *,


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

Harmonize type hints between `Table.join` and all its specialized siblings.

## Issues closed

* Resolves #11664
