### PR TITLE
chore: remove misleading todo about removing Filterable

### DIFF
--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -23,7 +23,8 @@ class Reduction(Value):
     shape = ds.scalar
 
 
-# TODO(kszucs): all reductions all filterable so we could remove Filterable
+# All Reductions here are Filterable, but ReductionVectorizedUDF is only a Reduction,
+# and not Filterable, so we need to keep them separate for now.
 class Filterable(Value):
     where: Optional[Value[dt.Boolean]] = None
 


### PR DESCRIPTION
I tried to remove Filterable, and it's not that simple.

Alternatively, we could remove all of the legacy UDF stuff in https://github.com/ibis-project/ibis/tree/main/ibis/legacy/udf. It has been deprecated since version 9.0, in March 2024, nearly 2 years ago. If we did that, then it would allow us to remove [ops.ReductionVectorizedUDF](https://github.com/ibis-project/ibis/blob/a83cfef0f6b84f3dbb83ca55682100f32488d7c2/ibis/expr/operations/vectorized.py#L36), which is the only op that inherits from Reduction but NOT Filterable.