### PR TITLE
feat(datatypes): support ibis.dtype(nullable=None)

### DIFF
--- a/ibis/backends/pyspark/datatypes.py
+++ b/ibis/backends/pyspark/datatypes.py
@@ -44,7 +44,9 @@ _pyspark_interval_units = {
 
 class PySparkType(TypeMapper):
     @classmethod
-    def to_ibis(cls, typ, nullable=True):
+    def to_ibis(cls, typ: pt.DataType, nullable: bool | None = None) -> dt.DataType:
+        if nullable is None:
+            nullable = True
         """Convert a pyspark type to an ibis type."""
         if isinstance(typ, pt.DecimalType):
             return dt.Decimal(typ.precision, typ.scale, nullable=nullable)

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -147,9 +147,8 @@ class SqlglotType(TypeMapper):
             )
             typecode = typ.this
 
-        nullable = typ.args.get(
-            "nullable", nullable if nullable is not None else cls.default_nullable
-        )
+        if nullable is None:
+            nullable = typ.args.get("nullable", cls.default_nullable)
         if method := getattr(cls, f"_from_sqlglot_{typecode.name}", None):
             if typecode == sge.DataType.Type.ARRAY:
                 dtype = method(
@@ -1475,11 +1474,13 @@ class SingleStoreDBType(MySQLType):
     dialect = "singlestore"
 
     @classmethod
-    def to_ibis(cls, typ, nullable=True):
+    def to_ibis(cls, typ: sge.DataType, nullable: bool | None = None) -> dt.DataType:
         """Convert SingleStoreDB type to Ibis type.
 
         Handles both standard MySQL types and SingleStoreDB-specific extensions.
         """
+        if nullable is None:
+            nullable = cls.default_nullable
         if hasattr(typ, "this"):
             type_name = str(typ.this).upper()
 

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -112,7 +112,7 @@ class DataType(Concrete, Coercible):
         return castable(self, to, **kwargs)
 
     @classmethod
-    def from_string(cls, value: str, nullable: bool = True) -> Self:
+    def from_string(cls, value: str, nullable: bool | None = None) -> Self:
         from ibis.expr.datatypes.parse import parse
 
         try:
@@ -120,12 +120,12 @@ class DataType(Concrete, Coercible):
         except SyntaxError:
             raise TypeError(f"{value!r} cannot be parsed as a datatype")
 
-        if not nullable:
+        if nullable is not None:
             return typ.copy(nullable=nullable)
         return typ
 
     @classmethod
-    def from_typehint(cls, typ, nullable=True) -> Self:
+    def from_typehint(cls, typ, nullable: bool = True) -> Self:
         # All types are nullable by default
         # (eg `ibis.dtype(int)` results in `Int64(nullable=True)`),
         # so if we are handed Union[None, T], simplify it to T.
@@ -193,7 +193,7 @@ class DataType(Concrete, Coercible):
             raise TypeError(f"Value {typ!r} is not a valid datatype")
 
     @classmethod
-    def from_numpy(cls, numpy_type: np.dtype, nullable: bool = True) -> Self:
+    def from_numpy(cls, numpy_type: np.dtype, nullable: bool | None = None) -> Self:
         """Return the equivalent ibis datatype."""
         from ibis.formats.numpy import NumpyType
 
@@ -201,7 +201,7 @@ class DataType(Concrete, Coercible):
 
     @classmethod
     def from_pandas(
-        cls, pandas_type: np.dtype | ExtensionDtype, nullable: bool = True
+        cls, pandas_type: np.dtype | ExtensionDtype, nullable: bool | None = None
     ) -> Self:
         """Return the equivalent ibis datatype."""
         from ibis.formats.pandas import PandasType
@@ -209,14 +209,18 @@ class DataType(Concrete, Coercible):
         return PandasType.to_ibis(pandas_type, nullable=nullable)
 
     @classmethod
-    def from_pyarrow(cls, arrow_type: pa.DataType, nullable: bool = True) -> Self:
+    def from_pyarrow(
+        cls, arrow_type: pa.DataType, nullable: bool | None = None
+    ) -> Self:
         """Return the equivalent ibis datatype."""
         from ibis.formats.pyarrow import PyArrowType
 
         return PyArrowType.to_ibis(arrow_type, nullable=nullable)
 
     @classmethod
-    def from_polars(cls, polars_type: pl.DataType, nullable: bool = True) -> Self:
+    def from_polars(
+        cls, polars_type: pl.DataType, nullable: bool | None = None
+    ) -> Self:
         """Return the equivalent ibis datatype."""
         from ibis.formats.polars import PolarsType
 
@@ -1104,51 +1108,58 @@ Includes:
 
 
 @overload
-def dtype(value: type[int] | Literal["int"], nullable: bool = True) -> Int64: ...
+def dtype(value: type[int] | Literal["int"], nullable: bool | None = None) -> Int64: ...
 @overload
 def dtype(
-    value: type[str] | Literal["str", "string"], nullable: bool = True
+    value: type[str] | Literal["str", "string"], nullable: bool | None = None
 ) -> String: ...
 @overload
 def dtype(
-    value: type[bool] | Literal["bool", "boolean"], nullable: bool = True
+    value: type[bool] | Literal["bool", "boolean"], nullable: bool | None = None
 ) -> Boolean: ...
 @overload
-def dtype(value: type[bytes] | Literal["bytes"], nullable: bool = True) -> Binary: ...
-@overload
-def dtype(value: type[Real] | Literal["float"], nullable: bool = True) -> Float64: ...
+def dtype(
+    value: type[bytes] | Literal["bytes"], nullable: bool | None = None
+) -> Binary: ...
 @overload
 def dtype(
-    value: type[pydecimal.Decimal] | Literal["decimal"], nullable: bool = True
+    value: type[Real] | Literal["float"], nullable: bool | None = None
+) -> Float64: ...
+@overload
+def dtype(
+    value: type[pydecimal.Decimal] | Literal["decimal"], nullable: bool | None = None
 ) -> Decimal: ...
 @overload
 def dtype(
-    value: type[pydatetime.datetime] | Literal["timestamp"], nullable: bool = True
+    value: type[pydatetime.datetime] | Literal["timestamp"],
+    nullable: bool | None = None,
 ) -> Timestamp: ...
 @overload
 def dtype(
-    value: type[pydatetime.date] | Literal["date"], nullable: bool = True
+    value: type[pydatetime.date] | Literal["date"], nullable: bool | None = None
 ) -> Date: ...
 @overload
 def dtype(
-    value: type[pydatetime.time] | Literal["time"], nullable: bool = True
+    value: type[pydatetime.time] | Literal["time"], nullable: bool | None = None
 ) -> Time: ...
 @overload
 def dtype(
-    value: type[pydatetime.timedelta] | Literal["interval"], nullable: bool = True
+    value: type[pydatetime.timedelta] | Literal["interval"],
+    nullable: bool | None = None,
 ) -> Interval: ...
 @overload
 def dtype(
-    value: type[pyuuid.UUID] | Literal["uuid"], nullable: bool = True
+    value: type[pyuuid.UUID] | Literal["uuid"], nullable: bool | None = None
 ) -> UUID: ...
 @overload
 def dtype(
-    value: IntoDtype,
-    nullable: bool = True,
+    value: DataType | str | np.dtype | ExtensionDtype | pl.DataType | pa.DataType,
+    nullable: bool | None = None,
 ) -> DataType: ...
 
 
-def dtype(value: IntoDtype, nullable: bool = True) -> DataType:
+@lazy_singledispatch
+def dtype(value, nullable: bool | None = None) -> DataType:
     """Create a DataType object.
 
     Parameters
@@ -1158,21 +1169,42 @@ def dtype(value: IntoDtype, nullable: bool = True) -> DataType:
         strings, python type annotations, numpy dtypes, pandas dtypes, and
         pyarrow types.
     nullable
-        Whether the type should be nullable. Defaults to True.
-        If `value` is a string prefixed by "!", the type is always non-nullable.
+        Whether the resulting type should be nullable.
+        If `None`, we try to infer nullability from the input value.
+        For example, if `value` is a string starting with '!', the resulting type
+        will be non-nullable.
+        For inputs without an explicit nullability (like the python type `int` or
+        numpy dtype of `np.int32`), we default to `nullable=True`.
 
     Examples
     --------
     >>> import ibis
     >>> ibis.dtype("int32")
     Int32(nullable=True)
+
+    Prefixing the type with "!" makes it non-nullable:
+
     >>> ibis.dtype("!int32")
     Int32(nullable=False)
-    >>> ibis.dtype("array<float>")
-    Array(value_type=Float64(nullable=True), length=None, nullable=True)
+
+    We support a rich string syntax for nested and parametric types:
+
+    >>> ibis.dtype("array<!float>")
+    Array(value_type=Float64(nullable=False), length=None, nullable=True)
+    >>> ibis.dtype("!struct<a: interval('s'), b: !bool>")
+    Struct([('a', Interval(unit=<IntervalUnit.SECOND: 's'>, nullable=True)), ('b', Boolean(nullable=False))], nullable=False)
+    >>> ibis.dtype("map<timestamp('America/Anchorage', 6), boolean>")
+    Map(key_type=Timestamp(timezone='America/Anchorage', scale=6, nullable=True), value_type=Boolean(nullable=True), nullable=True)
+
+    The function is idempotent (AKA is a no-op when passed a DataType):
+    >>> t = ibis.dtype("int32")
+    >>> ibis.dtype(t) is t
+    True
 
     DataType objects may also be created from Python types:
 
+    >>> ibis.dtype(int)
+    Int64(nullable=True)
     >>> ibis.dtype(int, nullable=False)
     Int64(nullable=False)
     >>> ibis.dtype(list[float])
@@ -1183,45 +1215,61 @@ def dtype(value: IntoDtype, nullable: bool = True) -> DataType:
     >>> import pyarrow as pa
     >>> ibis.dtype(pa.int32())
     Int32(nullable=True)
+    >>> ibis.dtype(pa.int32(), nullable=False)
+    Int32(nullable=False)
+
+    The `nullable` parameter may be used to override the nullability:
+
+    >>> ibis.dtype("!int32", nullable=True)
+    Int32(nullable=True)
+    >>> i = ibis.dtype("int32")
+    >>> i
+    Int32(nullable=True)
+    >>> ibis.dtype(i, nullable=False)
+    Int32(nullable=False)
 
     """
     return _dtype(value, nullable=nullable)
 
 
 @lazy_singledispatch
-def _dtype(value, nullable=True) -> DataType:
+def _dtype(value, nullable: bool | None = None) -> DataType:
+    if nullable is None:
+        nullable = True
     return DataType.from_typehint(value, nullable)
 
 
 @_dtype.register(DataType)
-def from_datatype(value: DataType, nullable: bool = True) -> DataType:
-    # TODO: need change nullable to default of None, which means don't change.
-    # And if non-null, then do `return value.copy(nullable=nullable)`
-    return value
+def from_datatype(value: DataType, nullable: bool | None = None) -> DataType:
+    if nullable is None:
+        return value
+    return value.copy(nullable=nullable)
 
 
 @_dtype.register(str)
-def from_string(value, nullable: bool = True) -> DataType:
+def from_string(value: str, nullable: bool | None = None) -> DataType:
     return DataType.from_string(value, nullable)
 
 
 @_dtype.register("numpy.dtype")
-def from_numpy_dtype(value, nullable=True) -> DataType:
+def from_numpy_dtype(value: np.dtype, nullable: bool | None = None) -> DataType:
     return DataType.from_numpy(value, nullable)
 
 
 @_dtype.register("pandas.core.dtypes.base.ExtensionDtype")
-def from_pandas_extension_dtype(value, nullable=True) -> DataType:
+def from_pandas_extension_dtype(
+    value: ExtensionDtype, nullable: bool | None = None
+) -> DataType:
     return DataType.from_pandas(value, nullable)
 
 
 @_dtype.register("pyarrow.lib.DataType")
-def from_pyarrow(value, nullable=True) -> DataType:
+def from_pyarrow(value: pa.DataType, nullable: bool | None = None) -> DataType:
     return DataType.from_pyarrow(value, nullable)
 
 
 @_dtype.register("polars.datatypes.classes.DataTypeClass")
-def from_polars(value, nullable=True) -> DataType:
+def from_polars(value: pl.DataType, nullable: bool | None = None) -> DataType:
     return DataType.from_polars(value, nullable)
 
 

--- a/ibis/expr/datatypes/tests/test_parse.py
+++ b/ibis/expr/datatypes/tests/test_parse.py
@@ -46,6 +46,11 @@ from ibis.common.annotations import ValidationError
 )
 def test_primitive_from_string(nullable, spec, expected):
     assert dt.dtype(spec, nullable=nullable) == expected(nullable=nullable)
+    assert dt.dtype(spec, nullable=None) == expected(nullable=True)
+    assert dt.dtype(spec) == expected(nullable=True)
+    assert dt.dtype("!" + spec, nullable=nullable) == expected(nullable=nullable)
+    assert dt.dtype("!" + spec, nullable=None) == expected(nullable=False)
+    assert dt.dtype("!" + spec) == expected(nullable=False)
 
 
 @pytest.mark.parametrize(

--- a/ibis/formats/__init__.py
+++ b/ibis/formats/__init__.py
@@ -38,7 +38,7 @@ class TypeMapper(Generic[T]):
         raise NotImplementedError
 
     @classmethod
-    def to_ibis(cls, typ: T, nullable: bool = True) -> DataType:
+    def to_ibis(cls, typ: T, nullable: bool | None = None) -> DataType:
         """Convert a format-specific type object to an Ibis DataType.
 
         Parameters
@@ -47,6 +47,9 @@ class TypeMapper(Generic[T]):
             The format-specific type object to convert.
         nullable
             Whether the Ibis DataType should be nullable.
+            If `None`, the nullability will be inferred from `typ` if possible.
+            If inference is not possible, we fall back to the backend's default
+            nullability, which is typically `True`.
 
         Returns
         -------
@@ -56,7 +59,7 @@ class TypeMapper(Generic[T]):
         raise NotImplementedError
 
     @classmethod
-    def from_string(cls, text: str, nullable: bool = True) -> DataType:
+    def from_string(cls, text: str, nullable: bool | None = None) -> DataType:
         """Convert a backend-specific string representation into an Ibis DataType.
 
         Parameters
@@ -65,6 +68,7 @@ class TypeMapper(Generic[T]):
             The backend-specific string representation to convert.
         nullable
             Whether the Ibis DataType should be nullable.
+            If `None`, the specific type mapper will choose a default.
 
         Returns
         -------

--- a/ibis/formats/numpy.py
+++ b/ibis/formats/numpy.py
@@ -36,7 +36,13 @@ _to_numpy_types = {v: k for k, v in _from_numpy_types.items()}
 
 class NumpyType(TypeMapper[np.dtype]):
     @classmethod
-    def to_ibis(cls, typ: np.dtype, nullable: bool = True) -> dt.DataType:
+    def to_ibis(cls, typ: np.dtype, nullable: bool | None = True) -> dt.DataType:
+        # numpy's type system doesn't keep track of nullability.
+        # We accept nullable=None to be compatible with the rest of TypeMapper.to_ibis()
+        # implementations, but we treat None as True, since we can't infer nullability
+        # from a numpy dtype.
+        if nullable is None:
+            nullable = True
         if np.issubdtype(typ, np.datetime64):
             # TODO(kszucs): the following code provedes proper timestamp roundtrips
             # between ibis and numpy/pandas but breaks the test suite at several

--- a/ibis/formats/pandas.py
+++ b/ibis/formats/pandas.py
@@ -34,7 +34,15 @@ geospatial_supported = _find_spec("geopandas") is not None
 
 class PandasType(NumpyType):
     @classmethod
-    def to_ibis(cls, typ, nullable=True):
+    def to_ibis(
+        cls, typ: np.dtype | ExtensionDtype, nullable: bool | None = None
+    ) -> dt.DataType:
+        # pandas's type system doesn't keep track of nullability.
+        # We accept nullable=None to be compatible with the rest of TypeMapper.to_ibis()
+        # implementations, but we treat None as True, since we can't infer nullability
+        # from a pandas dtype.
+        if nullable is None:
+            nullable = True
         if pd.options.future.infer_string and isinstance(typ, pd.StringDtype):
             return dt.String(nullable=nullable)
         elif isinstance(typ, pdt.DatetimeTZDtype):
@@ -56,7 +64,7 @@ class PandasType(NumpyType):
             return super().to_ibis(typ, nullable=nullable)
 
     @classmethod
-    def from_ibis(cls, dtype) -> np.dtype | pd.Ex:
+    def from_ibis(cls, dtype: dt.DataType) -> np.dtype | ExtensionDtype:
         if pd.options.future.infer_string and dtype.is_string():
             return pd.StringDtype(na_value=np.nan)
         elif dtype.is_timestamp():

--- a/ibis/formats/polars.py
+++ b/ibis/formats/polars.py
@@ -39,9 +39,14 @@ _from_polars_types = {v: k for k, v in _to_polars_types.items()}
 
 class PolarsType(TypeMapper):
     @classmethod
-    def to_ibis(cls, typ: pl.DataType, nullable=True) -> dt.DataType:
+    def to_ibis(cls, typ: pl.DataType, nullable: bool | None = None) -> dt.DataType:
         """Convert a polars type to an ibis type."""
-
+        # polars's type system doesn't keep track of nullability.
+        # We accept nullable=None to be compatible with the rest of TypeMapper.to_ibis()
+        # implementations, but we treat None as True, since we can't infer nullability
+        # from a polars dtype.
+        if nullable is None:
+            nullable = True
         base_type = typ.base_type()
         if base_type in (pl.Categorical, pl.Enum):
             return dt.String(nullable=nullable)

--- a/ibis/formats/pyarrow.py
+++ b/ibis/formats/pyarrow.py
@@ -76,10 +76,16 @@ _to_pyarrow_types = {
 
 class PyArrowType(TypeMapper):
     @classmethod
-    def to_ibis(cls, typ: pa.DataType, nullable=True) -> dt.DataType:
+    def to_ibis(cls, typ: pa.DataType, nullable: bool | None = None) -> dt.DataType:
         """Convert a pyarrow type to an ibis type."""
+        # arrow's type system doesn't keep track of nullability.
+        # We accept nullable=None to be compatible with the rest of TypeMapper.to_ibis()
+        # implementations, but we treat None as True, since we can't infer nullability
+        # from a pyarrow dtype.
+        if nullable is None:
+            nullable = True
         if pa.types.is_null(typ):
-            return dt.null
+            return dt.null(nullable=nullable)
         elif pa.types.is_decimal(typ):
             return dt.Decimal(typ.precision, typ.scale, nullable=nullable)
         elif pa.types.is_timestamp(typ):

--- a/ibis/formats/tests/test_numpy.py
+++ b/ibis/formats/tests/test_numpy.py
@@ -115,6 +115,7 @@ def test_schema_from_numpy(numpy_schema):
         assert NumpyType.from_ibis(ibis_schema[name]) == numpy_type
 
 
+@pytest.mark.parametrize("nullable", [True, False, None])
 @pytest.mark.parametrize(
     ("numpy_dtype", "ibis_dtype"),
     [
@@ -135,8 +136,10 @@ def test_schema_from_numpy(numpy_schema):
         (np.datetime64, dt.timestamp),
     ],
 )
-def test_dtype_from_numpy(numpy_dtype, ibis_dtype):
-    assert NumpyType.to_ibis(np.dtype(numpy_dtype)) == ibis_dtype
+def test_dtype_from_numpy(numpy_dtype, ibis_dtype, nullable):
+    if nullable is False:
+        ibis_dtype = ibis_dtype.copy(nullable=False)
+    assert NumpyType.to_ibis(np.dtype(numpy_dtype), nullable=nullable) == ibis_dtype
 
 
 def test_dtype_from_numpy_dtype_timedelta():

--- a/ibis/formats/tests/test_pandas.py
+++ b/ibis/formats/tests/test_pandas.py
@@ -53,6 +53,7 @@ def test_dtype_to_pandas(pandas_type, ibis_type):
     assert PandasType.from_ibis(ibis_type) == pandas_type
 
 
+@pytest.mark.parametrize("nullable", [True, False, None])
 @pytest.mark.parametrize(
     ("pandas_type", "ibis_type"),
     [
@@ -77,9 +78,11 @@ def test_dtype_to_pandas(pandas_type, ibis_type):
     ],
     ids=str,
 )
-def test_dtype_from_pandas_arrow_dtype(pandas_type, ibis_type):
+def test_dtype_from_pandas_arrow_dtype(pandas_type, ibis_type, nullable):
+    if nullable is False:
+        ibis_type = ibis_type.copy(nullable=False)
     series = pd.Series([], dtype=f"{pandas_type}[pyarrow]")
-    assert PandasType.to_ibis(series.dtype) == ibis_type
+    assert PandasType.to_ibis(series.dtype, nullable=nullable) == ibis_type
 
 
 def test_dtype_from_pandas_arrow_string_dtype():

--- a/ibis/formats/tests/test_polars.py
+++ b/ibis/formats/tests/test_polars.py
@@ -66,7 +66,10 @@ from ibis.formats.polars import PolarsData, PolarsSchema, PolarsType  # noqa: E4
 )
 def test_to_from_ibis_type(ibis_dtype, polars_type):
     assert PolarsType.from_ibis(ibis_dtype) == polars_type
-    assert PolarsType.to_ibis(polars_type) == ibis_dtype
+    assert PolarsType.from_ibis(ibis_dtype.copy(nullable=False)) == polars_type
+    assert PolarsType.to_ibis(polars_type) == ibis_dtype(nullable=True)
+    assert PolarsType.to_ibis(polars_type, nullable=None) == ibis_dtype(nullable=True)
+    assert PolarsType.to_ibis(polars_type, nullable=True) == ibis_dtype(nullable=True)
     assert PolarsType.to_ibis(polars_type, nullable=False) == ibis_dtype(nullable=False)
 
 


### PR DESCRIPTION
This removes the footgun where currently `ibis.dtype("!int64", nullable=True)` results in a non-nullable dtype. Besides that, this shouldn't affect users at all.

This also removes the slightly smaller footgun where `ibis.dtype(existing_dtype)` would always return a nullable version. I think it is preferable for this to be a no-op (return the original dtype unchanged), and only to adjust the nullability if it is explicitly provided.

This also sets us up to work with any future type systems that have an inherent sense of nullability. All the ones we currently support (numpy, pandas, arrow, and polars) do not keep track of nullability, so this doesn't do much there. This might not be much of a reason to do this. IF you want, we could limit the changes just to the top-level dtype() function, and not adjust the TypeMapper.to_ibis() signature, but I thought I might as well make everything consistent, its a tiny bit more code but not much.

Finally, this adds a lot more examples to the docstring for dtype() so that users get a taste of the string DSL.

This was inspired by https://github.com/ibis-project/ibis/pull/11607, and would help reduce the scope of that PR.