### PR TITLE
fix(mssql): use one-part name in sp_rename when creating a table with override=true

### DIFF
--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -726,7 +726,7 @@ GO"""
                     sge.Drop(kind="TABLE", this=this, exists=True).sql(self.dialect)
                 )
                 old = raw_table.sql(self.dialect)
-                new = raw_this.sql(self.dialect)
+                new = raw_this.name
                 cur.execute(f"EXEC sp_rename '{old}', '{new}'")
 
         if temp:

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1855,7 +1855,21 @@ def test_table_not_found(con):
         con.table(gen_name("table_not_found"))
 
 
-@pytest.mark.parametrize("overwrite", [True, False])
+@pytest.mark.parametrize(
+    "overwrite",
+    [
+        param(
+            True,
+            marks=[
+                pytest.mark.notimpl(
+                    ["mysql", "singlestoredb", "risingwave"],
+                    reason="Cross-database load fails with overwrite (needs investigation).",
+                )
+            ],
+        ),
+        False,
+    ],
+)
 @pytest.mark.notimpl(
     ["flink"], raises=com.IbisError, reason="not yet implemented for Flink"
 )

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1855,6 +1855,7 @@ def test_table_not_found(con):
         con.table(gen_name("table_not_found"))
 
 
+@pytest.mark.parametrize("overwrite", [True, False])
 @pytest.mark.notimpl(
     ["flink"], raises=com.IbisError, reason="not yet implemented for Flink"
 )
@@ -1863,7 +1864,7 @@ def test_table_not_found(con):
     raises=AssertionError,
     reason="Schema resolution issue with cross-database table loading in Materialize (needs investigation).",
 )
-def test_no_accidental_cross_database_table_load(con_create_database):
+def test_no_accidental_cross_database_table_load(con_create_database, overwrite):
     con = con_create_database
 
     # Create an extra database
@@ -1874,7 +1875,9 @@ def test_no_accidental_cross_database_table_load(con_create_database):
         table := gen_name("table"), schema=(sch1 := ibis.schema({"a": "int"}))
     )
 
-    con.create_table(table, schema=ibis.schema({"b": "string"}), database=dbname)
+    con.create_table(
+        table, schema=ibis.schema({"b": "string"}), database=dbname, overwrite=overwrite
+    )
 
     # Can grab table object from current db:
     t = con.table(table)


### PR DESCRIPTION
## Description of changes

Instead of using sqlglot's `table.sql()` function to get the target table name, use `table.name`.

The `sp_rename` stored proc requires that the new name is just the table name. Previously we were supplying the fully qualified name and this was causing incorrect tables to be created.

For example, `conn.create_table("my_table", database=("my_db", "dbo"), override=true)' would create a table called `my_db.dbo.[my_db.dbo.my_table]`

Ref: https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-rename-transact-sql

## Issues closed

I haven't raised an issue for this, and couldn't find one when searching.