### PR TITLE
docs(homepage): update altair url

### DIFF
--- a/docs/why.qmd
+++ b/docs/why.qmd
@@ -331,7 +331,7 @@ Ibis already works well with visualization libraries like:
 - [matplotlib](https://github.com/matplotlib/matplotlib)
 - [seaborn](https://github.com/mwaskom/seaborn)
 - [Plotly](https://github.com/plotly/plotly.py)
-- [Vega-Altair](https://github.com/altair-viz/altair)
+- [Vega-Altair](https://github.com/vega/altair)
 - [plotnine](https://github.com/has2k1/plotnine)
 
 Ibis already works well with dashboarding libraries like:


### PR DESCRIPTION
## Description of changes

The old link to altair is out-of-date, the altair-viz org moved into Vega [directly](https://github.com/vega/altair)
