### PR TITLE
test: add test for contains selector with how=all parameter

### DIFF
--- a/ibis/tests/expr/test_selectors.py
+++ b/ibis/tests/expr/test_selectors.py
@@ -111,6 +111,14 @@ def test_contains(t):
     assert t.select(s.contains("a")).equals(t.select("a", "ga"))
 
 
+def test_contains_how_all(t):
+    # Test that how=all requires all needles to be in the column name
+    assert t.select(s.contains(("g", "a"), how=all)).equals(t.select("ga"))
+    # Column "a" contains "a" but not "g", so it should not be selected
+    # Column "g" contains "g" but not "a", so it should not be selected
+    # Column "ga" contains both "g" and "a", so it should be selected
+
+
 @pytest.mark.parametrize(
     ("rx", "expected"),
     [("e|f", ("e", "f")), (re.compile("e|f"), ("e", "f"))],


### PR DESCRIPTION
## Summary
Relates to #11803

This PR adds a test case to verify that the `contains` selector correctly respects the `how=all` parameter.

## Changes
- Added `test_contains_how_all` test function
- Tests that with `how=all`, only columns containing ALL specified needles are selected
- Verifies that column "ga" is selected when searching for ("g", "a") with `how=all`
- Verifies that columns "a" and "g" are NOT selected as they don't contain both needles

## Background
Issue #11803 reported that `contains` with `how=all` was not working as expected. After analyzing the code, the implementation appears correct. This test validates the expected behavior.

If the test passes, it confirms the selector is working correctly and the issue may be due to user error or a different edge case. If it fails, the test will help identify the specific problem.

## Test Plan
- [x] Added test case for `how=all` parameter
- [x] Test validates correct behavior per documentation examples
- [x] Waiting for CI to confirm test passes