### PR TITLE
refactor: move _binop() util function to be near ir.Value, not ir.Expr

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -9,7 +9,6 @@ from public import public
 
 import ibis
 import ibis.expr.operations as ops
-from ibis.common.annotations import ValidationError
 from ibis.common.exceptions import IbisError, TranslationError
 from ibis.common.grounds import Immutable
 from ibis.common.patterns import Coercible, CoercionError
@@ -944,38 +943,3 @@ class Expr(Immutable, Coercible):
         raise NotImplementedError(
             f"{type(self)} expressions cannot be converted into scalars"
         )
-
-
-def _binop(op_class: type[ops.Binary], left: ir.Value, right: ir.Value) -> ir.Value:
-    """Try to construct a binary operation.
-
-    Parameters
-    ----------
-    op_class
-        The `ops.Binary` subclass for the operation
-    left
-        Left operand
-    right
-        Right operand
-
-    Returns
-    -------
-    ir.Value
-        A value expression
-
-    Examples
-    --------
-    >>> import ibis
-    >>> import ibis.expr.operations as ops
-    >>> expr = _binop(ops.TimeAdd, ibis.time("01:00"), ibis.interval(hours=1))
-    >>> expr
-    TimeAdd(datetime.time(1, 0), 1h): datetime.time(1, 0) + 1 h
-    >>> _binop(ops.TimeAdd, 1, ibis.interval(hours=1))
-    TimeAdd(datetime.time(0, 0, 1), 1h): datetime.time(0, 0, 1) + 1 h
-    """
-    try:
-        node = op_class(left, right)
-    except (ValidationError, NotImplementedError):
-        return NotImplemented
-    else:
-        return node.to_expr()

--- a/ibis/expr/types/logical.py
+++ b/ibis/expr/types/logical.py
@@ -7,7 +7,7 @@ from public import public
 import ibis
 import ibis.expr.operations as ops
 from ibis import util
-from ibis.expr.types.core import _binop
+from ibis.expr.types.generic import _binop
 from ibis.expr.types.numeric import NumericColumn, NumericScalar, NumericValue
 
 if TYPE_CHECKING:

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -8,8 +8,7 @@ from public import public
 import ibis
 import ibis.expr.operations as ops
 from ibis.common.exceptions import IbisTypeError
-from ibis.expr.types.core import _binop
-from ibis.expr.types.generic import Column, Scalar, Value
+from ibis.expr.types.generic import Column, Scalar, Value, _binop
 
 if TYPE_CHECKING:
     import ibis.expr.types as ir

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -8,8 +8,7 @@ from public import public
 
 import ibis.expr.operations as ops
 from ibis import util
-from ibis.expr.types.core import _binop
-from ibis.expr.types.generic import Column, Scalar, Value
+from ibis.expr.types.generic import Column, Scalar, Value, _binop
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -11,8 +11,7 @@ import ibis.expr.operations as ops
 from ibis import util
 from ibis.common.annotations import annotated
 from ibis.common.temporal import IntervalUnit
-from ibis.expr.types.core import _binop
-from ibis.expr.types.generic import Column, Scalar, Value
+from ibis.expr.types.generic import Column, Scalar, Value, _binop
 from ibis.util import deprecated
 
 if TYPE_CHECKING:


### PR DESCRIPTION
This function is only uses with Values, not general Expr,
so it should be co-located there.

This adds a runtime assert to verify we are using this correctly internally.

It also improves the docstring to not be misleading about ops.Binary,
and to give some more examples of the edge cases.

I found this in https://github.com/ibis-project/ibis/actions/runs/18572797607/job/52950629575?pr=11613
after I started deep diving as to why `ibis.table({"a": int}) == ibis.table({"b": str}).b` didn't error (it returns False), when I expected it to error. I might think that we should adjust this behavior so that this does error, but that is for a different PR. This is just a nice refactor.