### PR TITLE
fix(window): support scalar values in WindowFunction.group_by

### DIFF
--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -27,6 +27,12 @@ from ibis.legacy.udf.vectorized import analytic, reduction
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
 
+pytestmark = pytest.mark.notimpl(
+    ["polars"],
+    raises=com.OperationNotDefinedError,
+    reason="window functions aren't yet implemented for the polars backend",
+)
+
 
 # adapted from https://gist.github.com/xmnlab/2c1f93df1a6c6bde4e32c8579117e9cc
 def pandas_ntile(x, bucket: int):
@@ -306,7 +312,6 @@ with pytest.warns(FutureWarning, match="v9.0"):
         ),
     ],
 )
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 def test_grouped_bounded_expanding_window(
     backend, alltypes, df, result_fn, expected_fn
 ):
@@ -388,8 +393,6 @@ def test_grouped_bounded_expanding_window(
         ),
     ],
 )
-# Some backends do not support non-grouped window specs
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 def test_ungrouped_bounded_expanding_window(
     backend, alltypes, df, result_fn, expected_fn
 ):
@@ -417,7 +420,6 @@ def test_ungrouped_bounded_expanding_window(
     ],
     ids=["zero-two", "none-zero-two"],
 )
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(["druid"], raises=PyDruidProgrammingError)
 def test_grouped_bounded_following_window(backend, alltypes, df, preceding, following):
     window = ibis.window(
@@ -510,7 +512,6 @@ def test_grouped_bounded_following_window(backend, alltypes, df, preceding, foll
         ),
     ],
 )
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 def test_grouped_bounded_preceding_window(
     backend, alltypes, df, window_fn, window_size
 ):
@@ -582,7 +583,6 @@ def test_grouped_bounded_preceding_window(
         ),
     ],
 )
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 def test_grouped_unbounded_window(backend, alltypes, df, result_fn, expected_fn):
     # Define a window that is
     # 1) Grouped
@@ -611,7 +611,6 @@ def test_grouped_unbounded_window(backend, alltypes, df, result_fn, expected_fn)
 )
 @pytest.mark.notimpl(["snowflake"], raises=AssertionError)
 @pytest.mark.notyet(["mssql"], raises=PyODBCProgrammingError)
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(
     ["risingwave"],
     raises=PsycoPg2InternalError,
@@ -640,7 +639,6 @@ def test_simple_ungrouped_unbound_following_window(
 @pytest.mark.never(
     ["mssql"], raises=Exception, reason="order by constant is not supported"
 )
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(
     ["risingwave"],
     raises=PsycoPg2InternalError,
@@ -919,8 +917,6 @@ def test_simple_ungrouped_window_with_scalar_order_by(alltypes):
         ),
     ],
 )
-# Some backends do not support non-grouped window specs
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 def test_ungrouped_unbounded_window(
     backend, alltypes, df, result_fn, expected_fn, ordered
 ):
@@ -946,7 +942,6 @@ def test_ungrouped_unbounded_window(
     backend.assert_series_equal(left, right)
 
 
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(
     ["impala"], raises=ImpalaHiveServer2Error, reason="limited RANGE support"
 )
@@ -1005,7 +1000,7 @@ def test_grouped_bounded_range_window(backend, alltypes, df):
     backend.assert_series_equal(result.val, expected.val)
 
 
-@pytest.mark.notimpl(["clickhouse", "polars"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["clickhouse"], raises=com.OperationNotDefinedError)
 @pytest.mark.notyet(
     ["clickhouse"],
     reason="clickhouse doesn't implement percent_rank",
@@ -1027,7 +1022,6 @@ def test_percent_rank_whole_table_no_order_by(backend, alltypes, df):
     backend.assert_series_equal(result.val, expected.val)
 
 
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(["druid"], raises=PyDruidProgrammingError)
 def test_grouped_ordered_window_coalesce(backend, alltypes, df):
     t = alltypes
@@ -1062,7 +1056,6 @@ def test_grouped_ordered_window_coalesce(backend, alltypes, df):
     backend.assert_series_equal(result, expected)
 
 
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(
     ["risingwave"],
     raises=PsycoPg2InternalError,
@@ -1083,7 +1076,6 @@ def test_mutate_window_filter(backend, alltypes):
     backend.assert_frame_equal(res, sol, check_dtype=False)
 
 
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(["druid", "athena"], raises=com.TableNotFound)
 def test_first_last(backend):
     t = backend.win
@@ -1125,7 +1117,7 @@ def test_first_last(backend):
     ["mysql"], raises=MySQLOperationalError, reason="not supported by MySQL"
 )
 @pytest.mark.notyet(
-    ["polars", "sqlite"],
+    ["sqlite"],
     raises=com.OperationNotDefinedError,
     reason="not support by the backend",
 )
@@ -1174,7 +1166,6 @@ def test_range_expression_bounds(backend):
     assert len(result) == con.execute(t.count())
 
 
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.notyet(
     ["clickhouse"],
     reason="clickhouse doesn't implement percent_rank",
@@ -1214,7 +1205,6 @@ def test_rank_followed_by_over_call_merge_frames(backend, alltypes, df):
     reason="IS NULL not valid syntax for mssql",
     raises=PyODBCProgrammingError,
 )
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(
     ["risingwave"],
     raises=PsycoPg2InternalError,
@@ -1239,11 +1229,6 @@ def test_windowed_order_by_sequence_is_preserved(con):
     assert pd.isna(value)
 
 
-@pytest.mark.notimpl(
-    ["polars"],
-    raises=com.OperationNotDefinedError,
-    reason="window functions aren't yet implemented for the polars backend",
-)
 @pytest.mark.notimpl(
     ["flink"],
     raises=AssertionError,
@@ -1286,3 +1271,15 @@ def test_duplicate_ordered_sum(con):
     # final position, since the *output* order doesn't depend on ORDER BY
     # provided by the user
     assert result[2:] in ([60, 100], [70, 100], [100, 60], [100, 70])
+
+
+def test_over_with_scalar_group_by(backend, alltypes):
+    """You can pass a scalar value to the group_by of a WindowFunction, and that works fine.
+    All values have the same grouping key, so it is basically a noop, but it works.
+    """
+    with_over = alltypes.select(
+        # This shouldn't get confused with the column named "string_col"
+        x=alltypes.tinyint_col.sum().over(group_by=ibis.literal("string_col"))
+    )
+    without_over = alltypes.select(x=alltypes.tinyint_col.sum())
+    backend.assert_series_equal(with_over.x.to_pandas(), without_over.x.to_pandas())

--- a/ibis/expr/operations/window.py
+++ b/ibis/expr/operations/window.py
@@ -15,7 +15,7 @@ import ibis.expr.rules as rlz
 from ibis.common.patterns import CoercionError
 from ibis.common.typing import VarTuple  # noqa: TC001
 from ibis.expr.operations.analytic import Analytic  # noqa: TC001
-from ibis.expr.operations.core import Column, Value
+from ibis.expr.operations.core import Value
 from ibis.expr.operations.generic import Literal
 from ibis.expr.operations.numeric import Negate
 from ibis.expr.operations.reductions import Reduction  # noqa: TC001
@@ -71,7 +71,7 @@ class WindowFunction(Value):
     how: LiteralType["rows", "range"] = "rows"
     start: Optional[WindowBoundary[dt.Numeric | dt.Interval]] = None
     end: Optional[WindowBoundary[dt.Numeric | dt.Interval]] = None
-    group_by: VarTuple[Column] = ()
+    group_by: VarTuple[Value] = ()
     order_by: VarTuple[SortKey] = ()
 
     dtype = rlz.dtype_like("func")


### PR DESCRIPTION
## Description of changes

This fails at expression construction time, because ops.WindowFunction is overly restrictive. It requires that group_by be a VarTuple[Column], when really VarTuple[Value] is fine:

```python
t = ibis.memtable({"gb": [1, 1, 2, 2], "val": [5, 6, 7, 8]})
t.val.sum().over(group_by=("gb", ibis.literal("foo")))
```

Of course, this is a little silly, since including a scalar in a groupby is effectively a noop, but still, it should compile.

Another followup here is to actually optimize this out during compilation time, and not even emit groupby keys that are scalars.