### PR TITLE
fix: emit explicit CAST for float literals in SQL compilation

### DIFF
--- a/ibis/backends/sql/compilers/postgres.py
+++ b/ibis/backends/sql/compilers/postgres.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import math
 import string
 import textwrap
 from functools import partial, reduce
@@ -649,7 +650,9 @@ $$""".format(
         return self.f.right(arg, self.f.length(end)).eq(end)
 
     def visit_NonNullLiteral(self, op, *, value, dtype):
-        if dtype.is_binary():
+        if dtype.is_floating() and math.isfinite(value):
+            return self.cast(sge.convert(value), dtype)
+        elif dtype.is_binary():
             return self.cast("".join(map(r"\x{:0>2x}".format, value)), dt.binary)
         elif dtype.is_time():
             to_int32 = partial(self.cast, to=dt.int32)

--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -49,6 +49,20 @@ def test_literal(backend, expr):
     assert "432" in ibis.to_sql(expr, dialect=backend.name())
 
 
+def test_float_literal_has_cast_on_postgres():
+    """Float literals should have an explicit CAST on postgres.
+
+    Without the CAST, postgres interprets bare float values like 0.5518
+    as numeric/decimal, which causes errors when converting to pyarrow.
+
+    Regression test for https://github.com/ibis-project/ibis/issues/11947
+    """
+    expr = ibis.literal(0.5518, type="double")
+    sql = ibis.to_sql(expr, dialect="postgres")
+    assert "DOUBLE PRECISION" in sql
+    assert "CAST" in sql
+
+
 @pytest.mark.never(["polars"], reason="not SQL", raises=ValueError)
 def test_group_by_has_index(backend, snapshot):
     countries = ibis.table(


### PR DESCRIPTION
Float literals were compiled without an explicit CAST, causing Postgres to interpret values like `0.5518` as `numeric`/`decimal` instead of `double precision`. Integer literals already received the correct CAST.

Adds a `dtype.is_floating()` check in the Postgres compiler's `visit_NonNullLiteral` that wraps finite float values in `CAST(... AS DOUBLE PRECISION)`, matching the existing behavior for other typed literals.

Non-finite values (NaN, inf) are left to the base class handler which already produces the correct `'NaN'::DOUBLE PRECISION` etc.

Closes #11947