### PR TITLE
chore: don't enforce capitalization rules in commit messages

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -5,11 +5,6 @@
     "footer-leading-blank": [1, "always"],
     "footer-max-line-length": [2, "always", 1000],
     "header-max-length": [2, "always", 120],
-    "subject-case": [
-      2,
-      "never",
-      ["sentence-case", "start-case", "pascal-case", "upper-case"]
-    ],
     "subject-empty": [2, "never"],
     "subject-full-stop": [2, "never", "."],
     "type-case": [2, "always", "lower-case"],


### PR DESCRIPTION
I keep on getting forced to go back to my local environment and `git rebase -i` to fix my commit messages from `feat(typing): Improve signatures of commont Values` to `feat(typing): improve signatures of commont Values`.

This is annoying. I don't see the the benefit of enforcing this. If we do enforce it, then I think we need a way of autofixing it more easily.