### PR TITLE
fix(exasol): update Exasol Docker image tag to 2025.1.8

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -369,7 +369,7 @@ services:
       - oracle:/opt/oracle/data
 
   exasol:
-    image: exasol/docker-db:2025.1.3
+    image: exasol/docker-db:2025.1.8
     privileged: true
     ports:
       - 8563:8563


### PR DESCRIPTION
## Description of changes

Update Exasol Docker image tag to 2025.1.8 in tests, replacing the tag 2025.1.3 that is no longer available.
Reference: https://community.exasol.com/t/docker-images-for-2025-1-versions/206

This was noticed while re-basing and testing PR #11703 

(edit: original PR targeted the latest-2025.1 tag)
