### PR TITLE
Repro for error on memtable 

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -880,6 +880,22 @@ def test_in_memory_table(backend, con, arg, lambda_, expected, monkeypatch):
     backend.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    "size",
+    [
+        100,
+        1_000,
+        10_000,
+    ],
+)
+def test_large_memory_table(con, monkeypatch, size):
+    monkeypatch.setattr(ibis.options, "default_backend", con)
+
+    expr = ibis.memtable({"a": range(size)}).count()
+    result = con.execute(expr)
+    assert result == size
+
+
 def test_filter_memory_table(backend, con, monkeypatch):
     monkeypatch.setattr(ibis.options, "default_backend", con)
 


### PR DESCRIPTION
This is a repro to show that using a large memtable on postgres gives an error. (at least I think this should repro, I am still having trouble getting postgres running in my env)

On my computer, this happens somewhere around 8400 rows, but is inconsistent, sometimes 8400 rows works, sometimes it errors. I'm getting this when connected to a hosted serverless neon.tech postgres instance.

I get a warning: `WARNING:psycopg:error ignored terminating <psycopg.Pipeline [BAD] at 0x3488be590>: the connection is lost`, and then an error at https://github.com/ibis-project/ibis/blob/9431fa9dce8402db3c07e23b2541f1c223835e73/ibis/backends/postgres/__init__.py#L110:

```
OperationalError: sending prepared query failed: SSL error: bad length
SSL SYSCALL error: EOF detected
```

I can repo even more simply with `pgbackend._register_in_memory_tables(big_memtable)`, but I thought it would be good to only test the public API

Perhaps this is due to the `executemany()` getting called too many times? Should we batch the memtable in smaller chunks?

If you give me any pointers I can try to put up a fix, but I don't understand the root cause yet.