### PR TITLE
fix: preserve recursive CTEs

### DIFF
--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -694,6 +694,7 @@ class SQLGlotCompiler(abc.ABC):
             lambda parsed, cte: parsed.with_(
                 cte.args["alias"],
                 as_=cte.args["this"],
+                recursive=isinstance(cte.parent, sge.With) and cte.parent.recursive,
                 dialect=self.dialect,
                 copy=False,
             ),


### PR DESCRIPTION
### Issue

```
In [1]: import ibis

In [2]: query = """WITH RECURSIVE numbers (n) AS (
   ...:     SELECT 1 AS n
   ...:     UNION ALL
   ...:     SELECT n + 1 FROM numbers WHERE n < 5
   ...: )
   ...: SELECT n FROM numbers;"""

In [3]: db = ibis.duckdb.connect()

In [4]: q = db.sql(query)

In [5]: ibis.to_sql(db.sql(query))
Out[5]: 
WITH numbers(n) AS (
  SELECT
    1 AS n
  UNION ALL
  SELECT
    n + 1
  FROM numbers
  WHERE
    n < 5
)
SELECT
  n
FROM numbers

```

### After proposed fix

```
In [1]: import ibis

In [4]: ...

In [5]: ibis.to_sql(db.sql(query))
Out[5]: 
WITH RECURSIVE numbers(n) AS (
  SELECT
    1 AS n
  UNION ALL
  SELECT
    n + 1
  FROM numbers
  WHERE
    n < 5
)
SELECT
  n
FROM numbers

```
