### PR TITLE
feat(typing): make `@lazy_singledispatch` return generic type

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -155,7 +155,7 @@ def from_polars(value, nullable=True):
 
 
 # lock the dispatcher to prevent new types from being registered
-del dtype.register
+dtype.finalize()
 
 
 @public

--- a/ibis/expr/datatypes/value.py
+++ b/ibis/expr/datatypes/value.py
@@ -250,7 +250,7 @@ def infer_shapely_multipolygon(value) -> dt.MultiPolygon:
 
 
 # lock the dispatcher to prevent adding new implementations
-del infer.register
+infer.finalize()
 
 
 # TODO(kszucs): should raise ValueError instead of TypeError

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -55,7 +55,7 @@ class Schema(Concrete, Coercible, MapSet[str, dt.DataType]):
         return self.fields[name]
 
     @classmethod
-    def __coerce__(cls, value) -> Schema:
+    def __coerce__(cls, value, **kwargs) -> Schema:
         if isinstance(value, cls):
             return value
         return schema(value)
@@ -482,5 +482,5 @@ def infer_polars_dataframe(df):
 
 
 # lock the dispatchers to avoid adding new implementations
-del infer.register
-del schema.register
+infer.finalize()
+schema.finalize()

--- a/ibis/expr/tests/test_schema.py
+++ b/ibis/expr/tests/test_schema.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import NamedTuple
 
@@ -12,6 +13,15 @@ import ibis.expr.schema as sch
 from ibis.common.exceptions import IntegrityError
 from ibis.common.grounds import Annotable
 from ibis.common.patterns import CoercedTo
+
+
+def test_schema_factory_typing():
+    s = sch.schema({"a": "int64", "b": "string"})
+
+    def func_that_takes_schema(sch: sch.Schema):
+        return sch
+
+    func_that_takes_schema(s)
 
 
 def test_whole_schema():


### PR DESCRIPTION
This has no runtime changes. This is feature now makes this type check correctly:

```python
def test_lazy_singledispatch_typing():
    # If we declare the original function as returning type T,
    # then all registered implementations must also return type T.
    @lazy_singledispatch
    def returns_int(x) -> int:
        return x

    @returns_int.register(int)
    def _(x) -> int:
        return x + 1

    @returns_int.register(str)  # ty:ignore[invalid-argument-type]
    def _(x) -> str:
        return x + "!"

    # And all the results should be typed as int

    def func_taking_int(x: int):
        return x

    def func_taking_str(x: str):
        return x

    inty = returns_int(1)
    func_taking_int(inty)
    func_taking_str(inty)  # ty:ignore[invalid-argument-type]
```

This also has the downstream effect that now `ibis.schema()` is typed as returning a Schema. Before, it was typed  (at least by ty) as returning `Unknown`.