### PR TITLE
fix: add upper _method_overrides in decompile

### DIFF
--- a/ibis/expr/decompile.py
+++ b/ibis/expr/decompile.py
@@ -24,7 +24,6 @@ _method_overrides = {
     ops.ExtractMicrosecond: "microsecond",
     ops.ExtractMillisecond: "millisecond",
     ops.ExtractMinute: "minute",
-    ops.ExtractMinute: "minute",
     ops.ExtractMonth: "month",
     ops.ExtractQuarter: "quarter",
     ops.ExtractSecond: "second",
@@ -38,6 +37,7 @@ _method_overrides = {
     ops.StringContains: "contains",
     ops.StringSQLILike: "ilike",
     ops.StringSQLLike: "like",
+    ops.Uppercase: "upper",
 }
 
 

--- a/ibis/expr/tests/test_decompile.py
+++ b/ibis/expr/tests/test_decompile.py
@@ -86,3 +86,16 @@ def test_view():
 def test_distinct():
     expr = ibis.table({"x": "int"}, name="t").distinct()
     assert "t.distinct()" in decompile(expr)
+
+
+@pytest.mark.parametrize(
+    ("method", "override"),
+    [
+        (ibis._.x.upper(), ".upper()"),
+        (ibis._.x.lower(), ".lower()"),
+        (ibis._.y.minute(), ".minute()"),
+    ],
+)
+def test_method_overrides(method, override):
+    expr = ibis.table({"x": "string", "y": "timestamp"}, name="t").select(method)
+    assert override in decompile(expr)


### PR DESCRIPTION
## Description of changes

Additionally, this change removes a duplicated entry for ops.ExtractMinute

## Issues closed

* Resolves #11717

