### PR TITLE
fix: remove bogus leading ' from Struct repr

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -988,7 +988,7 @@ class Struct(Parametric, MapSet):
 
     def __repr__(self) -> str:
         name = self.__class__.__name__
-        return f"'{name}({list(self.items())}, nullable={self.nullable})"
+        return f"{name}({list(self.items())}, nullable={self.nullable})"
 
     @property
     def _pretty_piece(self) -> str:


### PR DESCRIPTION
Really simple fix. This slipped in somehow. This is a pre-requisite for/ is part of https://github.com/ibis-project/ibis/pull/11694