### PR TITLE
feat(ddl): disallow inserting by position, require source columns to be subset of target columns

### DIFF
--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -187,9 +187,6 @@ def test_insert(con):
     con.insert(name, [{"a": 1}, {"a": 2}], overwrite=True)
     assert t.count().execute() == 2
 
-    con.insert(name, [(1,), (2,)])
-    assert t.count().execute() == 4
-
     con.insert(name, {"a": [1, 2]}, overwrite=True)
     assert t.count().execute() == 2
 

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -1163,13 +1163,15 @@ $$ {defn["source"]} $$"""
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
 
-        if not isinstance(obj, ir.Table):
-            obj = ibis.memtable(obj)
+        source_table = self._ensure_table_to_insert(
+            target_columns=self.get_schema(name, catalog=catalog, database=db),
+            data=obj,
+        )
 
-        self._run_pre_execute_hooks(obj)
+        self._run_pre_execute_hooks(source_table)
 
         query = self._build_insert_from_table(
-            target=name, source=obj, db=db, catalog=catalog
+            data=source_table, table_name=name, db=db, catalog=catalog
         )
         table = sg.table(name, db=db, catalog=catalog, quoted=self.compiler.quoted)
 

--- a/ibis/backends/tests/errors.py
+++ b/ibis/backends/tests/errors.py
@@ -121,6 +121,7 @@ except ImportError:
     TrinoUserError = None
 
 try:
+    from psycopg2.errors import ActiveSqlTransaction as PsycoPg2ActiveSqlTransaction
     from psycopg2.errors import ArraySubscriptError as PsycoPg2ArraySubscriptError
     from psycopg2.errors import DivisionByZero as PsycoPg2DivisionByZero
     from psycopg2.errors import IndeterminateDatatype as PsycoPg2IndeterminateDatatype
@@ -133,11 +134,13 @@ try:
     from psycopg2.errors import SyntaxError as PsycoPg2SyntaxError
     from psycopg2.errors import UndefinedObject as PsycoPg2UndefinedObject
 except ImportError:
-    PsycoPg2SyntaxError = PsycoPg2IndeterminateDatatype = (
-        PsycoPg2InvalidTextRepresentation
-    ) = PsycoPg2DivisionByZero = PsycoPg2InternalError = PsycoPg2ProgrammingError = (
-        PsycoPg2OperationalError
-    ) = PsycoPg2UndefinedObject = PsycoPg2ArraySubscriptError = None
+    PsycoPg2ActiveSqlTransaction = PsycoPg2SyntaxError = (
+        PsycoPg2IndeterminateDatatype
+    ) = PsycoPg2InvalidTextRepresentation = PsycoPg2DivisionByZero = (
+        PsycoPg2InternalError
+    ) = PsycoPg2ProgrammingError = PsycoPg2OperationalError = (
+        PsycoPg2UndefinedObject
+    ) = PsycoPg2ArraySubscriptError = None
 
 try:
     from psycopg.errors import ArraySubscriptError as PsycoPgArraySubscriptError


### PR DESCRIPTION
After slowly picking apart the prerequisites for this PR, I think it is finally focused enough to actually tackle! Resolves https://github.com/ibis-project/ibis/issues/11731

This is breaking, but probably not for a huge fraction of users (???). Currently, on main, this works, aligning by position:

```python
con.create_table("table", {"a": "int64", "b": "int64"})
con.insert("table", [{"a bogus column name": 4, "foobar": 5}])
```

After this PR, the above errors, which I think it is good.

Currently, on main, this (inserting data with anonymous column names) works, and after this PR it will continue to work. Originally in this PR I dropped support for this, hence you can see some comments in the thread below. But after that discussion we decided to keep supporting this.

```python
con.insert("table", [(1,2), (3,4)])
```

A summary of the changes are
- refactoring memtable() to have an internal variant, _memtable(), that ALSO provides analysis of whether the given data had column names vs was unnamed. eg [(1,2), (3,4)] is unnamed. The public API doesn't change, but we use this internal version to infer the columns during `con.insert("table", [(1,2), (3,4)])`
- moved the test for the above from the duckdb backend to a more general test file so all backends get the test
- added a _ensure_table_to_insert() utility method to the base SQL backend that all subclasses can use so they can share the verification and coercion logic.