### PR TITLE
fix: support `Backend == "some non backend object"`

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -997,6 +997,8 @@ class BaseBackend(abc.ABC, _FileIOHandler, CacheHandler):
         return hash(self.db_identity)
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
         return self.db_identity == other.db_identity
 
     @functools.cached_property

--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -143,3 +143,8 @@ def test_unbind(alltypes, expr_fn):
 def test_get_backend(con, alltypes):
     assert alltypes.get_backend() is con
     assert alltypes.id.min().get_backend() is con
+
+
+def test_backend_equality(con):
+    assert con == con
+    assert con != "a non backend object"


### PR DESCRIPTION
Currently this errors because it tries to access `other.db_identity`. Now it allows the other object to define equlity