### PR TITLE
fix(deferred): rebind context for chained mutate resolve

### DIFF
--- a/ibis/common/tests/test_deferred.py
+++ b/ibis/common/tests/test_deferred.py
@@ -411,6 +411,16 @@ def test_deferred_method_with_kwargs(table):
     assert repr(expr) == "_.a.log(base=_.b)"
 
 
+def test_deferred_chained_mutate_resolve():
+    input_table = ibis.memtable({"a": [1, 2, 3], "b": [4, 5, 6]})
+    expr = _.mutate(c=_.a + _.b).mutate(d=_.c * 2)
+    result = expr.resolve(input_table)
+
+    expected = input_table.mutate(c=input_table.a + input_table.b)
+    expected = expected.mutate(d=expected.c * 2)
+    assert result.equals(expected)
+
+
 def test_deferred_apply(table):
     expr = Deferred(Call(operator.add, _.a, 2))
     res = expr.resolve(table)

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -11,7 +11,7 @@ import ibis.expr.builders as bl
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.common.annotations import ValidationError
-from ibis.common.deferred import Deferred, _, deferrable
+from ibis.common.deferred import Deferred, Resolver, _, deferrable, resolve_deferred
 from ibis.common.grounds import Singleton
 from ibis.expr.rewrites import rewrite_window_input
 from ibis.expr.types.core import Expr
@@ -1806,8 +1806,8 @@ class Column(Value, FixedTextJupyterMixin):
 
             if isinstance(value, str):
                 return table[value]
-            elif isinstance(value, Deferred):
-                return value.resolve(table)
+            elif isinstance(value, (Deferred, Resolver)):
+                return resolve_deferred(value, {"_": table})
             else:
                 value = value(table)
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -18,7 +18,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 from ibis import util
-from ibis.common.deferred import Deferred, Resolver
+from ibis.common.deferred import Deferred, Resolver, resolve_deferred
 from ibis.common.selectors import Expandable, Selector
 from ibis.expr.rewrites import DerefMap
 from ibis.expr.types.core import Expr
@@ -479,10 +479,8 @@ def bind(table: Table, value) -> Iterator[ir.Value]:
     elif isinstance(value, Table):
         for name in value.columns:
             yield ops.Field(value, name).to_expr()
-    elif isinstance(value, Deferred):
-        yield value.resolve(table)
-    elif isinstance(value, Resolver):
-        yield value.resolve({"_": table})
+    elif isinstance(value, (Deferred, Resolver)):
+        yield resolve_deferred(value, {"_": table})
     elif isinstance(value, Expandable):
         yield from value.expand(table)
     elif callable(value):


### PR DESCRIPTION
## Description of changes

Fix deferred chained `mutate()` resolution so each step rebinds `_` to the
intermediate table, matching normal table chaining semantics. Added shared
deferred resolution helpers for binding contexts and a regression test for the
chained mutate case.

## Issues closed

* Resolves #11815