### PR TITLE
fix: type Value.name() as returning Self, not Value

### DIFF
--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -42,7 +42,7 @@ _SENTINEL = object()
 class Value(Expr):
     """Base class for a data generating expression having a known type."""
 
-    def name(self, name: str, /) -> Value:
+    def name(self, name: str, /) -> Self:
         """Rename an expression to `name`.
 
         Parameters


### PR DESCRIPTION
This was erasing a lot of the usefuly type info. Now it doesn't