### PR TITLE
feat(api): support Table.cast(my_col=int)

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -926,7 +926,7 @@ class Table(Expr, FixedTextJupyterMixin):
         if schema is None:
             schema = {}
         schema = sch.schema(schema)
-        schema = sch.schema({**dict(schema.items()), **overrides})
+        schema = sch.schema({**schema, **overrides})
 
         cols = []
 


### PR DESCRIPTION
This is just a nice to have. I also made the docstring simpler, and describe behavior better.

The docstring is the test. Technically try_cast() isn't tested directly, but since it just calls the internal _cast() method directly, the same as cast(), I thought that was adequate.