### PR TITLE
feat: add IntoMemtable TypeAlias

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -53,6 +53,8 @@ if TYPE_CHECKING:
     from google.cloud.bigquery.table import RowIterator
     from google.cloud.bigquery.table import TableListItem as BqTableListItem
 
+    from ibis.expr.api import IntoMemtable
+
 
 SCOPES = ["https://www.googleapis.com/auth/bigquery"]
 EXTERNAL_DATA_SCOPES = [
@@ -856,7 +858,7 @@ class Backend(
         self,
         name: str,
         /,
-        obj: pd.DataFrame | ir.Table | list | dict,
+        obj: ir.Table | IntoMemtable,
         *,
         database: str | None = None,
         overwrite: bool = False,
@@ -899,7 +901,7 @@ class Backend(
         self,
         name: str,
         /,
-        obj: pd.DataFrame | ir.Table | list | dict,
+        obj: ir.Table | IntoMemtable,
         on: str,
         *,
         database: str | None = None,

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -44,6 +44,8 @@ if TYPE_CHECKING:
     import pandas as pd
     import polars as pl
 
+    from ibis.expr.api import IntoMemtable
+
 
 def _to_memtable(v):
     return ibis.memtable(v).op() if not isinstance(v, ops.InMemoryTable) else v
@@ -409,7 +411,7 @@ class Backend(SupportsTempTables, SQLBackend, CanCreateDatabase, DirectExampleLo
         self,
         name: str,
         /,
-        obj: pd.DataFrame | ir.Table,
+        obj: IntoMemtable | ir.Table,
         *,
         settings: Mapping[str, Any] | None = None,
         overwrite: bool = False,

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from pyflink.table import Table, TableEnvironment
     from pyflink.table.table_result import TableResult
 
-    from ibis.expr.api import Watermark
+    from ibis.expr.api import IntoMemtable, Watermark
 
 _INPUT_TYPE_TO_FUNC_TYPE = {InputType.PYTHON: "general", InputType.PANDAS: "pandas"}
 
@@ -903,7 +903,7 @@ class Backend(
         self,
         name: str,
         /,
-        obj: pa.Table | pd.DataFrame | ir.Table | list | dict,
+        obj: ir.Table | IntoMemtable,
         *,
         database: str | None = None,
         catalog: str | None = None,

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
     import ibis.expr.operations as ops
+    from ibis.expr.api import IntoMemtable
 
 
 __all__ = (
@@ -710,7 +711,7 @@ class Backend(SQLBackend, HasCurrentDatabase, NoExampleLoader):
         self,
         name: str,
         /,
-        obj: ir.Table | Any,
+        obj: ir.Table | IntoMemtable,
         *,
         database: str | tuple[str, str] | None = None,
         overwrite: bool = False,

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -47,6 +47,8 @@ if TYPE_CHECKING:
     import snowflake.connector
     import snowflake.snowpark
 
+    from ibis.expr.api import IntoMemtable
+
 
 @contextlib.contextmanager
 def download_file(url: str) -> Generator[str]:
@@ -1128,7 +1130,7 @@ $$ {defn["source"]} $$"""
         self,
         name: str,
         /,
-        obj: pd.DataFrame | ir.Table | list | dict,
+        obj: IntoMemtable | ir.Table,
         *,
         database: str | None = None,
         overwrite: bool = False,

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
     from ibis.backends.sql.compilers.base import SQLGlotCompiler
+    from ibis.expr.api import IntoMemtable
     from ibis.expr.schema import IntoSchema
 
 
@@ -412,7 +413,7 @@ class SQLBackend(BaseBackend):
         self,
         name: str,
         /,
-        obj: pd.DataFrame | ir.Table | list | dict,
+        obj: ir.Table | IntoMemtable,
         *,
         database: str | None = None,
         overwrite: bool = False,
@@ -548,7 +549,7 @@ class SQLBackend(BaseBackend):
         self,
         name: str,
         /,
-        obj: pd.DataFrame | ir.Table | list | dict,
+        obj: ir.Table | IntoMemtable,
         on: str,
         *,
         database: str | None = None,

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -38,6 +38,8 @@ if TYPE_CHECKING:
     import polars as pl
     import pyarrow as pa
 
+    from ibis.expr.api import IntoMemtable
+
 
 @functools.cache
 def _init_sqlite3():
@@ -606,7 +608,7 @@ class Backend(
         self,
         name: str,
         /,
-        obj: pd.DataFrame | ir.Table | list | dict,
+        obj: ir.Table | IntoMemtable,
         *,
         database: str | None = None,
         overwrite: bool = False,


### PR DESCRIPTION
This is just a subset of the changes in https://github.com/ibis-project/ibis/pull/11776, I'm slowly chipping away at that to make it more digestible

This TypeAlias defines the types that can be converted into a memtable, including:
- Iterables of mappings (list of dicts)
- Iterables of iterables (list of lists/tuples)
- Mappings of iterables (dict of lists)
- pandas DataFrames
- Objects implementing Arrow C Stream interface
- pyarrow Datasets
- polars DataFrames and LazyFrames
- geopandas GeoDataFrames

This also updates all backend insert() and upsert() method signatures to use IntoMemtable.

Updated backends:
- sql (SQLBackend base class)
- clickhouse
- snowflake
- sqlite
- impala
- bigquery
- flink