### PR TITLE
fix: correctly handle empty scheme in trino backend connect

### DIFF
--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -298,7 +298,7 @@ class Backend(
         """
         if (
             isinstance(auth, str)
-            and (scheme := urlparse(host).scheme)
+            and (scheme := urlparse(host).scheme) is not None
             and scheme != "http"
         ):
             auth = BasicAuthentication(user, auth)


### PR DESCRIPTION
## Summary
Fixes #11841 

The walrus operator in the auth string check was evaluating to False when `urlparse(host).scheme` returned an empty string, preventing `BasicAuthentication` from being set up correctly when using `http_scheme` parameter with hosts that don't have a scheme prefix.

## Changes
- Changed condition from `and (scheme := urlparse(host).scheme)` to `and (scheme := urlparse(host).scheme) is not None`
- This correctly handles empty string schemes (when host is provided without protocol prefix like "example.com")

## Test Plan
- [x] Manually verified the logic handles empty string scheme correctly
- [x] Verified existing trino tests still pass
- [x] Confirmed the fix allows BasicAuthentication to be set up when host doesn't have scheme prefix