### PR TITLE
fix(flink): override `WITH_PROPERTIES_PREFIX` with `"WITH"`

### DIFF
--- a/ibis/backends/sql/dialects.py
+++ b/ibis/backends/sql/dialects.py
@@ -218,6 +218,8 @@ class Flink(Hive):
     REGEXP_EXTRACT_DEFAULT_GROUP = 0
 
     class Generator(Hive.Generator):
+        WITH_PROPERTIES_PREFIX = "WITH"
+
         UNNEST_WITH_ORDINALITY = False
 
         TYPE_MAPPING = Hive.Generator.TYPE_MAPPING.copy() | {


### PR DESCRIPTION
## Description of changes
WITH_PROPERTIES_PREFIX should be "WITH" in Apache Flink SQLs
For example, 
```SQL
create table table_name (,,,,) with (,,,,)
```

## Issues closed

Resolves 
https://github.com/ibis-project/ibis/issues/11633
