### PR TITLE
fix(databricks): lazily create memtable volume on first use

### DIFF
--- a/ibis/backends/databricks/__init__.py
+++ b/ibis/backends/databricks/__init__.py
@@ -407,9 +407,15 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
             staging_allowed_local_path=staging_allowed_local_path,
             **config,
         )
+        if memtable_volume is None:
+            short_version = "".join(map(str, sys.version_info[:3]))
+            memtable_volume = (
+                f"{getpass.getuser()}-py={short_version}-pid={os.getpid()}"
+            )
+        self._memtable_volume = memtable_volume
+        self._memtable_volume_created = False
         self._memtable_catalog = self.current_catalog
         self._memtable_database = self.current_database
-        self._post_connect(memtable_volume=memtable_volume)
 
     @contextlib.contextmanager
     def begin(self):
@@ -431,39 +437,30 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
         new_backend = cls()
         new_backend._can_reconnect = False
         new_backend.con = con
-        new_backend._post_connect(memtable_volume=memtable_volume)
         return new_backend
 
-    def _post_connect(self, *, memtable_volume: str) -> None:
-        if memtable_volume is None:
-            short_version = "".join(map(str, sys.version_info[:3]))
-            memtable_volume = (
-                f"{getpass.getuser()}-py={short_version}-pid={os.getpid()}"
-            )
-        self._memtable_volume = memtable_volume
-        self._memtable_volume_created = False
-
-    def _ensure_memtable_volume(self) -> None:
-        if self._memtable_volume_created:
-            return
-        sql = f"CREATE VOLUME IF NOT EXISTS `{self._memtable_volume}` COMMENT 'Ibis memtable storage volume'"
-        with self.con.cursor() as cur:
-            cur.execute(sql)
-        self._memtable_volume_created = True
+    def _ensure_memtable_volume(self, memtable_volume: str | None = None) -> str:
+        if not self._memtable_volume_created:
+            if memtable_volume is not None:
+                self._memtable_volume = memtable_volume
+            sql = f"CREATE VOLUME IF NOT EXISTS `{self._memtable_volume}` COMMENT 'Ibis memtable storage volume'"
+            with self.con.cursor() as cur:
+                cur.execute(sql)
+            self._memtable_volume_created = True
+        return self._memtable_volume_path
 
     @functools.cached_property
     def _memtable_volume_path(self) -> str:
         return f"/Volumes/{self._memtable_catalog}/{self._memtable_database}/{self._memtable_volume}"
 
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
-        self._ensure_memtable_volume()
         import pyarrow.parquet as pq
 
         quoted = self.compiler.quoted
         name = op.name
         stem = f"{name}.parquet"
 
-        upstream_path = f"{self._memtable_volume_path}/{stem}"
+        upstream_path = f"{self._ensure_memtable_volume()}/{stem}"
         sql = sge.Create(
             kind="VIEW",
             this=sg.table(name, quoted=quoted),

--- a/ibis/backends/databricks/tests/conftest.py
+++ b/ibis/backends/databricks/tests/conftest.py
@@ -85,7 +85,33 @@ class TestConf(BackendTest):
         )
 
 
+class TestConfReadonly(BackendTest):
+    supports_map = True
+    driver_supports_multiple_statements = False
+    deps = ("databricks.sql",)
+
+    @staticmethod
+    def connect(*, tmpdir, worker_id, **kw) -> BaseBackend:  # noqa: ARG004
+        return ibis.databricks.connect(
+            server_hostname=env["DATABRICKS_SERVER_HOSTNAME"],
+            http_path=env["DATABRICKS_HTTP_PATH"],
+            access_token=env["DATABRICKS_TOKEN"],
+            catalog=DATABRICKS_CATALOG,
+            schema="default",
+            **kw,
+        )
+
+
 @pytest.fixture(scope="session")
 def con(tmp_path_factory, data_dir, worker_id):
     with TestConf.load_data(data_dir, tmp_path_factory, worker_id) as be:
         yield be.connection
+
+
+@pytest.fixture(scope="session")
+def con_readonly(tmp_path_factory, worker_id):
+    """Read-only connection — no data loading, just connect and query."""
+    yield TestConfReadonly.connect(
+        tmpdir=tmp_path_factory,
+        worker_id=worker_id,
+    )


### PR DESCRIPTION
## Description of changes

Previously, the memtable volume was created eagerly in _post_connect()
immediately after connecting, which caused read-only users to fail with
a PermissionDenied error even when they never intended to use memtables.

This change defers volume creation until the first memtable is actually
registered via _register_in_memory_table(), allowing read-only users to
connect and query existing data without requiring CREATE VOLUME privilege.

## Issues closed

* Resolves #11598 

-->
