### PR TITLE
fix(deferred): allow date + deferred interval type inference

### DIFF
--- a/ibis/common/deferred.py
+++ b/ibis/common/deferred.py
@@ -563,14 +563,19 @@ def const(value):
     return Deferred(Just(value))
 
 
-def _contains_deferred(obj: Any) -> bool:
+def contains_deferred(obj: Any) -> bool:
+    """Return whether an object contains deferred values."""
     if isinstance(obj, (Resolver, Deferred)):
         return True
     elif (typ := type(obj)) in (tuple, list, set):
-        return any(_contains_deferred(o) for o in obj)
+        return any(contains_deferred(o) for o in obj)
     elif typ is dict:
-        return any(_contains_deferred(o) for o in obj.values())
+        return any(contains_deferred(o) for o in obj.values())
     return False
+
+
+def _contains_deferred(obj: Any) -> bool:
+    return contains_deferred(obj)
 
 
 F = TypeVar("F", bound=Callable)
@@ -611,7 +616,7 @@ def deferrable(func=None, *, repr=None):
 
         @functools.wraps(func)
         def inner(*args, **kwargs):
-            if _contains_deferred((args, kwargs)):
+            if contains_deferred((args, kwargs)):
                 # Try to bind the arguments now, raising a nice error
                 # immediately if the function was called incorrectly
                 sig.bind(*args, **kwargs)

--- a/ibis/expr/operations/temporal.py
+++ b/ibis/expr/operations/temporal.py
@@ -368,15 +368,21 @@ class TimestampDiff(Binary):
     dtype = dt.Interval("s")
 
 
+def _interval_units(args: tuple[Value, Value]) -> list[IntervalUnit]:
+    units: list[IntervalUnit] = []
+    for arg in args:
+        if arg.dtype.is_interval():
+            units.append(arg.dtype.unit)
+    return units
+
+
 @public
 class IntervalBinary(Binary):
     """Base class for interval binary operations."""
 
     @attribute
     def dtype(self):
-        interval_unit_args = [
-            arg.dtype.unit for arg in (self.left, self.right) if arg.dtype.is_interval()
-        ]
+        interval_unit_args = _interval_units((self.left, self.right))
         unit = rlz._promote_interval_resolution(interval_unit_args)
 
         return self.left.dtype.copy(unit=unit)

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -9,6 +9,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis import util
 from ibis.common.annotations import Attribute, attribute
+from ibis.common.deferred import Deferred, Resolver
 from ibis.common.grounds import Concrete
 from ibis.common.patterns import CoercionError, NoMatch, Pattern
 from ibis.common.temporal import IntervalUnit
@@ -136,11 +137,16 @@ def _promote_interval_resolution(units: list[IntervalUnit]) -> IntervalUnit:
     raise AssertionError("unreachable")
 
 
+def _is_deferred_value(value: object) -> bool:
+    return isinstance(value, (Deferred, Resolver))
+
+
 def arg_type_error_format(op: ops.Value) -> str:
+    if _is_deferred_value(op):
+        return repr(op)
     if isinstance(op, ops.Literal):
         return f"Literal({op.value}):{op.dtype}"
-    else:
-        return f"{op.name}:{op.dtype}"
+    return f"{op.name}:{op.dtype}"
 
 
 class ValueOf(Concrete, Pattern):

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -3140,6 +3140,7 @@ def _is_null_literal(value: Any) -> bool:
     )
 
 
+@deferrable
 def _binop(op_class: type[ops.Value], left: Value | Any, right: Value | Any) -> Value:
     """Try to construct a binary operation between two Values.
 

--- a/ibis/tests/expr/test_temporal.py
+++ b/ibis/tests/expr/test_temporal.py
@@ -840,6 +840,15 @@ def test_date_expression():
     assert repr(deferred) == "date(_.s)"
 
 
+def test_date_add_with_deferred_interval():
+    t = ibis.memtable({"days": [0, 10, 100, 365]})
+    deferred_expr = ibis.date(1970, 1, 1) + _.days.as_interval("D")
+    resolved = deferred_expr.resolve(t)
+
+    expected = ibis.date(1970, 1, 1) + t.days.as_interval("D")
+    assert resolved.equals(expected)
+
+
 def test_time_literal():
     expr = ibis.time(1, 2, 3)
     sol = ops.TimeFromHMS(1, 2, 3).to_expr()


### PR DESCRIPTION
## Description of changes

Make binary ops deferrable so date + deferred interval expressions resolve after
binding to a table, avoiding premature type inference errors. Added small helpers
for deferred detection and interval unit extraction, plus a regression test for
deferred interval addition.

## Issues closed

* Resolves #11797