### PR TITLE
fix(polars): handle cross joins without passing join keys

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -313,6 +313,9 @@ def join(op, **kw):
         left, right = right, left
     elif how == "outer":
         how = "full"
+    elif how == "cross":
+        # Cross joins don't use join keys
+        return left.join(right, how=how)
 
     joined = left.join(right, on=on, how=how, coalesce=False)
     joined = joined.drop(*on)

--- a/ibis/backends/polars/tests/test_join.py
+++ b/ibis/backends/polars/tests/test_join.py
@@ -25,3 +25,47 @@ def test_memtable_join(con):
     left = result.sort_values("x").reset_index(drop=True)
     right = expected.sort_values("x").reset_index(drop=True)
     tm.assert_frame_equal(left, right)
+
+
+def test_memtable_join_left(con):
+    t1 = ibis.memtable({"x": [1, 2, 3], "y": [4, 5, 6], "z": ["a", "b", "c"]})
+    t2 = ibis.memtable({"x": [3, 2, 1], "y": [7, 8, 9], "z": ["d", "e", "f"]})
+    expr = t1.join(t2, "x", how="left")
+
+    result = con.execute(expr)
+    expected = pd.DataFrame(
+        {
+            "x": [1, 2, 3],
+            "y": [4, 5, 6],
+            "z": ["a", "b", "c"],
+            "x_right": [1, 2, 3],
+            "y_right": [9, 8, 7],
+            "z_right": ["f", "e", "d"],
+        }
+    )
+
+    left = result.sort_values("x").reset_index(drop=True)
+    right = expected.sort_values("x").reset_index(drop=True)
+    tm.assert_frame_equal(left, right)
+
+
+def test_memtable_join_cross(con):
+    t1 = ibis.memtable({"x": [1, 2, 3], "y": [4, 5, 6], "z": ["a", "b", "c"]})
+    t2 = ibis.memtable({"x": [3, 2, 1], "y": [7, 8, 9], "z": ["d", "e", "f"]})
+    expr = t1.join(t2, how="cross")
+
+    result = con.execute(expr)
+    expected = pd.DataFrame(
+        {
+            "x": [1, 1, 1, 2, 2, 2, 3, 3, 3],
+            "y": [4, 4, 4, 5, 5, 5, 6, 6, 6],
+            "z": ["a", "a", "a", "b", "b", "b", "c", "c", "c"],
+            "x_right": [1, 2, 3, 1, 2, 3, 1, 2, 3],
+            "y_right": [9, 8, 7, 9, 8, 7, 9, 8, 7],
+            "z_right": ["f", "e", "d", "f", "e", "d", "f", "e", "d"],
+        }
+    )
+
+    left = result.sort_values(["x", "x_right"]).reset_index(drop=True)
+    right = expected.sort_values(["x", "x_right"]).reset_index(drop=True)
+    tm.assert_frame_equal(left, right)


### PR DESCRIPTION
## Description of changes
Update the polars compiler to not pass on keys when doing a cross join. Also updates the join tests to include a left join and a cross join for the polars backend.


## Issues closed
Resolves #11764
