### PR TITLE
fix(sql): preserve timezone-cast semantics in trino and duckdb

### DIFF
--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -4,7 +4,7 @@ import os
 import random
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 import duckdb
 import numpy as np
@@ -14,6 +14,7 @@ import pytest
 from pytest import param
 
 import ibis
+from ibis import _
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 from ibis.conftest import LINUX, SANDBOXED, not_windows
@@ -199,6 +200,59 @@ def test_to_other_sql(con, snapshot):
 
     sql = ibis.to_sql(t, dialect="snowflake")
     snapshot.assert_match(sql, "out.sql")
+
+
+def test_timezone_cast_extracts_and_time():
+    con = ibis.duckdb.connect()
+    t = ibis.memtable(
+        {"x": [datetime(2023, 1, 2, 0, 0, tzinfo=timezone.utc)]},
+        schema=ibis.schema({"x": "timestamp('UTC')"}),
+    )
+    expr = t.select(
+        ams_hour=t.x.cast("timestamp('Europe/Amsterdam')").hour(),
+        utc_hour=t.x.cast("timestamp('UTC')").hour(),
+        ams_time=t.x.cast("timestamp('Europe/Amsterdam')").time(),
+        utc_time=t.x.cast("timestamp('UTC')").time(),
+    )
+
+    result = con.execute(expr)
+
+    assert result.ams_hour.iat[0] == 1
+    assert result.utc_hour.iat[0] == 0
+    assert str(result.ams_time.iat[0]) == "01:00:00"
+    assert str(result.utc_time.iat[0]) == "00:00:00"
+
+
+def test_timezone_cast_epoch_seconds_uses_timezone_instant():
+    con = ibis.duckdb.connect()
+    t = ibis.memtable({"a": [1]})
+    expr = t.select(var=ibis.literal("2023-01-02")).mutate(
+        es_ams=ibis.timestamp(_.var, timezone="Europe/Amsterdam").epoch_seconds(),
+        es_utc=ibis.timestamp(_.var, timezone="UTC").epoch_seconds(),
+        es_ams2=_.var.cast("timestamp('Europe/Amsterdam')").epoch_seconds(),
+        es_utc2=_.var.cast("timestamp('UTC')").epoch_seconds(),
+    )
+
+    result = con.execute(expr).iloc[0]
+
+    assert result.es_ams == 1672614000
+    assert result.es_utc == 1672617600
+    assert result.es_ams2 == 1672614000
+    assert result.es_utc2 == 1672617600
+
+
+def test_to_trino_sql_timezone_cast_uses_timezone_functions():
+    t = ibis.memtable({"x": ["2023-01-02"]})
+    expr = t.select(
+        casted=t.x.cast("timestamp('Europe/Paris')"),
+        hour=t.x.cast("timestamp('Europe/Paris')").hour(),
+        time=t.x.cast("timestamp('Europe/Paris')").time(),
+    )
+
+    sql = ibis.to_sql(expr, dialect="trino")
+
+    assert "AT_TIMEZONE(" in sql
+    assert "WITH_TIMEZONE(" in sql
 
 
 def test_insert_preserves_column_case(con):

--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -4,7 +4,7 @@ import os
 import random
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 import duckdb
 import numpy as np
@@ -16,6 +16,7 @@ from pytest import param
 import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
+from ibis import _
 from ibis.conftest import LINUX, SANDBOXED, not_windows
 from ibis.util import gen_name
 
@@ -199,6 +200,51 @@ def test_to_other_sql(con, snapshot):
 
     sql = ibis.to_sql(t, dialect="snowflake")
     snapshot.assert_match(sql, "out.sql")
+
+
+def test_timezone_cast_extracts_and_time_match_scalar():
+    con = ibis.duckdb.connect()
+    value = datetime(2023, 1, 2, 0, 0, tzinfo=timezone.utc)
+    t = ibis.memtable(
+        {"x": [value]},
+        schema=ibis.schema({"x": "timestamp('UTC')"}),
+    )
+    scalar = ibis.literal(value, type="timestamp('UTC')").cast(
+        "timestamp('Europe/Amsterdam')"
+    )
+    expr = t.select(
+        scalar_hour=scalar.hour(),
+        column_hour=t.x.cast("timestamp('Europe/Amsterdam')").hour(),
+        scalar_time=scalar.time(),
+        column_time=t.x.cast("timestamp('Europe/Amsterdam')").time(),
+        utc_hour=t.x.cast("timestamp('UTC')").hour(),
+        utc_time=t.x.cast("timestamp('UTC')").time(),
+    )
+
+    result = con.execute(expr).iloc[0]
+
+    assert result.scalar_hour == result.column_hour == 1
+    assert result.utc_hour == 0
+    assert str(result.scalar_time) == str(result.column_time) == "01:00:00"
+    assert str(result.utc_time) == "00:00:00"
+
+
+def test_timezone_cast_epoch_seconds_uses_timezone_instant():
+    con = ibis.duckdb.connect()
+    t = ibis.memtable({"a": [1]})
+    expr = t.select(var=ibis.literal("2023-01-02")).mutate(
+        es_ams=ibis.timestamp(_.var, timezone="Europe/Amsterdam").epoch_seconds(),
+        es_utc=ibis.timestamp(_.var, timezone="UTC").epoch_seconds(),
+        es_ams2=_.var.cast("timestamp('Europe/Amsterdam')").epoch_seconds(),
+        es_utc2=_.var.cast("timestamp('UTC')").epoch_seconds(),
+    )
+
+    result = con.execute(expr).iloc[0]
+
+    assert result.es_ams == 1672614000
+    assert result.es_utc == 1672617600
+    assert result.es_ams2 == 1672614000
+    assert result.es_utc2 == 1672617600
 
 
 def test_insert_preserves_column_case(con):

--- a/ibis/backends/sql/compilers/duckdb.py
+++ b/ibis/backends/sql/compilers/duckdb.py
@@ -392,12 +392,41 @@ class DuckDBCompiler(SQLGlotCompiler):
         )
         return self.agg.count(sge.Distinct(expressions=[row]), where=where)
 
+    def _localize_timestamp_for_extract(self, op, *, arg):
+        if op.arg.dtype.is_timestamp() and (timezone := op.arg.dtype.timezone) is not None:
+            return self.f.timezone(timezone, arg)
+        return arg
+
+    def visit_Time(self, op, *, arg):
+        arg = self._localize_timestamp_for_extract(op, arg=arg)
+        return super().visit_Time(op, arg=arg)
+
+    def visit_ExtractEpochSeconds(self, op, *, arg):
+        if op.arg.dtype.is_timestamp() and op.arg.dtype.timezone is not None:
+            return self.f.epoch(arg)
+        return super().visit_ExtractEpochSeconds(op, arg=arg)
+
+    def visit_ExtractHour(self, op, *, arg):
+        return self.f.extract("hour", self._localize_timestamp_for_extract(op, arg=arg))
+
+    def visit_ExtractMinute(self, op, *, arg):
+        return self.f.extract(
+            "minute", self._localize_timestamp_for_extract(op, arg=arg)
+        )
+
+    def visit_ExtractSecond(self, op, *, arg):
+        return self.f.extract(
+            "second", self._localize_timestamp_for_extract(op, arg=arg)
+        )
+
     def visit_ExtractMillisecond(self, op, *, arg):
+        arg = self._localize_timestamp_for_extract(op, arg=arg)
         return self.f.mod(self.f.extract("ms", arg), 1_000)
 
     # DuckDB extracts subminute microseconds and milliseconds
     # so we have to finesse it a little bit
     def visit_ExtractMicrosecond(self, op, *, arg):
+        arg = self._localize_timestamp_for_extract(op, arg=arg)
         return self.f.mod(self.f.extract("us", arg), 1_000_000)
 
     def visit_TimestampFromUNIX(self, op, *, arg, unit):
@@ -428,6 +457,15 @@ class DuckDBCompiler(SQLGlotCompiler):
             return func(sg.cast(arg, to=self.type_mapper.from_ibis(dt.int32)))
         elif to.is_timestamp() and dtype.is_numeric():
             return self.f.to_timestamp(arg)
+        elif to.is_timestamp() and to.timezone is not None and (
+            dtype.is_string() or dtype.is_date()
+        ):
+            # DuckDB TIMESTAMPTZ casts from strings/dates do not retain the target
+            # timezone intent by default, so parse as naive timestamp and then
+            # localize into the requested timezone.
+            return self.f.timezone(
+                to.timezone, self.cast(arg, dt.Timestamp(scale=to.scale))
+            )
         elif to.is_geospatial():
             if dtype.is_binary():
                 return self.f.st_geomfromwkb(arg)

--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -585,9 +585,21 @@ class TrinoCompiler(SQLGlotCompiler):
             if from_.is_integer():
                 return self.f.from_unixtime(arg, tz)
             else:
-                return self.f.from_unixtime_nanos(
+                out = self.f.from_unixtime_nanos(
                     self.cast(arg, dt.Decimal(38, 9)) * 1_000_000_000
                 )
+                return self.f.at_timezone(out, tz)
+
+        if to.is_timestamp() and (timezone := to.timezone) is not None:
+            if from_.is_string() or from_.is_date():
+                arg = self.cast(arg, dt.Timestamp(scale=to.scale))
+                from_ = dt.Timestamp(scale=to.scale)
+
+            if from_.is_timestamp():
+                if from_.timezone is None:
+                    arg = self.f.with_timezone(arg, "UTC")
+                return self.f.at_timezone(arg, timezone)
+
         return super().visit_Cast(op, arg=arg, to=to)
 
     def visit_CountDistinctStar(self, op, *, arg, where):

--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -587,9 +587,21 @@ class TrinoCompiler(SQLGlotCompiler):
             if from_.is_integer():
                 return self.f.from_unixtime(arg, tz)
             else:
-                return self.f.from_unixtime_nanos(
+                out = self.f.from_unixtime_nanos(
                     self.cast(arg, dt.Decimal(38, 9)) * 1_000_000_000
                 )
+                return self.f.at_timezone(out, tz)
+
+        if to.is_timestamp() and (timezone := to.timezone) is not None:
+            if from_.is_string() or from_.is_date():
+                arg = self.cast(arg, dt.Timestamp(scale=to.scale))
+                return self.f.with_timezone(arg, timezone)
+
+            if from_.is_timestamp():
+                if from_.timezone is None:
+                    return self.f.with_timezone(arg, timezone)
+                return self.f.at_timezone(arg, timezone)
+
         return super().visit_Cast(op, arg=arg, to=to)
 
     def visit_CountDistinctStar(self, op, *, arg, where):

--- a/ibis/backends/sql/tests/test_compiler.py
+++ b/ibis/backends/sql/tests/test_compiler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import sqlglot as sg
 
 import ibis
@@ -26,3 +28,20 @@ def test_transpile_join():
         "SELECT * FROM t1 JOIN t2 ON x = y", read="duckdb", write=Trino
     )
     assert "CROSS JOIN" not in result
+
+
+def test_trino_timezone_cast_uses_timezone_functions():
+    string_expr = ibis.memtable({"x": ["2023-01-02"]}).select(
+        casted=_.x.cast("timestamp('Europe/Paris')")
+    )
+    timestamp_expr = ibis.memtable(
+        {"x": [datetime(2023, 1, 2, 0, 0, tzinfo=timezone.utc)]},
+        schema=ibis.schema({"x": "timestamp('UTC')"}),
+    ).select(casted=_.x.cast("timestamp('Europe/Paris')"))
+
+    string_sql = ibis.to_sql(string_expr, dialect="trino")
+    timestamp_sql = ibis.to_sql(timestamp_expr, dialect="trino")
+
+    assert "WITH_TIMEZONE(" in string_sql
+    assert "AT_TIMEZONE(" not in string_sql
+    assert "AT_TIMEZONE(" in timestamp_sql

--- a/ibis/backends/trino/tests/test_client.py
+++ b/ibis/backends/trino/tests/test_client.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import math
 import string
+from datetime import datetime, timezone
 
 import pytest
 
 import ibis
 import ibis.common.exceptions as exc
-from ibis import udf, util
+from ibis import _, udf, util
 from ibis.backends.trino.tests.conftest import (
     TRINO_HOST,
     TRINO_PASS,
@@ -146,6 +147,43 @@ def test_create_table_timestamp():
     finally:
         con.drop_table(table)
         assert table not in con.list_tables()
+
+
+def test_timezone_cast_extracts_and_time():
+    con = ibis.trino.connect(database="memory", schema="default")
+    t = ibis.memtable(
+        {"x": [datetime(2023, 1, 2, 0, 0, tzinfo=timezone.utc)]},
+        schema=ibis.schema({"x": "timestamp('UTC')"}),
+    )
+    expr = t.select(
+        casted=t.x.cast("timestamp('Europe/Paris')"),
+        hour=t.x.cast("timestamp('Europe/Paris')").hour(),
+        time=t.x.cast("timestamp('Europe/Paris')").time(),
+    )
+
+    result = con.execute(expr).iloc[0]
+
+    assert str(result.casted) == "2023-01-02 01:00:00+01:00"
+    assert result.hour == 1
+    assert str(result.time) == "01:00:00"
+
+
+def test_timezone_cast_epoch_seconds_uses_timezone_instant():
+    con = ibis.trino.connect(database="memory", schema="default")
+    t = ibis.memtable({"a": [1]})
+    expr = t.select(var=ibis.literal("2023-01-02")).mutate(
+        es_ams=ibis.timestamp(_.var, timezone="Europe/Amsterdam").epoch_seconds(),
+        es_utc=ibis.timestamp(_.var, timezone="UTC").epoch_seconds(),
+        es_ams2=_.var.cast("timestamp('Europe/Amsterdam')").epoch_seconds(),
+        es_utc2=_.var.cast("timestamp('UTC')").epoch_seconds(),
+    )
+
+    result = con.execute(expr).iloc[0]
+
+    assert result.es_ams == 1672614000
+    assert result.es_utc == 1672617600
+    assert result.es_ams2 == 1672614000
+    assert result.es_utc2 == 1672617600
 
 
 def test_table_access_database_schema(con):


### PR DESCRIPTION
## Description:

This PR fixes timezone cast regressions in DuckDB and Trino.

For DuckDB, timezone aware extraction from casted UTC timestamp columns now matches scalar casts, and timezone-aware string/date casts preserve the intended instant for `epoch_seconds()`.

For Trino, casts to timezone aware timestamps now distinguish between two cases:
- string/date and naive timestamp inputs are localized with `WITH_TIMEZONE`
- timezone-aware timestamp inputs are converted with `AT_TIMEZONE`

This fixes the incorrect `epoch_seconds()` behavior for timezone-aware casts from string/date inputs and preserves the expected `hour()` and `time()` behavior when casting UTC timestamps to another timezone.

It also tightens regression coverage with:
- DuckDB runtime tests for casted column vs scalar `hour()` and `time()`
- Trino runtime tests for UTC timestamp cast `hour()` and `time()` and timezone-aware `epoch_seconds()`
- SQL compiler coverage for the `WITH_TIMEZONE` and `AT_TIMEZONE` translation paths

Fixes #11965.
Fixes #11211.
References #11527.
References #11879.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks using `ruff format --check ibis/backends/sql/compilers/trino.py ibis/backends/sql/tests/test_compiler.py ibis/backends/trino/tests/test_client.py ibis/backends/duckdb/tests/test_client.py` and `ruff check ibis/backends/sql/compilers/trino.py ibis/backends/sql/tests/test_compiler.py ibis/backends/trino/tests/test_client.py ibis/backends/duckdb/tests/test_client.py`.
- [x] I have run focused tests using `PYTHONPATH=$PWD pytest -q ibis/backends/duckdb/tests/test_client.py ibis/backends/trino/tests/test_client.py ibis/backends/sql/tests/test_compiler.py -k timezone_cast`.
- [x] I have verified the Trino backend behavior with a live local Docker backed service.

### The validation screenshot of the tests run, locally:

<img width="1850" height="600" alt="image" src="https://github.com/user-attachments/assets/aced7db9-6132-4906-b33b-860de6f53941" />

### Before the fix:

<img width="1500" height="385" alt="image" src="https://github.com/user-attachments/assets/41bdd722-bc92-4e1c-bb8d-0dc80353723b" />

### After the fix:

<img width="1500" height="385" alt="image" src="https://github.com/user-attachments/assets/98ec7773-2247-4026-9ded-07ce02a42809" />
