### PR TITLE
fix-strip-f-whitespace

### DIFF
--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -1006,14 +1006,17 @@ class SQLGlotCompiler(abc.ABC):
         return self._make_interval(arg, unit)
 
     ### String Instruments
+    def _trim_whitespace(self) -> sge.Expression:
+        return sge.Literal.string(string.whitespace)
+
     def visit_Strip(self, op, *, arg):
-        return self.f.trim(arg, string.whitespace)
+        return self.f.trim(arg, self._trim_whitespace())
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.rtrim(arg, string.whitespace)
+        return self.f.rtrim(arg, self._trim_whitespace())
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.ltrim(arg, string.whitespace)
+        return self.f.ltrim(arg, self._trim_whitespace())
 
     def visit_LPad(self, op, *, arg, length, pad):
         return self.f.lpad(arg, self.f.greatest(self.f.length(arg), length), pad)

--- a/ibis/backends/sql/compilers/databricks.py
+++ b/ibis/backends/sql/compilers/databricks.py
@@ -30,6 +30,8 @@ class DatabricksCompiler(PySparkCompiler):
         SIMPLE_OPS[ops.UnwrapJSONFloat64],
         SIMPLE_OPS[ops.UnwrapJSONBoolean],
     )
+    SIMPLE_OPS.pop(ops.LStrip, None)
+    SIMPLE_OPS.pop(ops.RStrip, None)
 
     UNSUPPORTED_OPS = (
         ops.ElementWiseVectorizedUDF,

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -85,8 +85,6 @@ class PySparkCompiler(SQLGlotCompiler):
         ops.EndsWith: "endswith",
         ops.Hash: "hash",
         ops.Log10: "log10",
-        ops.LStrip: "ltrim",
-        ops.RStrip: "rtrim",
         ops.MapLength: "size",
         ops.MapContains: "map_contains_key",
         ops.MapMerge: "map_concat",
@@ -97,6 +95,14 @@ class PySparkCompiler(SQLGlotCompiler):
         ops.UnwrapJSONFloat64: "unwrap_json_float",
         ops.UnwrapJSONBoolean: "unwrap_json_bool",
     }
+
+    _TRIM_WHITESPACE_CODEPOINTS = (32, 9, 10, 13, 11, 12)
+
+    def _trim_whitespace(self) -> sge.Expression:
+        # Build trim characters via CHR() to avoid backslash escapes being
+        # interpreted as literals when escapedStringLiterals is disabled.
+        chars = [self.f.chr(code) for code in self._TRIM_WHITESPACE_CODEPOINTS]
+        return self.f.concat(*chars)
 
     def visit_InSubquery(self, op, *, rel, needle):
         if op.needle.dtype.is_struct():


### PR DESCRIPTION
## Description of changes

Fix PySpark/Databricks `strip()` behavior so whitespace trimming no longer removes
literal `f` characters. The compiler now builds the trim character set using
`CHR()` codepoints (space, tab, newline, carriage return, vertical tab, form feed),
and `LStrip/RStrip` use the same safe path. Added a PySpark regression test.

## Issues closed

* Resolves #11894