### PR TITLE
fix(bigquery): approx_median with where clause duplicates where clause onto quantile argument.

### DIFF
--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_approx_median_where_string_filter/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_approx_median_where_string_filter/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  APPROX_QUANTILES(IF(`t0`.`string_col` > 'a', `t0`.`float_col`, NULL), 2 IGNORE NULLS)[1] AS `ApproxMedian_float_col_Greater_string_col_'a'`
+FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -558,6 +558,12 @@ def test_approx(alltypes, agg, where, snapshot):
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
+def test_approx_median_where_string_filter(alltypes, snapshot):
+    t = alltypes
+    expr = t.float_col.approx_median(where=t.string_col > "a")
+    snapshot.assert_match(to_sql(expr), "out.sql")
+
+
 @pytest.mark.parametrize("funcname", ["bit_and", "bit_or", "bit_xor"])
 @pytest.mark.parametrize(
     "where",

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1183,6 +1183,7 @@ def test_corr_cov(
     )
 
 
+@pytest.mark.parametrize("filtered", [False, True])
 @pytest.mark.notimpl(
     ["mysql", "singlestoredb", "sqlite", "mssql", "druid"],
     raises=com.OperationNotDefinedError,
@@ -1194,8 +1195,9 @@ def test_corr_cov(
     # Ref: https://materialize.com/docs/transform-data/patterns/percentiles/
     raises=com.OperationNotDefinedError,
 )
-def test_approx_median(alltypes):
-    expr = alltypes.double_col.approx_median()
+def test_approx_median(alltypes, filtered):
+    where = alltypes.int_col <= 100 if filtered else None
+    expr = alltypes.double_col.approx_median(where=where)
     result = expr.execute()
     assert isinstance(result, float)
 


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Prevent duplication of where clause for bigquery onto quantile argument. 
Adds system test to test for similar behaviours in other backends.

## Issues closed

Resolves #11951 