### PR TITLE
fix(sqlite): precision loss in divide

### DIFF
--- a/ibis/backends/sql/compilers/sqlite.py
+++ b/ibis/backends/sql/compilers/sqlite.py
@@ -545,5 +545,13 @@ class SQLiteCompiler(SQLGlotCompiler):
             )
         return self.f._ibis_date_delta(left, right)
 
+    def visit_Divide(self, op, *, left, right):
+        left = (
+            sge.cast(left, sge.DataType.Type.FLOAT, copy=False)
+            if all(arg.dtype.is_integer() for arg in op.args)
+            else left
+        )
+        return self.binop(sge.Div, left, right)
+
 
 compiler = SQLiteCompiler()

--- a/ibis/backends/sqlite/tests/test_numeric.py
+++ b/ibis/backends/sqlite/tests/test_numeric.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pandas as pd
+import pandas.testing as tm
+
+import ibis
+
+
+def test_divide_precision(con):
+    df = pd.DataFrame({"a": [10, 20, 30], "b": [2, 3, 4], "c": [5, 10, 15]})
+
+    t = ibis.memtable(df)
+
+    expr = (t.a + t.b) * t.c - t.a / t.b
+
+    actual = con.execute(expr).squeeze()
+
+    expected = pd.Series([55.0, 223.333, 502.5])
+
+    tm.assert_series_equal(
+        actual, expected, check_exact=False, check_names=False, atol=0.001
+    )


### PR DESCRIPTION
## Description of changes

Fix precision loss in Divide for the SQLite backend

## Issues closed

* Resolves #11743

