### PR TITLE
fix(sql): avoid oracle nan literal import crash with sqlglot

### DIFF
--- a/ibis/backends/sql/compilers/__init__.py
+++ b/ibis/backends/sql/compilers/__init__.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import importlib
+from typing import Any
+
 __all__ = [
     "AthenaCompiler",
     "BigQueryCompiler",
@@ -23,23 +26,38 @@ __all__ = [
     "TrinoCompiler",
 ]
 
-from ibis.backends.sql.compilers.athena import AthenaCompiler
-from ibis.backends.sql.compilers.bigquery import BigQueryCompiler
-from ibis.backends.sql.compilers.clickhouse import ClickHouseCompiler
-from ibis.backends.sql.compilers.databricks import DatabricksCompiler
-from ibis.backends.sql.compilers.datafusion import DataFusionCompiler
-from ibis.backends.sql.compilers.druid import DruidCompiler
-from ibis.backends.sql.compilers.duckdb import DuckDBCompiler
-from ibis.backends.sql.compilers.exasol import ExasolCompiler
-from ibis.backends.sql.compilers.flink import FlinkCompiler
-from ibis.backends.sql.compilers.impala import ImpalaCompiler
-from ibis.backends.sql.compilers.materialize import MaterializeCompiler
-from ibis.backends.sql.compilers.mssql import MSSQLCompiler
-from ibis.backends.sql.compilers.mysql import MySQLCompiler
-from ibis.backends.sql.compilers.oracle import OracleCompiler
-from ibis.backends.sql.compilers.postgres import PostgresCompiler
-from ibis.backends.sql.compilers.pyspark import PySparkCompiler
-from ibis.backends.sql.compilers.risingwave import RisingWaveCompiler
-from ibis.backends.sql.compilers.snowflake import SnowflakeCompiler
-from ibis.backends.sql.compilers.sqlite import SQLiteCompiler
-from ibis.backends.sql.compilers.trino import TrinoCompiler
+_COMPILER_MODULES = {
+    "AthenaCompiler": "ibis.backends.sql.compilers.athena",
+    "BigQueryCompiler": "ibis.backends.sql.compilers.bigquery",
+    "ClickHouseCompiler": "ibis.backends.sql.compilers.clickhouse",
+    "DataFusionCompiler": "ibis.backends.sql.compilers.datafusion",
+    "DatabricksCompiler": "ibis.backends.sql.compilers.databricks",
+    "DruidCompiler": "ibis.backends.sql.compilers.druid",
+    "DuckDBCompiler": "ibis.backends.sql.compilers.duckdb",
+    "ExasolCompiler": "ibis.backends.sql.compilers.exasol",
+    "FlinkCompiler": "ibis.backends.sql.compilers.flink",
+    "ImpalaCompiler": "ibis.backends.sql.compilers.impala",
+    "MaterializeCompiler": "ibis.backends.sql.compilers.materialize",
+    "MSSQLCompiler": "ibis.backends.sql.compilers.mssql",
+    "MySQLCompiler": "ibis.backends.sql.compilers.mysql",
+    "OracleCompiler": "ibis.backends.sql.compilers.oracle",
+    "PostgresCompiler": "ibis.backends.sql.compilers.postgres",
+    "PySparkCompiler": "ibis.backends.sql.compilers.pyspark",
+    "RisingWaveCompiler": "ibis.backends.sql.compilers.risingwave",
+    "SQLiteCompiler": "ibis.backends.sql.compilers.sqlite",
+    "SnowflakeCompiler": "ibis.backends.sql.compilers.snowflake",
+    "TrinoCompiler": "ibis.backends.sql.compilers.trino",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if (module_name := _COMPILER_MODULES.get(name)) is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = importlib.import_module(module_name)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_COMPILER_MODULES))

--- a/ibis/backends/sql/compilers/_compat.py
+++ b/ibis/backends/sql/compilers/_compat.py
@@ -16,3 +16,21 @@ def _get_arg_name(expr_cls: type[sge.Expression], *args: str) -> str:
 # to keep the code backward compatible, we take the first valid arg name
 WITH_ARG = _get_arg_name(sge.Select, "with", "with_")
 EXCEPT_ARG = _get_arg_name(sge.Star, "except", "except_")
+
+
+def _supports_special_float_literals() -> bool:
+    try:
+        sge.Literal.number("binary_double_nan")
+    except Exception:
+        return False
+    else:
+        return True
+
+
+_SPECIAL_FLOATS_AS_IDENTIFIER = not _supports_special_float_literals()
+
+
+def special_float_literal(name: str) -> sge.Expression:
+    if _SPECIAL_FLOATS_AS_IDENTIFIER:
+        return sge.to_identifier(name)
+    return sge.Literal.number(name)

--- a/ibis/backends/sql/compilers/oracle.py
+++ b/ibis/backends/sql/compilers/oracle.py
@@ -9,6 +9,7 @@ import ibis.expr.operations as ops
 from ibis.backends.sql.compilers.base import NULL, STAR, AggGen, SQLGlotCompiler
 from ibis.backends.sql.datatypes import OracleType
 from ibis.backends.sql.dialects import Oracle
+from ibis.backends.sql.compilers._compat import special_float_literal
 from ibis.backends.sql.rewrites import (
     FirstValue,
     LastValue,
@@ -38,10 +39,10 @@ class OracleCompiler(SQLGlotCompiler):
 
     post_rewrites = (split_select_distinct_with_order_by,)
 
-    NAN = sge.to_identifier("binary_double_nan")
+    NAN = special_float_literal("binary_double_nan")
     """Backend's NaN literal."""
 
-    POS_INF = sge.to_identifier("binary_double_infinity")
+    POS_INF = special_float_literal("binary_double_infinity")
     """Backend's positive infinity literal."""
 
     NEG_INF = -POS_INF


### PR DESCRIPTION
## Description of changes

Guard Oracle NaN/Inf literal construction against newer sqlglot behavior by using
a compat helper that falls back to identifiers when special numeric literals
aren’t supported. Also switched SQL compiler imports to lazy loading to avoid
eager Oracle import during unrelated backend initialization. Added a regression
test to ensure compilers package can be imported without pulling Oracle.

## Issues closed

* Resolves #11890