### PR TITLE
feat(snowflake): implement hexdigest using SHA2/MD5

### DIFF
--- a/ibis/backends/sql/compilers/snowflake.py
+++ b/ibis/backends/sql/compilers/snowflake.py
@@ -333,6 +333,16 @@ $$""",
     def visit_RegexSplit(self, op, *, arg, pattern):
         return self.f.udf.regexp_split(arg, pattern)
 
+    def visit_HexDigest(self, op, *, arg, how):
+        if how == "md5":
+            return self.f.md5(arg)
+        elif how == "sha256":
+            return self.f.sha2(arg, 256)
+        elif how == "sha512":
+            return self.f.sha2(arg, 512)
+        else:
+            raise NotImplementedError(f"No available hashing function for {how}")
+
     def visit_Map(self, op, *, keys, values):
         return self.if_(
             sg.and_(self.f.is_array(keys), self.f.is_array(values)),

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1823,7 +1823,6 @@ def test_hashbytes(backend, alltypes):
         "polars",
         "postgres",
         "risingwave",
-        "snowflake",
         "trino",
         "athena",
     ]


### PR DESCRIPTION
## Summary

Snowflake natively supports `SHA2(msg, digest_size)` and `MD5(msg)` but the Snowflake compiler was missing a `visit_HexDigest` method, causing `OperationNotDefinedError` when calling `.hexdigest()` on string columns.

This adds the compilation rule:
- `hexdigest("md5")` → `MD5(arg)`
- `hexdigest("sha256")` → `SHA2(arg, 256)`
- `hexdigest("sha512")` → `SHA2(arg, 512)`

## Changes

- **`ibis/backends/sql/compilers/snowflake.py`**: Added `visit_HexDigest` method to `SnowflakeCompiler`
- **`ibis/backends/tests/test_generic.py`**: Removed `"snowflake"` from the `notimpl` marker on `test_hexdigest`

## Test plan

- [ ] Existing `test_hexdigest` should now pass on the Snowflake backend (previously marked `notimpl`)
- [ ] No changes to other backends

Made with [Cursor](https://cursor.com)