### PR TITLE
fix(bigquery): handle project in database arg for create_view/drop_view

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -1309,36 +1309,26 @@ class Backend(
         database: str | None = None,
         overwrite: bool = False,
     ) -> ir.Table:
-        table_loc = self._to_sqlglot_table(database)
-        catalog, db = self._to_catalog_db_tuple(table_loc)
+        project_id, dataset = self._parse_project_and_dataset(database)
 
         stmt = sge.Create(
             kind="VIEW",
-            this=sg.table(
-                name,
-                db=db or self.current_database,
-                catalog=catalog or self.billing_project,
-            ),
+            this=sg.table(name, db=dataset, catalog=project_id),
             expression=self.compile(obj),
             replace=overwrite,
         )
         self._run_pre_execute_hooks(obj)
         self.raw_sql(stmt.sql(self.name))
-        return self.table(name, database=(catalog, database))
+        return self.table(name, database=(project_id, dataset))
 
     def drop_view(
         self, name: str, /, *, database: str | None = None, force: bool = False
     ) -> None:
-        table_loc = self._to_sqlglot_table(database)
-        catalog, db = self._to_catalog_db_tuple(table_loc)
+        project_id, dataset = self._parse_project_and_dataset(database)
 
         stmt = sge.Drop(
             kind="VIEW",
-            this=sg.table(
-                name,
-                db=db or self.current_database,
-                catalog=catalog or self.billing_project,
-            ),
+            this=sg.table(name, db=dataset, catalog=project_id),
             exists=force,
         )
         self.raw_sql(stmt.sql(self.name))


### PR DESCRIPTION
## Bug
https://github.com/ibis-project/ibis/issues/11974 — `create_view()` with `database="my-project.my_dataset"` fails with `ValueError: my-project.my-project.my_dataset is not a BigQuery dataset`, while `create_table()` handles the same input correctly.

## Root cause
`create_view()` and `drop_view()` use `_to_sqlglot_table()` + `_to_catalog_db_tuple()` and then fall back to `self.billing_project` / `self.current_database`. This pipeline doesn't match how BigQuery project/dataset strings are parsed — the generic sqlglot path can duplicate the project component.

`create_table()` uses `_parse_project_and_dataset()` instead, which correctly handles BigQuery's `project.dataset` format.

## Fix
Replaced the `_to_sqlglot_table` + `_to_catalog_db_tuple` + fallback pattern in `create_view()` and `drop_view()` with `_parse_project_and_dataset()`, matching `create_table()`'s approach. This ensures consistent behavior across all three methods.

Also fixed the `return self.table(...)` call in `create_view()` which was passing the raw `database` string instead of the parsed dataset.

## Testing
Verified that the code path aligns with `create_table()`'s proven approach. `_parse_project_and_dataset` correctly handles all input forms: `None`, `"dataset"`, and `"project.dataset"`.

Happy to address any feedback.

Greetings, saschabuehrle