### PR TITLE
chore(mssql): always append semicolon to statement

### DIFF
--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -427,7 +427,8 @@ class Backend(
         # Although the semicolon isn't required for most statements, the
         # T-SQL docs state that it will be required in a future version.
         # https://learn.microsoft.com/en-us/sql/t-sql/language-elements/transact-sql-syntax-conventions-transact-sql?view=sql-server-ver17&tabs=code
-        query = f"{query};"
+        if not query.rstrip().endswith(";"):
+            query = f"{query};"
 
         with self.begin() as cur:
             cur.execute(query, *args, **kwargs)


### PR DESCRIPTION
## Description of changes

Terminate all MSSQL statements with a semicolon. This is required for some statements (e.g. [`MERGE`](https://github.com/ibis-project/ibis/pull/11624)).

Raising a separate PR so that this broader change (not solely affecting `Backend.upsert()` implementation) is reflected in the changelog. All tests pass as-is.