### PR TITLE
feat(typing): make types more precise for many common Values

### DIFF
--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1484,7 +1484,7 @@ class Scalar(Value):
 
         return PolarsData.convert_scalar(df, self.type())
 
-    def as_scalar(self) -> Scalar:
+    def as_scalar(self) -> Self:
         """Tell ibis to treat this expression as a single scalar value.
 
         If the expression is a literal, it will be returned as is.
@@ -2481,7 +2481,7 @@ class Column(Value, FixedTextJupyterMixin):
         where: ir.BooleanValue | None = None,
         order_by: Any = None,
         include_null: bool = False,
-    ) -> Value:
+    ) -> Scalar:
         """Return the first value of a column.
 
         Parameters
@@ -2535,7 +2535,7 @@ class Column(Value, FixedTextJupyterMixin):
         where: ir.BooleanValue | None = None,
         order_by: Any = None,
         include_null: bool = False,
-    ) -> Value:
+    ) -> Scalar:
         """Return the last value of a column.
 
         Parameters
@@ -2647,7 +2647,7 @@ class Column(Value, FixedTextJupyterMixin):
         """
         return ibis.dense_rank().over(order_by=self)
 
-    def percent_rank(self) -> Column:
+    def percent_rank(self) -> ir.FloatingColumn:
         """Return the relative rank of the values in the column.
 
         Examples
@@ -2671,7 +2671,7 @@ class Column(Value, FixedTextJupyterMixin):
         """
         return ibis.percent_rank().over(order_by=self)
 
-    def cume_dist(self) -> Column:
+    def cume_dist(self) -> ir.FloatingColumn:
         """Return the cumulative distribution over a window.
 
         Examples
@@ -3015,7 +3015,7 @@ class NullColumn(Column, NullValue):
 
 @public
 @deferrable
-def null(type: dt.DataType | str | None = None, /) -> Value:
+def null(type: dt.DataType | str | None = None, /) -> NullScalar:
     """Create a NULL scalar.
 
     `NULL`s with an unspecified type are castable and comparable to values,

--- a/ibis/expr/types/logical.py
+++ b/ibis/expr/types/logical.py
@@ -11,6 +11,8 @@ from ibis.expr.types.generic import _binop
 from ibis.expr.types.numeric import NumericColumn, NumericScalar, NumericValue
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     import ibis.expr.types as ir
 
 
@@ -53,7 +55,7 @@ class BooleanValue(NumericValue):
         # must be used.
         return ops.IfElse(self, true_expr, false_expr).to_expr()
 
-    def __and__(self, other: BooleanValue) -> BooleanValue:
+    def __and__(self, other: bool | BooleanValue | ibis.Deferred) -> BooleanValue:
         """Construct a binary AND conditional expression with `self` and `other`.
 
         Parameters
@@ -101,7 +103,7 @@ class BooleanValue(NumericValue):
 
     __rand__ = __and__
 
-    def __or__(self, other: BooleanValue) -> BooleanValue:
+    def __or__(self, other: bool | BooleanValue | ibis.Deferred) -> BooleanValue:
         """Construct a binary OR conditional expression with `self` and `other`.
 
         Parameters
@@ -137,7 +139,7 @@ class BooleanValue(NumericValue):
 
     __ror__ = __or__
 
-    def __xor__(self, other: BooleanValue) -> BooleanValue:
+    def __xor__(self, other: bool | BooleanValue | ibis.Deferred) -> BooleanValue:
         """Construct a binary XOR conditional expression with `self` and `other`.
 
         Parameters
@@ -198,7 +200,7 @@ class BooleanValue(NumericValue):
 
     __rxor__ = __xor__
 
-    def __invert__(self) -> BooleanValue:
+    def __invert__(self) -> Self:
         """Construct a unary NOT conditional expression with `self`.
 
         Parameters
@@ -230,7 +232,7 @@ class BooleanValue(NumericValue):
         """
         return ops.Not(self).to_expr()
 
-    def negate(self) -> BooleanValue:
+    def negate(self) -> Self:
         """DEPRECATED."""
         util.warn_deprecated(
             "`-bool_val`/`bool_val.negate()`",
@@ -247,7 +249,9 @@ class BooleanScalar(NumericScalar, BooleanValue):
 
 @public
 class BooleanColumn(NumericColumn, BooleanValue):
-    def any(self, *, where: BooleanValue | None = None) -> BooleanValue:
+    def any(
+        self, *, where: bool | BooleanValue | ibis.Deferred | None = None
+    ) -> BooleanScalar:
         """Return whether at least one element is `True`.
 
         If the expression does not reference any foreign tables, the result
@@ -339,7 +343,9 @@ class BooleanColumn(NumericColumn, BooleanValue):
 
         return op.to_expr()
 
-    def notany(self, *, where: BooleanValue | None = None) -> BooleanValue:
+    def notany(
+        self, *, where: bool | BooleanValue | ibis.Deferred | None = None
+    ) -> BooleanScalar:
         """Return whether no elements are `True`.
 
         Parameters
@@ -373,7 +379,9 @@ class BooleanColumn(NumericColumn, BooleanValue):
         """
         return ~self.any(where=where)
 
-    def all(self, *, where: BooleanValue | None = None) -> BooleanScalar:
+    def all(
+        self, *, where: bool | BooleanValue | ibis.Deferred | None = None
+    ) -> BooleanScalar:
         """Return whether all elements are `True`.
 
         Parameters
@@ -410,7 +418,9 @@ class BooleanColumn(NumericColumn, BooleanValue):
         """
         return ops.All(self, where=self._bind_to_parent_table(where)).to_expr()
 
-    def notall(self, *, where: BooleanValue | None = None) -> BooleanScalar:
+    def notall(
+        self, *, where: bool | BooleanValue | ibis.Deferred | None = None
+    ) -> BooleanScalar:
         """Return whether not all elements are `True`.
 
         Parameters
@@ -447,7 +457,13 @@ class BooleanColumn(NumericColumn, BooleanValue):
         """
         return ~self.all(where=where)
 
-    def cumany(self, *, where=None, group_by=None, order_by=None) -> BooleanColumn:
+    def cumany(
+        self,
+        *,
+        where: bool | BooleanValue | ibis.Deferred | None = None,
+        group_by=None,
+        order_by=None,
+    ) -> BooleanColumn:
         """Accumulate the `any` aggregate.
 
         Returns
@@ -487,7 +503,13 @@ class BooleanColumn(NumericColumn, BooleanValue):
             ibis.cumulative_window(group_by=group_by, order_by=order_by)
         )
 
-    def cumall(self, *, where=None, group_by=None, order_by=None) -> BooleanColumn:
+    def cumall(
+        self,
+        *,
+        where: bool | BooleanValue | ibis.Deferred | None = None,
+        group_by=None,
+        order_by=None,
+    ) -> BooleanColumn:
         """Accumulate the `all` aggregate.
 
         Returns

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -11,12 +11,19 @@ from ibis.common.exceptions import IbisTypeError
 from ibis.expr.types.generic import Column, Scalar, Value, _binop
 
 if TYPE_CHECKING:
+    from decimal import Decimal
+    from typing import Union
+
+    from typing_extensions import Self
+
     import ibis.expr.types as ir
+
+    Number = Union[int, float, Decimal]
 
 
 @public
 class NumericValue(Value):
-    def negate(self) -> NumericValue:
+    def negate(self) -> Self:
         """Negate a numeric expression.
 
         Returns
@@ -42,7 +49,7 @@ class NumericValue(Value):
         """
         return ops.Negate(self).to_expr()
 
-    def __neg__(self) -> NumericValue:
+    def __neg__(self) -> Self:
         """Negate `self`.
 
         Returns
@@ -163,9 +170,9 @@ class NumericValue(Value):
 
     def clip(
         self,
-        lower: NumericValue | None = None,
-        upper: NumericValue | None = None,
-    ) -> NumericValue:
+        lower: Number | NumericValue | ibis.Deferred | None = None,
+        upper: Number | NumericValue | ibis.Deferred | None = None,
+    ) -> Self:
         """Trim values outside of `lower` and `upper` bounds.
 
         `NULL` values are preserved and are not replaced with bounds.
@@ -211,7 +218,7 @@ class NumericValue(Value):
 
         return ops.Clip(self, lower, upper).to_expr()
 
-    def abs(self) -> NumericValue:
+    def abs(self) -> Self:
         """Return the absolute value of `self`.
 
         Examples
@@ -530,7 +537,7 @@ class NumericValue(Value):
         """
         return ops.Atan(self).to_expr()
 
-    def atan2(self, other: NumericValue, /) -> NumericValue:
+    def atan2(self, other: Number | NumericValue | ibis.Deferred, /) -> NumericValue:
         """Compute the two-argument version of arc tangent.
 
         Examples
@@ -635,86 +642,90 @@ class NumericValue(Value):
         """
         return ops.Tan(self).to_expr()
 
-    def __add__(self, other: NumericValue) -> NumericValue:
+    def __add__(self, other: Number | NumericValue | ibis.Deferred) -> NumericValue:
         """Add `self` with `other`."""
         return _binop(ops.Add, self, other)
 
     add = radd = __radd__ = __add__
 
-    def __sub__(self, other: NumericValue) -> NumericValue:
+    def __sub__(self, other: Number | NumericValue | ibis.Deferred) -> NumericValue:
         """Subtract `other` from `self`."""
         return _binop(ops.Subtract, self, other)
 
     sub = __sub__
 
-    def __rsub__(self, other: NumericValue) -> NumericValue:
+    def __rsub__(self, other: Number | NumericValue | ibis.Deferred) -> NumericValue:
         """Subtract `self` from `other`."""
         return _binop(ops.Subtract, other, self)
 
     rsub = __rsub__
 
-    def __mul__(self, other: NumericValue) -> NumericValue:
+    def __mul__(self, other: Number | NumericValue | ibis.Deferred) -> NumericValue:
         """Multiply `self` and `other`."""
         return _binop(ops.Multiply, self, other)
 
     mul = rmul = __rmul__ = __mul__
 
-    def __truediv__(self, other):
+    def __truediv__(self, other: Number | NumericValue | ibis.Deferred) -> NumericValue:
         """Divide `self` by `other`."""
         return _binop(ops.Divide, self, other)
 
     div = __div__ = __truediv__
 
-    def __rtruediv__(self, other: NumericValue) -> NumericValue:
-        """Divide `other` by `self`."""
+    def __rtruediv__(
+        self, other: Number | NumericValue | ibis.Deferred
+    ) -> NumericValue:
+        """Perform `other` / `self`."""
         return _binop(ops.Divide, other, self)
 
     rdiv = __rdiv__ = __rtruediv__
 
     def __floordiv__(
         self,
-        other: NumericValue,
-    ) -> NumericValue:
-        """Floor divide `self` by `other`."""
+        other: Number | NumericValue | ibis.Deferred,
+    ) -> IntegerValue:
+        """Perform `self` // `other`."""
         return _binop(ops.FloorDivide, self, other)
 
     floordiv = __floordiv__
 
     def __rfloordiv__(
         self,
-        other: NumericValue,
-    ) -> NumericValue:
-        """Floor divide `other` by `self`."""
+        other: Number | NumericValue | ibis.Deferred,
+    ) -> IntegerValue:
+        """Perform `other` // `self`."""
         return _binop(ops.FloorDivide, other, self)
 
     rfloordiv = __rfloordiv__
 
-    def __pow__(self, other: NumericValue) -> NumericValue:
+    def __pow__(self, other: Number | NumericValue | ibis.Deferred) -> NumericValue:
         """Raise `self` to the `other`th power."""
         return _binop(ops.Power, self, other)
 
     pow = __pow__
 
-    def __rpow__(self, other: NumericValue) -> NumericValue:
+    def __rpow__(self, other: Number | NumericValue | ibis.Deferred) -> NumericValue:
         """Raise `other` to the `self`th power."""
         return _binop(ops.Power, other, self)
 
     rpow = __rpow__
 
-    def __mod__(self, other: NumericValue) -> NumericValue:
+    def __mod__(self, other: Number | NumericValue | ibis.Deferred) -> NumericValue:
         """Compute `self` modulo `other`."""
         return _binop(ops.Modulus, self, other)
 
     mod = __mod__
 
-    def __rmod__(self, other: NumericValue) -> NumericValue:
+    def __rmod__(self, other: Number | NumericValue | ibis.Deferred) -> NumericValue:
         """Compute `other` modulo `self`."""
 
         return _binop(ops.Modulus, other, self)
 
     rmod = __rmod__
 
-    def point(self, right: int | float | NumericValue, /) -> ir.PointValue:
+    def point(
+        self, right: int | float | NumericValue | ibis.Deferred, /
+    ) -> ir.PointValue:
         """Return a point constructed from the coordinate values.
 
         Constant coordinates result in construction of a `POINT` literal or
@@ -767,7 +778,7 @@ class NumericColumn(Column, NumericValue):
     def kurtosis(
         self,
         *,
-        where: ir.BooleanValue | None = None,
+        where: bool | ir.BooleanValue | ibis.Deferred | None = None,
         how: Literal["sample", "pop"] = "sample",
     ) -> NumericScalar:
         """Return the kurtosis of a numeric column.
@@ -816,7 +827,7 @@ class NumericColumn(Column, NumericValue):
     def std(
         self,
         *,
-        where: ir.BooleanValue | None = None,
+        where: bool | ir.BooleanValue | ibis.Deferred | None = None,
         how: Literal["sample", "pop"] = "sample",
     ) -> NumericScalar:
         """Return the standard deviation of a numeric column.
@@ -920,9 +931,9 @@ class NumericColumn(Column, NumericValue):
         right: NumericColumn,
         /,
         *,
-        where: ir.BooleanValue | None = None,
+        where: bool | ir.BooleanValue | ibis.Deferred | None = None,
         how: Literal["sample", "pop"] = "sample",
-    ) -> NumericScalar:
+    ) -> FloatingScalar:
         """Return the correlation of two numeric columns.
 
         Parameters
@@ -979,9 +990,9 @@ class NumericColumn(Column, NumericValue):
         right: NumericColumn,
         /,
         *,
-        where: ir.BooleanValue | None = None,
+        where: bool | ir.BooleanValue | ibis.Deferred | None = None,
         how: Literal["sample", "pop"] = "sample",
-    ) -> NumericScalar:
+    ) -> FloatingScalar:
         """Return the covariance of two numeric columns.
 
         Parameters
@@ -1037,7 +1048,9 @@ class NumericColumn(Column, NumericValue):
             where=self._bind_to_parent_table(where),
         ).to_expr()
 
-    def mean(self, *, where: ir.BooleanValue | None = None) -> NumericScalar:
+    def mean(
+        self, *, where: bool | ir.BooleanValue | ibis.Deferred | None = None
+    ) -> NumericScalar:
         """Return the mean of a numeric column.
 
         Parameters
@@ -1093,7 +1106,13 @@ class NumericColumn(Column, NumericValue):
         # of default name generated by ops.Value operations
         return ops.Mean(self, where=self._bind_to_parent_table(where)).to_expr()
 
-    def cummean(self, *, where=None, group_by=None, order_by=None) -> NumericColumn:
+    def cummean(
+        self,
+        *,
+        where: bool | ir.BooleanValue | ibis.Deferred | None = None,
+        group_by=None,
+        order_by=None,
+    ) -> FloatingColumn:
         """Return the cumulative mean of the input.
 
         Examples
@@ -1141,7 +1160,9 @@ class NumericColumn(Column, NumericValue):
             ibis.cumulative_window(group_by=group_by, order_by=order_by)
         )
 
-    def sum(self, *, where: ir.BooleanValue | None = None) -> NumericScalar:
+    def sum(
+        self, *, where: bool | ir.BooleanValue | ibis.Deferred | None = None
+    ) -> NumericScalar:
         """Return the sum of a numeric column.
 
         Parameters
@@ -1195,7 +1216,13 @@ class NumericColumn(Column, NumericValue):
         """
         return ops.Sum(self, where=self._bind_to_parent_table(where)).to_expr()
 
-    def cumsum(self, *, where=None, group_by=None, order_by=None) -> NumericColumn:
+    def cumsum(
+        self,
+        *,
+        where: bool | ir.BooleanValue | ibis.Deferred | None = None,
+        group_by=None,
+        order_by=None,
+    ) -> NumericColumn:
         """Return the cumulative sum of the input.
 
         Examples
@@ -1322,7 +1349,7 @@ class NumericColumn(Column, NumericValue):
         binwidth: float | None = None,
         base: float | None = None,
         eps: float = 1e-13,
-    ):
+    ) -> IntegerColumn:
         """Compute a histogram with fixed width bins.
 
         Parameters
@@ -1556,9 +1583,9 @@ class IntegerValue(NumericValue):
 
     def convert_base(
         self,
-        from_base: IntegerValue,
-        to_base: IntegerValue,
-    ) -> IntegerValue:
+        from_base: int | IntegerValue,
+        to_base: int | IntegerValue,
+    ) -> ir.StringValue:
         """Convert an integer from one base to another.
 
         Parameters
@@ -1570,46 +1597,46 @@ class IntegerValue(NumericValue):
 
         Returns
         -------
-        IntegerValue
+        StringValue
             Converted expression
         """
         return ops.BaseConvert(self, from_base, to_base).to_expr()
 
-    def __and__(self, other: IntegerValue) -> IntegerValue:
+    def __and__(self, other: int | IntegerValue | ibis.Deferred) -> IntegerValue:
         """Bitwise and `self` with `other`."""
         return _binop(ops.BitwiseAnd, self, other)
 
     __rand__ = __and__
 
-    def __or__(self, other: IntegerValue) -> IntegerValue:
+    def __or__(self, other: int | IntegerValue | ibis.Deferred) -> IntegerValue:
         """Bitwise or `self` with `other`."""
         return _binop(ops.BitwiseOr, self, other)
 
     __ror__ = __or__
 
-    def __xor__(self, other: IntegerValue) -> IntegerValue:
+    def __xor__(self, other: int | IntegerValue | ibis.Deferred) -> IntegerValue:
         """Bitwise xor `self` with `other`."""
         return _binop(ops.BitwiseXor, self, other)
 
     __rxor__ = __xor__
 
-    def __lshift__(self, other: IntegerValue) -> IntegerValue:
+    def __lshift__(self, other: int | IntegerValue | ibis.Deferred) -> IntegerValue:
         """Bitwise left shift `self` with `other`."""
         return _binop(ops.BitwiseLeftShift, self, other)
 
-    def __rlshift__(self, other: IntegerValue) -> IntegerValue:
+    def __rlshift__(self, other: int | IntegerValue | ibis.Deferred) -> IntegerValue:
         """Bitwise left shift `self` with `other`."""
         return _binop(ops.BitwiseLeftShift, other, self)
 
-    def __rshift__(self, other: IntegerValue) -> IntegerValue:
+    def __rshift__(self, other: int | IntegerValue | ibis.Deferred) -> IntegerValue:
         """Bitwise right shift `self` with `other`."""
         return _binop(ops.BitwiseRightShift, self, other)
 
-    def __rrshift__(self, other: IntegerValue) -> IntegerValue:
+    def __rrshift__(self, other: int | IntegerValue | ibis.Deferred) -> IntegerValue:
         """Bitwise right shift `self` with `other`."""
         return _binop(ops.BitwiseRightShift, other, self)
 
-    def __invert__(self) -> IntegerValue:
+    def __invert__(self) -> Self:
         """Bitwise not of `self`.
 
         Returns
@@ -1632,7 +1659,9 @@ class IntegerScalar(NumericScalar, IntegerValue):
 
 @public
 class IntegerColumn(NumericColumn, IntegerValue):
-    def bit_and(self, *, where: ir.BooleanValue | None = None) -> IntegerScalar:
+    def bit_and(
+        self, *, where: bool | ir.BooleanValue | ibis.Deferred | None = None
+    ) -> IntegerScalar:
         """Aggregate the column using the bitwise and operator.
 
         Examples
@@ -1651,7 +1680,9 @@ class IntegerColumn(NumericColumn, IntegerValue):
         """
         return ops.BitAnd(self, where=self._bind_to_parent_table(where)).to_expr()
 
-    def bit_or(self, *, where: ir.BooleanValue | None = None) -> IntegerScalar:
+    def bit_or(
+        self, *, where: bool | ir.BooleanValue | ibis.Deferred | None = None
+    ) -> IntegerScalar:
         """Aggregate the column using the bitwise or operator.
 
         Examples
@@ -1670,7 +1701,9 @@ class IntegerColumn(NumericColumn, IntegerValue):
         """
         return ops.BitOr(self, where=self._bind_to_parent_table(where)).to_expr()
 
-    def bit_xor(self, *, where: ir.BooleanValue | None = None) -> IntegerScalar:
+    def bit_xor(
+        self, *, where: bool | ir.BooleanValue | ibis.Deferred | None = None
+    ) -> IntegerScalar:
         """Aggregate the column using the bitwise exclusive or operator.
 
         Examples

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -13,12 +13,15 @@ from ibis.expr.types.generic import Column, Scalar, Value, _binop
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
+    from typing_extensions import Self
+
     import ibis.expr.types as ir
+    from ibis.common.deferred import Deferred
 
 
 @public
 class StringValue(Value):
-    def __getitem__(self, key: slice | int | ir.IntegerScalar) -> StringValue:
+    def __getitem__(self, key: slice | int | ir.IntegerValue | Deferred) -> StringValue:
         """Index or slice a string expression.
 
         Parameters
@@ -135,7 +138,7 @@ class StringValue(Value):
         """
         return ops.StringLength(self).to_expr()
 
-    def lower(self) -> StringValue:
+    def lower(self) -> Self:
         """Convert string to all lowercase.
 
         Returns
@@ -171,7 +174,7 @@ class StringValue(Value):
         """
         return ops.Lowercase(self).to_expr()
 
-    def upper(self) -> StringValue:
+    def upper(self) -> Self:
         """Convert string to all uppercase.
 
         Returns
@@ -207,7 +210,7 @@ class StringValue(Value):
         """
         return ops.Uppercase(self).to_expr()
 
-    def reverse(self) -> StringValue:
+    def reverse(self) -> Self:
         """Reverse the characters of a string.
 
         Returns
@@ -269,7 +272,7 @@ class StringValue(Value):
         """
         return ops.StringAscii(self).to_expr()
 
-    def strip(self) -> StringValue:
+    def strip(self) -> Self:
         r"""Remove whitespace from left and right sides of a string.
 
         Returns
@@ -305,7 +308,7 @@ class StringValue(Value):
         """
         return ops.Strip(self).to_expr()
 
-    def lstrip(self) -> StringValue:
+    def lstrip(self) -> Self:
         r"""Remove whitespace from the left side of string.
 
         Returns
@@ -341,7 +344,7 @@ class StringValue(Value):
         """
         return ops.LStrip(self).to_expr()
 
-    def rstrip(self) -> StringValue:
+    def rstrip(self) -> Self:
         r"""Remove whitespace from the right side of string.
 
         Returns
@@ -377,7 +380,7 @@ class StringValue(Value):
         """
         return ops.RStrip(self).to_expr()
 
-    def capitalize(self) -> StringValue:
+    def capitalize(self) -> Self:
         """Uppercase the first letter, lowercase the rest.
 
         This API matches the semantics of the Python [](`str.capitalize`)
@@ -410,7 +413,7 @@ class StringValue(Value):
     def __contains__(self, *_: Any) -> bool:
         raise TypeError("Use string_expr.contains(arg)")
 
-    def contains(self, substr: str | StringValue, /) -> ir.BooleanValue:
+    def contains(self, substr: str | StringValue | Deferred, /) -> ir.BooleanValue:
         """Return whether the expression contains `substr`.
 
         Parameters
@@ -498,7 +501,9 @@ class StringValue(Value):
         return ops.HexDigest(self, how.lower()).to_expr()
 
     def substr(
-        self, start: int | ir.IntegerValue, length: int | ir.IntegerValue | None = None
+        self,
+        start: int | ir.IntegerValue | Deferred,
+        length: int | ir.IntegerValue | Deferred | None = None,
     ) -> StringValue:
         """Extract a substring.
 
@@ -533,7 +538,7 @@ class StringValue(Value):
         """
         return ops.Substring(self, start, length).to_expr()
 
-    def left(self, nchars: int | ir.IntegerValue, /) -> StringValue:
+    def left(self, nchars: int | ir.IntegerValue | Deferred, /) -> StringValue:
         """Return the `nchars` left-most characters.
 
         Parameters
@@ -564,7 +569,7 @@ class StringValue(Value):
         """
         return self.substr(0, length=nchars)
 
-    def right(self, nchars: int | ir.IntegerValue, /) -> StringValue:
+    def right(self, nchars: int | ir.IntegerValue | Deferred, /) -> StringValue:
         """Return up to `nchars` from the end of each string.
 
         Parameters
@@ -595,7 +600,7 @@ class StringValue(Value):
         """
         return ops.StrRight(self, nchars).to_expr()
 
-    def repeat(self, n: int | ir.IntegerValue, /) -> StringValue:
+    def repeat(self, n: int | ir.IntegerValue | Deferred, /) -> StringValue:
         """Repeat a string `n` times.
 
         Parameters
@@ -654,9 +659,9 @@ class StringValue(Value):
 
     def find(
         self,
-        sub: str | StringValue,
-        start: int | ir.IntegerValue | None = None,
-        end: int | ir.IntegerValue | None = None,
+        sub: str | StringValue | Deferred,
+        start: int | ir.IntegerValue | Deferred | None = None,
+        end: int | ir.IntegerValue | Deferred | None = None,
         /,
     ) -> ir.IntegerValue:
         """Return the position of the first occurrence of substring.
@@ -707,7 +712,10 @@ class StringValue(Value):
         return ops.StringFind(self, sub, start, end).to_expr()
 
     def lpad(
-        self, width: int | ir.IntegerValue, fillchar: str | StringValue = " ", /
+        self,
+        width: int | ir.IntegerValue | Deferred,
+        fillchar: str | StringValue = " ",
+        /,
     ) -> StringValue:
         """Pad `arg` by truncating on the right or padding on the left.
 
@@ -742,7 +750,10 @@ class StringValue(Value):
         return ops.LPad(self, width, fillchar).to_expr()
 
     def rpad(
-        self, width: int | ir.IntegerValue, fillchar: str | StringValue = " ", /
+        self,
+        width: int | ir.IntegerValue | Deferred,
+        fillchar: str | StringValue = " ",
+        /,
     ) -> StringValue:
         """Pad `self` by truncating or padding on the right.
 
@@ -803,7 +814,9 @@ class StringValue(Value):
         return ops.FindInSet(self, str_list).to_expr()
 
     def join(
-        self, strings: Sequence[str | StringValue] | ir.ArrayValue, /
+        self,
+        strings: Sequence[str | StringValue | Deferred] | ir.ArrayValue | Deferred,
+        /,
     ) -> StringValue:
         """Join a list of strings using `self` as the separator.
 
@@ -857,7 +870,7 @@ class StringValue(Value):
             cls = ops.StringJoin
         return cls(strings, sep=self).to_expr()
 
-    def startswith(self, start: str | StringValue, /) -> ir.BooleanValue:
+    def startswith(self, start: str | StringValue | Deferred, /) -> ir.BooleanValue:
         """Determine whether `self` starts with `start`.
 
         Parameters
@@ -887,7 +900,7 @@ class StringValue(Value):
         """
         return ops.StartsWith(self, start).to_expr()
 
-    def endswith(self, end: str | StringValue, /) -> ir.BooleanValue:
+    def endswith(self, end: str | StringValue | Deferred, /) -> ir.BooleanValue:
         """Determine if `self` ends with `end`.
 
         Parameters
@@ -918,7 +931,9 @@ class StringValue(Value):
         return ops.EndsWith(self, end).to_expr()
 
     def like(
-        self, patterns: str | StringValue | Iterable[str | StringValue], /
+        self,
+        patterns: str | StringValue | Deferred | Iterable[str | StringValue | Deferred],
+        /,
     ) -> ir.BooleanValue:
         """Match `patterns` against `self`, case-sensitive.
 
@@ -962,7 +977,9 @@ class StringValue(Value):
         )
 
     def ilike(
-        self, patterns: str | StringValue | Iterable[str | StringValue], /
+        self,
+        patterns: str | StringValue | Deferred | Iterable[str | StringValue | Deferred],
+        /,
     ) -> ir.BooleanValue:
         """Match `patterns` against `self`, case-insensitive.
 
@@ -1008,7 +1025,7 @@ class StringValue(Value):
     @util.backend_sensitive(
         why="Different backends support different regular expression syntax."
     )
-    def re_search(self, pattern: str | StringValue, /) -> ir.BooleanValue:
+    def re_search(self, pattern: str | StringValue | Deferred, /) -> ir.BooleanValue:
         """Return whether `self` contains the regex `pattern`.
 
         Returns `True` if the regex matches any part of a string and `False` otherwise.
@@ -1047,7 +1064,7 @@ class StringValue(Value):
         why="Different backends support different regular expression syntax."
     )
     def re_extract(
-        self, pattern: str | StringValue, index: int | ir.IntegerValue
+        self, pattern: str | StringValue | Deferred, index: int | ir.IntegerValue
     ) -> StringValue:
         """Return the specified match at `index` from a regex `pattern`.
 
@@ -1105,7 +1122,7 @@ class StringValue(Value):
     @util.backend_sensitive(
         why="Different backends support different regular expression syntax."
     )
-    def re_split(self, pattern: str | StringValue, /) -> ir.ArrayValue:
+    def re_split(self, pattern: str | StringValue | Deferred, /) -> ir.ArrayValue:
         r"""Split a string by a regular expression `pattern`.
 
         Parameters
@@ -1152,7 +1169,9 @@ class StringValue(Value):
         why="Different backends support different regular expression syntax."
     )
     def re_replace(
-        self, pattern: str | StringValue, replacement: str | StringValue
+        self,
+        pattern: str | StringValue | Deferred,
+        replacement: str | StringValue | Deferred,
     ) -> StringValue:
         r"""Replace all matches found by regex `pattern` with `replacement`.
 
@@ -1219,7 +1238,11 @@ class StringValue(Value):
         """
         return ops.RegexReplace(self, pattern, replacement).to_expr()
 
-    def replace(self, pattern: StringValue, replacement: StringValue) -> StringValue:
+    def replace(
+        self,
+        pattern: str | StringValue | Deferred,
+        replacement: str | StringValue | Deferred,
+    ) -> StringValue:
         """Replace each exact match of `pattern` with `replacement`.
 
         This method transforms strings to strings. For replacing arbitrary
@@ -1346,7 +1369,7 @@ class StringValue(Value):
         """
         return ops.StringToTime(self, format_str).to_expr()
 
-    def protocol(self):
+    def protocol(self) -> Self:
         """Parse a URL and extract protocol.
 
         Examples
@@ -1362,7 +1385,7 @@ class StringValue(Value):
         """
         return ops.ExtractProtocol(self).to_expr()
 
-    def authority(self):
+    def authority(self) -> Self:
         """Parse a URL and extract authority.
 
         Examples
@@ -1378,7 +1401,7 @@ class StringValue(Value):
         """
         return ops.ExtractAuthority(self).to_expr()
 
-    def userinfo(self):
+    def userinfo(self) -> Self:
         """Parse a URL and extract user info.
 
         Examples
@@ -1394,7 +1417,7 @@ class StringValue(Value):
         """
         return ops.ExtractUserInfo(self).to_expr()
 
-    def host(self):
+    def host(self) -> Self:
         """Parse a URL and extract host.
 
         Examples
@@ -1410,7 +1433,7 @@ class StringValue(Value):
         """
         return ops.ExtractHost(self).to_expr()
 
-    def file(self):
+    def file(self) -> Self:
         """Parse a URL and extract file.
 
         Examples
@@ -1428,7 +1451,7 @@ class StringValue(Value):
         """
         return ops.ExtractFile(self).to_expr()
 
-    def path(self):
+    def path(self) -> Self:
         """Parse a URL and extract path.
 
         Examples
@@ -1446,7 +1469,7 @@ class StringValue(Value):
         """
         return ops.ExtractPath(self).to_expr()
 
-    def query(self, key: str | StringValue | None = None, /):
+    def query(self, key: str | StringValue | Deferred | None = None, /):
         """Parse a URL and returns query string or query string parameter.
 
         If key is passed, return the value of the query string parameter named.
@@ -1473,7 +1496,7 @@ class StringValue(Value):
         """
         return ops.ExtractQuery(self, key).to_expr()
 
-    def fragment(self):
+    def fragment(self) -> Self:
         """Parse a URL and extract fragment identifier.
 
         Examples
@@ -1489,7 +1512,7 @@ class StringValue(Value):
         """
         return ops.ExtractFragment(self).to_expr()
 
-    def split(self, delimiter: str | StringValue, /) -> ir.ArrayValue:
+    def split(self, delimiter: str | StringValue | Deferred, /) -> ir.ArrayValue:
         """Split as string on `delimiter`.
 
         ::: {.callout-note}
@@ -1535,7 +1558,10 @@ class StringValue(Value):
         return ops.StringSplit(self, delimiter).to_expr()
 
     def concat(
-        self, other: str | StringValue, /, *args: str | StringValue
+        self,
+        other: str | StringValue | Deferred,
+        /,
+        *args: str | StringValue | Deferred,
     ) -> StringValue:
         """Concatenate strings.
 
@@ -1579,7 +1605,7 @@ class StringValue(Value):
         """
         return ops.StringConcat((self, other, *args)).to_expr()
 
-    def __add__(self, other: str | StringValue) -> StringValue:
+    def __add__(self, other: str | StringValue | Deferred) -> StringValue:
         """Concatenate strings.
 
         Parameters
@@ -1630,7 +1656,7 @@ class StringValue(Value):
         """
         return self.concat(other)
 
-    def __radd__(self, other: str | StringValue) -> StringValue:
+    def __radd__(self, other: str | StringValue | Deferred) -> StringValue:
         """Concatenate strings.
 
         Parameters
@@ -1695,7 +1721,7 @@ class StringValue(Value):
 
     __rmul__ = __mul__
 
-    def levenshtein(self, other: StringValue, /) -> ir.IntegerValue:
+    def levenshtein(self, other: str | StringValue | Deferred, /) -> ir.IntegerValue:
         """Return the Levenshtein distance between two strings.
 
         Parameters
@@ -1728,5 +1754,7 @@ class StringScalar(Scalar, StringValue):
 
 @public
 class StringColumn(Column, StringValue):
-    def __getitem__(self, key: slice | int | ir.IntegerScalar) -> StringColumn:
+    def __getitem__(
+        self, key: slice | int | ir.IntegerValue | Deferred
+    ) -> StringColumn:
         return StringValue.__getitem__(self, key)


### PR DESCRIPTION
This partially mitigates https://github.com/ibis-project/ibis/issues/11680, at least for some of the more common types.

In particular, it solves this ask:
https://github.com/ibis-project/ibis/issues/11680#issuecomment-3558258767

I focused on the most common use cases, eg `StringValue + "foo"` is more important than NumericColumn.kurtosis()

This fixes several sorts of problems:
- It types methods as returning the right datashape. Sometimes this was as simple as use Self, but often this required `@overload` because the method depends on the datashape of second args, or it is an eg string->int method
- It make datatypes more precise in some places, eg before it was simply returning NumericValue, but we actually know it is FloatingScalar
- It fixes the typing in some places. eg in `StringValue.__getitem__`, it actually accepts IntegerColumn as well, not just IntegerScalar, as it was typed before. Or IntegerValue.convert_base() incorrectly said it returned a IntegerValue, but it actually returns a StringValue