### PR TITLE
refactor: rename SortKey.expr to SortKey.arg and View.child to View.parent

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -223,7 +223,7 @@ def sort(op, **kw):
     if not op.keys:
         return lf
 
-    newcols = {gen_name("sort_key"): translate(col.expr, **kw) for col in op.keys}
+    newcols = {gen_name("sort_key"): translate(col.arg, **kw) for col in op.keys}
     lf = lf.with_columns(**newcols)
 
     by = list(newcols.keys())
@@ -794,7 +794,7 @@ def execute_first_last(op, **kw):
     arg = arg.filter(predicate)
 
     if order_by := getattr(op, "order_by", ()):
-        keys = [translate(k.expr, **kw).filter(predicate) for k in order_by]
+        keys = [translate(k.arg, **kw).filter(predicate) for k in order_by]
         descending = [k.descending for k in order_by]
         arg = arg.sort_by(keys, descending=descending)
 
@@ -1082,7 +1082,7 @@ def array_collect(op, in_group_by=False, **kw):
     arg = arg.filter(predicate)
 
     if op.order_by:
-        keys = [translate(k.expr, **kw).filter(predicate) for k in op.order_by]
+        keys = [translate(k.arg, **kw).filter(predicate) for k in op.order_by]
         descending = [k.descending for k in op.order_by]
         arg = arg.sort_by(keys, descending=descending, nulls_last=True)
 
@@ -1398,9 +1398,9 @@ def execute_sql_string_view(op, *, ctx: pl.SQLContext, **kw):
 
 @translate.register(ops.View)
 def execute_view(op, *, ctx: pl.SQLContext, **kw):
-    child = translate(op.child, ctx=ctx, **kw)
-    ctx.register(op.name, child)
-    return child
+    parent = translate(op.parent, ctx=ctx, **kw)
+    ctx.register(op.name, parent)
+    return parent
 
 
 @translate.register(ops.Reference)
@@ -1589,7 +1589,7 @@ def execute_group_concat(op, **kw):
     arg = arg.filter(predicate)
 
     if order_by := op.order_by:
-        keys = [translate(k.expr, **kw).filter(predicate) for k in order_by]
+        keys = [translate(k.arg, **kw).filter(predicate) for k in order_by]
         descending = [k.descending for k in order_by]
         arg = arg.sort_by(keys, descending=descending)
 

--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -1172,8 +1172,8 @@ class SQLGlotCompiler(abc.ABC):
 
     ### Ordering and window functions
 
-    def visit_SortKey(self, op, *, expr, ascending: bool, nulls_first: bool):
-        return sge.Ordered(this=expr, desc=not ascending, nulls_first=nulls_first)
+    def visit_SortKey(self, op, *, arg, ascending: bool, nulls_first: bool):
+        return sge.Ordered(this=arg, desc=not ascending, nulls_first=nulls_first)
 
     def visit_ApproxMedian(self, op, *, arg, where):
         return self.agg.approx_quantile(arg, 0.5, where=where)
@@ -1547,19 +1547,19 @@ class SQLGlotCompiler(abc.ABC):
     def visit_CTE(self, op, *, parent):
         return sg.table(parent.alias_or_name, quoted=self.quoted)
 
-    def visit_View(self, op, *, child, name: str):
-        if isinstance(child, sge.Table):
-            child = sg.select(STAR, copy=False).from_(child, copy=False)
+    def visit_View(self, op, *, parent, name: str):
+        if isinstance(parent, sge.Table):
+            parent = sg.select(STAR, copy=False).from_(parent, copy=False)
         else:
-            child = child.copy()
+            parent = parent.copy()
 
-        if isinstance(child, sge.Subquery):
-            return child.as_(name, quoted=self.quoted)
+        if isinstance(parent, sge.Subquery):
+            return parent.as_(name, quoted=self.quoted)
         else:
             try:
-                return child.subquery(name, copy=False)
+                return parent.subquery(name, copy=False)
             except AttributeError:
-                return child.as_(name, quoted=self.quoted)
+                return parent.as_(name, quoted=self.quoted)
 
     def visit_SQLStringView(self, op, *, query: str, child, schema):
         return sg.parse_one(query, read=self.dialect)

--- a/ibis/backends/sql/rewrites.py
+++ b/ibis/backends/sql/rewrites.py
@@ -313,9 +313,9 @@ def merge_select_select(_, **kwargs):
     unique_qualified = toolz.unique(_.parent.qualified + qualified)
 
     sort_keys = tuple(s.replace(subs, filter=ops.Value) for s in _.sort_keys)
-    sort_key_exprs = {s.expr for s in sort_keys}
+    sort_key_args = {s.arg for s in sort_keys}
     parent_sort_keys = tuple(
-        k for k in _.parent.sort_keys if k.expr not in sort_key_exprs
+        k for k in _.parent.sort_keys if k.arg not in sort_key_args
     )
     unique_sort_keys = sort_keys + parent_sort_keys
 
@@ -325,7 +325,7 @@ def merge_select_select(_, **kwargs):
         predicates=unique_predicates,
         qualified=unique_qualified,
         sort_keys=tuple(
-            key for key in unique_sort_keys if not isinstance(key.expr, ops.Literal)
+            key for key in unique_sort_keys if not isinstance(key.arg, ops.Literal)
         ),
         distinct=distinct,
     )

--- a/ibis/expr/decompile.py
+++ b/ibis/expr/decompile.py
@@ -247,9 +247,9 @@ def table_column(op, rel, name):
 
 
 @translate.register(ops.SortKey)
-def sort_key(op, expr, ascending, nulls_first):
+def sort_key(op, arg, ascending, nulls_first):
     method = "asc" if ascending else "desc"
-    call = f"{expr}.{method}"
+    call = f"{arg}.{method}"
     if nulls_first:
         return f"{call}(nulls_first={nulls_first})"
     return f"{call}()"

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -413,8 +413,8 @@ def _scalar_parameter(op, dtype, **kwargs):
 
 
 @fmt.register(ops.SortKey)
-def _sort_key(op, expr, **kwargs):
-    return f"{'asc' if op.ascending else 'desc'} {expr}"
+def _sort_key(op, arg, **kwargs):
+    return f"{'asc' if op.ascending else 'desc'} {arg}"
 
 
 @fmt.register(ops.GeoSpatialBinOp)

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -394,7 +394,7 @@ class ArrayCollect(Filterable, Reduction):
     distinct: bool = False
 
     def __init__(self, arg, order_by, distinct, **kwargs):
-        if distinct and order_by and [arg] != [key.expr for key in order_by]:
+        if distinct and order_by and [arg] != [key.arg for key in order_by]:
             raise ValidationError(
                 "`collect` with `order_by` and `distinct=True` and may only "
                 "order by the collected column"

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -438,12 +438,11 @@ class SQLQueryResult(Relation):
 class View(PhysicalTable):
     """A view created from an expression."""
 
-    # TODO(kszucs): rename it to parent
-    child: Relation
+    parent: Relation
 
     @attribute
     def schema(self):
-        return self.child.schema
+        return self.parent.schema
 
 
 @public

--- a/ibis/expr/operations/sortkeys.py
+++ b/ibis/expr/operations/sortkeys.py
@@ -16,13 +16,12 @@ from ibis.expr.operations.core import Value
 class SortKey(Value):
     """A sort key."""
 
-    # TODO(kszucs): rename expr to arg or something else except expr
-    expr: Value
+    arg: Value
     ascending: bool = True
     nulls_first: bool = False
 
-    dtype = rlz.dtype_like("expr")
-    shape = rlz.shape_like("expr")
+    dtype = rlz.dtype_like("arg")
+    shape = rlz.shape_like("arg")
 
     @classmethod
     def __coerce__(cls, key, T=None, S=None):
@@ -35,7 +34,7 @@ class SortKey(Value):
 
     @property
     def name(self) -> str:
-        return self.expr.name
+        return self.arg.name
 
     @property
     def descending(self) -> bool:

--- a/ibis/expr/rewrites.py
+++ b/ibis/expr/rewrites.py
@@ -338,7 +338,7 @@ def window_merge_frames(_, window):
 
     order_keys = {}
     for sort_key in window.orderings + _.order_by:
-        order_keys[sort_key.expr] = sort_key.ascending, sort_key.nulls_first
+        order_keys[sort_key.arg] = sort_key.ascending, sort_key.nulls_first
 
     order_by = (
         ops.SortKey(expr, ascending=ascending, nulls_first=nulls_first)

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -3934,7 +3934,7 @@ class Table(Expr, FixedTextJupyterMixin):
         │ Adelie  │ Torgersen │           36.7 │          19.3 │               193 │ … │
         └─────────┴───────────┴────────────────┴───────────────┴───────────────────┴───┘
         """
-        return ops.View(child=self, name=alias).to_expr()
+        return ops.View(parent=self, name=alias).to_expr()
 
     def sql(self, query: str, /, *, dialect: str | None = None) -> ir.Table:
         '''Run a SQL query against a table expression.
@@ -4030,7 +4030,7 @@ class Table(Expr, FixedTextJupyterMixin):
 
         if isinstance(op, ops.View):
             name = op.name
-            expr = op.child.to_expr()
+            expr = op.parent.to_expr()
         else:
             name = util.gen_name("sql_query")
             expr = self

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -495,7 +495,7 @@ def test_order_by(table):
 
     sort_key = result.keys[0]
 
-    assert_equal(sort_key.expr, table.f.op())
+    assert_equal(sort_key.arg, table.f.op())
     assert sort_key.ascending
 
     # non-list input. per #150


### PR DESCRIPTION
# refactor: rename SortKey.expr to SortKey.arg and View.child to View.parent

## Summary

Renames internal operation fields for consistency with the rest of the codebase:
- `SortKey.expr` → `SortKey.arg` (matches pattern used by `Alias`, `Cast`, `Unary`, etc.)
- `View.child` → `View.parent` (matches pattern used by `Reference` base class)

## Problem

The TODO comments at `ibis/expr/operations/sortkeys.py:19` and `ibis/expr/operations/relations.py:441` noted these field names were inconsistent with other operations in the codebase.

## Solution

Renamed the fields and updated all usages:
- 11 files modified across core operations, rewrites, compilers, and tests
- All direct field accesses updated (`.expr` → `.arg`, `.child` → `.parent`)
- All visitor method signatures updated
- All keyword argument constructions updated

## Changes

| File | Change |
|------|--------|
| `ibis/expr/operations/sortkeys.py` | `expr: Value` → `arg: Value`, removed TODO |
| `ibis/expr/operations/relations.py` | `child: Relation` → `parent: Relation`, removed TODO |
| `ibis/expr/rewrites.py` | Field access `.expr` → `.arg` |
| `ibis/expr/operations/reductions.py` | Field access `.expr` → `.arg` |
| `ibis/backends/sql/rewrites.py` | Field accesses `.expr` → `.arg` |
| `ibis/backends/sql/compilers/base.py` | Visitor signatures updated |
| `ibis/backends/polars/compiler.py` | Field accesses updated for both SortKey and View |
| `ibis/expr/decompile.py` | Visitor signature updated |
| `ibis/expr/format.py` | Visitor signature updated |
| `ibis/expr/types/relations.py` | Keyword arg and field access updated |
| `ibis/tests/expr/test_table.py` | Test assertion updated |

## How to verify it

- [x] `ruff check ibis/` - All checks passed
- [x] `pytest ibis/expr/operations/tests/test_sortkeys.py` - 1 passed
- [x] `pytest ibis/tests/expr/test_table.py -k "order_by or view"` - 26 passed
- [x] `pytest ibis/tests/expr/` - 2741 passed, 3 xfailed
- [ ] Create a sort expression and verify it compiles correctly
- [ ] Create a view expression and verify it compiles correctly

## Breaking changes

Internal API only - no impact on public API:
- `SortKey` is typically created via `.asc()` / `.desc()` methods
- `View` is typically created via `.view()` method
- Direct field access is rare in user code

Any third-party code that directly accesses `sort_key.expr` or `view.child` will need to update to `.arg` and `.parent` respectively.

## Notes for reviewers

- `SQLStringView.child` was intentionally left unchanged (noted in TODO comments as requiring maintainer discussion)
- `SQLStringView` at `relations.py:453` still uses `child` field - this can be addressed in a follow-up if desired
