### PR TITLE
fix(impala/pyspark): handle VT/FF in strip methods

### DIFF
--- a/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/lstrip/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/lstrip/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  LTRIM(`t0`.`string_col`, ' \t\n\r\v\f') AS `LStrip(string_col)`
+  REGEXP_REPLACE(`t0`.`string_col`, '^\\s+', '') AS `LStrip(string_col)`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/lstrip/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/lstrip/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  REGEXP_REPLACE(`t0`.`string_col`, '^\\s+', '') AS `LStrip(string_col)`
+  LTRIM(`t0`.`string_col`, ' \t\n\r\v\f') AS `LStrip(string_col)`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/lstrip/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/lstrip/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  LTRIM(`t0`.`string_col`, ' \t\n\r\v\f') AS `LStrip(string_col)`
+  LTRIM(`t0`.`string_col`, CONCAT(' \t\n\r', CHR(  11), CHR(  12))) AS `LStrip(string_col)`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/rstrip/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/rstrip/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  RTRIM(`t0`.`string_col`, ' \t\n\r\v\f') AS `RStrip(string_col)`
+  REGEXP_REPLACE(`t0`.`string_col`, '\\s+$', '') AS `RStrip(string_col)`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/rstrip/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/rstrip/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  REGEXP_REPLACE(`t0`.`string_col`, '\\s+$', '') AS `RStrip(string_col)`
+  RTRIM(`t0`.`string_col`, ' \t\n\r\v\f') AS `RStrip(string_col)`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/rstrip/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/rstrip/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  RTRIM(`t0`.`string_col`, ' \t\n\r\v\f') AS `RStrip(string_col)`
+  RTRIM(`t0`.`string_col`, CONCAT(' \t\n\r', CHR(  11), CHR(  12))) AS `RStrip(string_col)`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/strip/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/strip/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  RTRIM(LTRIM(`t0`.`string_col`, ' \t\n\r\v\f'), ' \t\n\r\v\f') AS `Strip(string_col)`
+  REGEXP_REPLACE(`t0`.`string_col`, '^\\s+|\\s+$', '') AS `Strip(string_col)`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/strip/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/strip/out.sql
@@ -1,6 +1,6 @@
 SELECT
   RTRIM(
     LTRIM(`t0`.`string_col`, CONCAT(' \t\n\r', CHR(  11), CHR(  12))),
-    CONCAT(' \t\n\r', CHR(  11 ), CHR(  12))
+    CONCAT(' \t\n\r', CHR(  11), CHR(  12))
   ) AS `Strip(string_col)`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/strip/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/strip/out.sql
@@ -1,3 +1,6 @@
 SELECT
-  RTRIM(LTRIM(`t0`.`string_col`, ' \t\n\r\v\f'), ' \t\n\r\v\f') AS `Strip(string_col)`
+  RTRIM(
+    LTRIM(`t0`.`string_col`, CONCAT(' \t\n\r', CHR(  11), CHR(  12))),
+    CONCAT(' \t\n\r', CHR(  11 ), CHR(  12))
+  ) AS `Strip(string_col)`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/strip/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/strip/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  REGEXP_REPLACE(`t0`.`string_col`, '^\\s+|\\s+$', '') AS `Strip(string_col)`
+  RTRIM(LTRIM(`t0`.`string_col`, ' \t\n\r\v\f'), ' \t\n\r\v\f') AS `Strip(string_col)`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 class Backend(SupportsTempTables, BaseBackend, NoUrl, DirectExampleLoader):
     name = "polars"
     dialect = Polars
+    supports_temporary_tables = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -70,7 +71,7 @@ class Backend(SupportsTempTables, BaseBackend, NoUrl, DirectExampleLoader):
         if tables is not None and not isinstance(tables, Mapping):
             raise TypeError("Input to ibis.polars.connect must be a mapping")
 
-        # tables are ephemeral
+        # tables are emphemeral
         self._tables.clear()
 
         for name, table in (tables or {}).items():
@@ -374,7 +375,7 @@ class Backend(SupportsTempTables, BaseBackend, NoUrl, DirectExampleLoader):
             del self._tables[name]
             self._context.unregister(name)
         elif not force:
-            raise com.TableNotFound(name)
+            raise com.IbisError(f"Table {name!r} does not exist")
 
     def drop_view(self, name: str, /, *, force: bool = False) -> None:
         self.drop_table(name, force=force)
@@ -440,7 +441,7 @@ class Backend(SupportsTempTables, BaseBackend, NoUrl, DirectExampleLoader):
         self,
         expr: ir.Expr,
         params: Mapping[ir.Expr, object] | None = None,
-        limit: int | str | None = None,
+        limit: int | None = None,
         engine: Literal["cpu", "gpu", "streaming"] | pl.GPUEngine = "cpu",
         **kwargs: Any,
     ) -> pl.DataFrame:
@@ -464,7 +465,7 @@ class Backend(SupportsTempTables, BaseBackend, NoUrl, DirectExampleLoader):
         expr: ir.Expr,
         /,
         *,
-        params: Mapping[ir.Scalar, Any] | None = None,
+        params: Mapping[ir.Expr, object] | None = None,
         limit: int | None = None,
         engine: Literal["cpu", "gpu", "streaming"] | pl.GPUEngine = "cpu",
         **kwargs: Any,

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -31,7 +31,6 @@ if TYPE_CHECKING:
 class Backend(SupportsTempTables, BaseBackend, NoUrl, DirectExampleLoader):
     name = "polars"
     dialect = Polars
-    supports_temporary_tables = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -71,7 +70,7 @@ class Backend(SupportsTempTables, BaseBackend, NoUrl, DirectExampleLoader):
         if tables is not None and not isinstance(tables, Mapping):
             raise TypeError("Input to ibis.polars.connect must be a mapping")
 
-        # tables are emphemeral
+        # tables are ephemeral
         self._tables.clear()
 
         for name, table in (tables or {}).items():
@@ -375,7 +374,7 @@ class Backend(SupportsTempTables, BaseBackend, NoUrl, DirectExampleLoader):
             del self._tables[name]
             self._context.unregister(name)
         elif not force:
-            raise com.IbisError(f"Table {name!r} does not exist")
+            raise com.TableNotFound(name)
 
     def drop_view(self, name: str, /, *, force: bool = False) -> None:
         self.drop_table(name, force=force)
@@ -441,7 +440,7 @@ class Backend(SupportsTempTables, BaseBackend, NoUrl, DirectExampleLoader):
         self,
         expr: ir.Expr,
         params: Mapping[ir.Expr, object] | None = None,
-        limit: int | None = None,
+        limit: int | str | None = None,
         engine: Literal["cpu", "gpu", "streaming"] | pl.GPUEngine = "cpu",
         **kwargs: Any,
     ) -> pl.DataFrame:
@@ -465,7 +464,7 @@ class Backend(SupportsTempTables, BaseBackend, NoUrl, DirectExampleLoader):
         expr: ir.Expr,
         /,
         *,
-        params: Mapping[ir.Expr, object] | None = None,
+        params: Mapping[ir.Scalar, Any] | None = None,
         limit: int | None = None,
         engine: Literal["cpu", "gpu", "streaming"] | pl.GPUEngine = "cpu",
         **kwargs: Any,

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -45,6 +45,7 @@ class ImpalaCompiler(SQLGlotCompiler):
         ops.ArgMin,
         ops.Covariance,
         ops.ExtractDayOfYear,
+        ops.Kurtosis,
         ops.Levenshtein,
         ops.Map,
         ops.Median,
@@ -59,7 +60,6 @@ class ImpalaCompiler(SQLGlotCompiler):
         ops.TimestampBucket,
         ops.TimestampDelta,
         ops.Unnest,
-        ops.Kurtosis,
     )
 
     SIMPLE_OPS = {
@@ -77,9 +77,12 @@ class ImpalaCompiler(SQLGlotCompiler):
         ops.DayOfWeekName: "dayname",
         ops.ExtractEpochSeconds: "unix_timestamp",
         ops.Hash: "fnv_hash",
+        ops.LStrip: "ltrim",
         ops.Ln: "ln",
-        ops.TypeOf: "typeof",
+        ops.RStrip: "rtrim",
         ops.RegexReplace: "regexp_replace",
+        ops.Strip: "trim",
+        ops.TypeOf: "typeof",
     }
 
     @staticmethod

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from string import whitespace as WHITESPACE
+from string import whitespace
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -19,6 +19,8 @@ from ibis.backends.sql.rewrites import (
     rewrite_empty_order_by_window,
     split_select_distinct_with_order_by,
 )
+
+WHITESPACE = whitespace.encode("unicode-escape").decode()
 
 
 class ImpalaCompiler(SQLGlotCompiler):
@@ -325,18 +327,16 @@ class ImpalaCompiler(SQLGlotCompiler):
         return self.f.datediff(left, right)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.anon.ltrim(arg, repr(WHITESPACE))
+        return self.f.anon.ltrim(arg, WHITESPACE)
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.anon.rtrim(arg, repr(WHITESPACE))
+        return self.f.anon.rtrim(arg, WHITESPACE)
 
     def visit_Strip(self, op, *, arg):
         # Impala's `TRIM` doesn't allow specifying characters to trim off, unlike
         # Impala's `RTRIM` and `LTRIM` which accept a set of characters to
         # remove.
-        return self.f.anon.rtrim(
-            self.f.anon.ltrim(arg, repr(WHITESPACE)), repr(WHITESPACE)
-        )
+        return self.f.anon.rtrim(self.f.anon.ltrim(arg, WHITESPACE), WHITESPACE)
 
 
 compiler = ImpalaCompiler()

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -77,11 +77,8 @@ class ImpalaCompiler(SQLGlotCompiler):
         ops.DayOfWeekName: "dayname",
         ops.ExtractEpochSeconds: "unix_timestamp",
         ops.Hash: "fnv_hash",
-        ops.LStrip: "ltrim",
         ops.Ln: "ln",
-        ops.RStrip: "rtrim",
         ops.RegexReplace: "regexp_replace",
-        ops.Strip: "trim",
         ops.TypeOf: "typeof",
     }
 
@@ -328,16 +325,18 @@ class ImpalaCompiler(SQLGlotCompiler):
         return self.f.datediff(left, right)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.anon.ltrim(arg, WHITESPACE)
+        return self.f.anon.ltrim(arg, repr(WHITESPACE))
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.anon.rtrim(arg, WHITESPACE)
+        return self.f.anon.rtrim(arg, repr(WHITESPACE))
 
     def visit_Strip(self, op, *, arg):
         # Impala's `TRIM` doesn't allow specifying characters to trim off, unlike
         # Impala's `RTRIM` and `LTRIM` which accept a set of characters to
         # remove.
-        return self.f.anon.rtrim(self.f.anon.ltrim(arg, WHITESPACE), WHITESPACE)
+        return self.f.anon.rtrim(
+            self.f.anon.ltrim(arg, repr(WHITESPACE)), repr(WHITESPACE)
+        )
 
 
 compiler = ImpalaCompiler()

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from string import whitespace as WHITESPACE
+
 import sqlglot as sg
 import sqlglot.expressions as sge
 
@@ -323,13 +325,13 @@ class ImpalaCompiler(SQLGlotCompiler):
         return self.f.datediff(left, right)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, r"^\s+", "")
+        return self.f.regexp_replace(arg, rf"^[{WHITESPACE}]+", "")
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, r"\s+$", "")
+        return self.f.regexp_replace(arg, rf"[{WHITESPACE}]+$", "")
 
     def visit_Strip(self, op, *, arg):
-        return self.f.regexp_replace(arg, r"^\s+|\s+$", "")
+        return self.visit_RStrip(self.visit_LStrip(op, arg=arg), arg=arg)
 
 
 compiler = ImpalaCompiler()

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from string import whitespace as WHITESPACE
-
 import sqlglot as sg
 import sqlglot.expressions as sge
 
@@ -325,13 +323,13 @@ class ImpalaCompiler(SQLGlotCompiler):
         return self.f.datediff(left, right)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, rf"^[{WHITESPACE}]+", "")
+        return self.f.regexp_replace(arg, r"^\s+", "")
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, rf"[{WHITESPACE}]+$", "")
+        return self.f.regexp_replace(arg, r"\s+$", "")
 
     def visit_Strip(self, op, *, arg):
-        return self.visit_RStrip(self.visit_LStrip(op, arg=arg), arg=arg)
+        return self.f.regexp_replace(arg, r"^\s+|\s+$", "")
 
 
 compiler = ImpalaCompiler()

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -77,11 +77,8 @@ class ImpalaCompiler(SQLGlotCompiler):
         ops.DayOfWeekName: "dayname",
         ops.ExtractEpochSeconds: "unix_timestamp",
         ops.Hash: "fnv_hash",
-        ops.LStrip: "ltrim",
         ops.Ln: "ln",
-        ops.RStrip: "rtrim",
         ops.RegexReplace: "regexp_replace",
-        ops.Strip: "trim",
         ops.TypeOf: "typeof",
     }
 
@@ -328,16 +325,13 @@ class ImpalaCompiler(SQLGlotCompiler):
         return self.f.datediff(left, right)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.anon.ltrim(arg, WHITESPACE)
+        return self.f.regexp_replace(arg, rf"^[{WHITESPACE}]+", "")
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.anon.rtrim(arg, WHITESPACE)
+        return self.f.regexp_replace(arg, rf"[{WHITESPACE}]+$", "")
 
     def visit_Strip(self, op, *, arg):
-        # Impala's `TRIM` doesn't allow specifying characters to trim off, unlike
-        # Impala's `RTRIM` and `LTRIM` which accept a set of characters to
-        # remove.
-        return self.f.anon.rtrim(self.f.anon.ltrim(arg, WHITESPACE), WHITESPACE)
+        return self.visit_RStrip(self.visit_LStrip(op, arg=arg), arg=arg)
 
 
 compiler = ImpalaCompiler()

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -77,8 +77,11 @@ class ImpalaCompiler(SQLGlotCompiler):
         ops.DayOfWeekName: "dayname",
         ops.ExtractEpochSeconds: "unix_timestamp",
         ops.Hash: "fnv_hash",
+        ops.LStrip: "ltrim",
         ops.Ln: "ln",
+        ops.RStrip: "rtrim",
         ops.RegexReplace: "regexp_replace",
+        ops.Strip: "trim",
         ops.TypeOf: "typeof",
     }
 
@@ -325,13 +328,16 @@ class ImpalaCompiler(SQLGlotCompiler):
         return self.f.datediff(left, right)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, rf"^[{WHITESPACE}]+", "")
+        return self.f.anon.ltrim(arg, WHITESPACE)
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, rf"[{WHITESPACE}]+$", "")
+        return self.f.anon.rtrim(arg, WHITESPACE)
 
     def visit_Strip(self, op, *, arg):
-        return self.visit_RStrip(self.visit_LStrip(op, arg=arg), arg=arg)
+        # Impala's `TRIM` doesn't allow specifying characters to trim off, unlike
+        # Impala's `RTRIM` and `LTRIM` which accept a set of characters to
+        # remove.
+        return self.f.anon.rtrim(self.f.anon.ltrim(arg, WHITESPACE), WHITESPACE)
 
 
 compiler = ImpalaCompiler()

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from string import whitespace
-
 import sqlglot as sg
 import sqlglot.expressions as sge
 
@@ -19,8 +17,6 @@ from ibis.backends.sql.rewrites import (
     rewrite_empty_order_by_window,
     split_select_distinct_with_order_by,
 )
-
-WHITESPACE = whitespace.encode("unicode-escape").decode()
 
 
 class ImpalaCompiler(SQLGlotCompiler):
@@ -327,16 +323,13 @@ class ImpalaCompiler(SQLGlotCompiler):
         return self.f.datediff(left, right)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.anon.ltrim(arg, WHITESPACE)
+        return self.f.regexp_replace(arg, r"^\s+", "")
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.anon.rtrim(arg, WHITESPACE)
+        return self.f.regexp_replace(arg, r"\s+$", "")
 
     def visit_Strip(self, op, *, arg):
-        # Impala's `TRIM` doesn't allow specifying characters to trim off, unlike
-        # Impala's `RTRIM` and `LTRIM` which accept a set of characters to
-        # remove.
-        return self.f.anon.rtrim(self.f.anon.ltrim(arg, WHITESPACE), WHITESPACE)
+        return self.f.regexp_replace(arg, r"^\s+|\s+$", "")
 
 
 compiler = ImpalaCompiler()

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from string import whitespace
+
 import sqlglot as sg
 import sqlglot.expressions as sge
 
@@ -17,6 +19,8 @@ from ibis.backends.sql.rewrites import (
     rewrite_empty_order_by_window,
     split_select_distinct_with_order_by,
 )
+
+WHITESPACE = whitespace.encode("unicode-escape").decode()
 
 
 class ImpalaCompiler(SQLGlotCompiler):
@@ -323,13 +327,16 @@ class ImpalaCompiler(SQLGlotCompiler):
         return self.f.datediff(left, right)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, r"^\s+", "")
+        return self.f.anon.ltrim(arg, WHITESPACE)
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, r"\s+$", "")
+        return self.f.anon.rtrim(arg, WHITESPACE)
 
     def visit_Strip(self, op, *, arg):
-        return self.f.regexp_replace(arg, r"^\s+|\s+$", "")
+        # Impala's `TRIM` doesn't allow specifying characters to trim off, unlike
+        # Impala's `RTRIM` and `LTRIM` which accept a set of characters to
+        # remove.
+        return self.f.anon.rtrim(self.f.anon.ltrim(arg, WHITESPACE), WHITESPACE)
 
 
 compiler = ImpalaCompiler()

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from string import whitespace
+import string
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -19,6 +19,11 @@ from ibis.backends.sql.rewrites import (
     rewrite_empty_order_by_window,
     split_select_distinct_with_order_by,
 )
+
+# String escaping inside SQL string literals is dialect-sensitive; using
+# the `CHR()` function fixes issues with specific whitespace characters.
+VT = sge.Chr(expressions=[sge.Literal.number(ord("\v"))])
+FF = sge.Chr(expressions=[sge.Literal.number(ord("\f"))])
 
 
 class ImpalaCompiler(SQLGlotCompiler):
@@ -325,40 +330,17 @@ class ImpalaCompiler(SQLGlotCompiler):
         return self.f.datediff(left, right)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.anon.ltrim(
-            arg,
-            self.f.concat(
-                whitespace[:-1],
-                sge.Chr(expressions=[sge.Literal.number(ord(whitespace[-1]))]),
-            ),
-        )
+        return self.f.anon.ltrim(arg, self.f.concat(string.whitespace[:-2], VT, FF))
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.anon.rtrim(
-            arg,
-            self.f.concat(
-                whitespace[:-1],
-                sge.Chr(expressions=[sge.Literal.number(ord(whitespace[-1]))]),
-            ),
-        )
+        return self.f.anon.rtrim(arg, self.f.concat(string.whitespace[:-2], VT, FF))
 
     def visit_Strip(self, op, *, arg):
         # Impala's `TRIM` doesn't allow specifying characters to trim off, unlike
         # Impala's `RTRIM` and `LTRIM` which accept a set of characters to
         # remove.
-        return self.f.anon.rtrim(
-            self.f.anon.ltrim(
-                arg,
-                self.f.concat(
-                    whitespace[:-1],
-                    sge.Chr(expressions=[sge.Literal.number(ord(whitespace[-1]))]),
-                ),
-            ),
-            self.f.concat(
-                whitespace[:-1],
-                sge.Chr(expressions=[sge.Literal.number(ord(whitespace[-1]))]),
-            ),
-        )
+        whitespace = self.f.concat(string.whitespace[:-2], VT, FF)
+        return self.f.anon.rtrim(self.f.anon.ltrim(arg, whitespace), whitespace)
 
 
 compiler = ImpalaCompiler()

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -20,7 +20,7 @@ from ibis.backends.sql.rewrites import (
     split_select_distinct_with_order_by,
 )
 
-WHITESPACE = whitespace.encode("unicode-escape").decode()
+WHITESPACE = whitespace[:-1].encode("unicode-escape").decode()
 
 
 class ImpalaCompiler(SQLGlotCompiler):
@@ -327,16 +327,40 @@ class ImpalaCompiler(SQLGlotCompiler):
         return self.f.datediff(left, right)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.anon.ltrim(arg, WHITESPACE)
+        return self.f.anon.ltrim(
+            arg,
+            self.f.concat(
+                WHITESPACE,
+                sge.Chr(expressions=[sge.Literal.number(ord(whitespace[-1]))]),
+            ),
+        )
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.anon.rtrim(arg, WHITESPACE)
+        return self.f.anon.rtrim(
+            arg,
+            self.f.concat(
+                WHITESPACE,
+                sge.Chr(expressions=[sge.Literal.number(ord(whitespace[-1]))]),
+            ),
+        )
 
     def visit_Strip(self, op, *, arg):
         # Impala's `TRIM` doesn't allow specifying characters to trim off, unlike
         # Impala's `RTRIM` and `LTRIM` which accept a set of characters to
         # remove.
-        return self.f.anon.rtrim(self.f.anon.ltrim(arg, WHITESPACE), WHITESPACE)
+        return self.f.anon.rtrim(
+            self.f.anon.ltrim(
+                arg,
+                self.f.concat(
+                    WHITESPACE,
+                    sge.Chr(expressions=[sge.Literal.number(ord(whitespace[-1]))]),
+                ),
+            ),
+            self.f.concat(
+                WHITESPACE,
+                sge.Chr(expressions=[sge.Literal.number(ord(whitespace[-1]))]),
+            ),
+        )
 
 
 compiler = ImpalaCompiler()

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -20,8 +20,6 @@ from ibis.backends.sql.rewrites import (
     split_select_distinct_with_order_by,
 )
 
-WHITESPACE = whitespace[:-1].encode("unicode-escape").decode()
-
 
 class ImpalaCompiler(SQLGlotCompiler):
     __slots__ = ()
@@ -330,7 +328,7 @@ class ImpalaCompiler(SQLGlotCompiler):
         return self.f.anon.ltrim(
             arg,
             self.f.concat(
-                WHITESPACE,
+                whitespace[:-1],
                 sge.Chr(expressions=[sge.Literal.number(ord(whitespace[-1]))]),
             ),
         )
@@ -339,7 +337,7 @@ class ImpalaCompiler(SQLGlotCompiler):
         return self.f.anon.rtrim(
             arg,
             self.f.concat(
-                WHITESPACE,
+                whitespace[:-1],
                 sge.Chr(expressions=[sge.Literal.number(ord(whitespace[-1]))]),
             ),
         )
@@ -352,12 +350,12 @@ class ImpalaCompiler(SQLGlotCompiler):
             self.f.anon.ltrim(
                 arg,
                 self.f.concat(
-                    WHITESPACE,
+                    whitespace[:-1],
                     sge.Chr(expressions=[sge.Literal.number(ord(whitespace[-1]))]),
                 ),
             ),
             self.f.concat(
-                WHITESPACE,
+                whitespace[:-1],
                 sge.Chr(expressions=[sge.Literal.number(ord(whitespace[-1]))]),
             ),
         )

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -85,6 +85,7 @@ class PySparkCompiler(SQLGlotCompiler):
         ops.EndsWith: "endswith",
         ops.Hash: "hash",
         ops.Log10: "log10",
+        ops.Strip: "trim",
         ops.LStrip: "ltrim",
         ops.RStrip: "rtrim",
         ops.MapLength: "size",

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -4,7 +4,6 @@ import calendar
 import itertools
 import operator
 import re
-from string import whitespace as WHITESPACE
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -86,6 +85,9 @@ class PySparkCompiler(SQLGlotCompiler):
         ops.EndsWith: "endswith",
         ops.Hash: "hash",
         ops.Log10: "log10",
+        ops.Strip: "trim",
+        ops.LStrip: "ltrim",
+        ops.RStrip: "rtrim",
         ops.MapLength: "size",
         ops.MapContains: "map_contains_key",
         ops.MapMerge: "map_concat",
@@ -682,15 +684,6 @@ class PySparkCompiler(SQLGlotCompiler):
 
     def visit_ArrayMean(self, op, *, arg):
         return self._array_reduction(dtype=op.dtype, arg=arg, output=operator.truediv)
-
-    def visit_LStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, rf"^[{WHITESPACE}]+", "")
-
-    def visit_RStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, rf"[{WHITESPACE}]+$", "")
-
-    def visit_Strip(self, op, *, arg):
-        return self.visit_RStrip(self.visit_LStrip(op, arg=arg), arg=arg)
 
 
 compiler = PySparkCompiler()

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -4,7 +4,7 @@ import calendar
 import itertools
 import operator
 import re
-from string import whitespace as WHITESPACE
+from string import whitespace
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -27,6 +27,8 @@ from ibis.common.patterns import replace
 from ibis.config import options
 from ibis.expr.operations.udf import InputType
 from ibis.util import gen_name
+
+WHITESPACE = whitespace.encode("unicode-escape").decode()
 
 
 @replace(p.Limit)
@@ -684,18 +686,13 @@ class PySparkCompiler(SQLGlotCompiler):
         return self._array_reduction(dtype=op.dtype, arg=arg, output=operator.truediv)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.anon.ltrim(arg, repr(WHITESPACE))
+        return self.f.anon.ltrim(arg, WHITESPACE)
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.anon.rtrim(arg, repr(WHITESPACE))
+        return self.f.anon.rtrim(arg, WHITESPACE)
 
     def visit_Strip(self, op, *, arg):
-        # PySpark's `TRIM` didn't allow specifying characters to trim off, unlike
-        # PySpark's `RTRIM` and `LTRIM` which accept a set of characters to
-        # remove.
-        return self.f.anon.rtrim(
-            self.f.anon.ltrim(arg, repr(WHITESPACE)), repr(WHITESPACE)
-        )
+        return self.f.anon.trim(arg, WHITESPACE)
 
 
 compiler = PySparkCompiler()

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -4,7 +4,6 @@ import calendar
 import itertools
 import operator
 import re
-from string import whitespace as WHITESPACE
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -684,13 +683,13 @@ class PySparkCompiler(SQLGlotCompiler):
         return self._array_reduction(dtype=op.dtype, arg=arg, output=operator.truediv)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, rf"^[{WHITESPACE}]+", "")
+        return self.f.regexp_replace(arg, r"^\s+", "")
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, rf"[{WHITESPACE}]+$", "")
+        return self.f.regexp_replace(arg, r"\s+$", "")
 
     def visit_Strip(self, op, *, arg):
-        return self.visit_RStrip(self.visit_LStrip(op, arg=arg), arg=arg)
+        return self.f.regexp_replace(arg, r"^\s+|\s+$", "")
 
 
 compiler = PySparkCompiler()

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -4,7 +4,6 @@ import calendar
 import itertools
 import operator
 import re
-from string import whitespace
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -27,8 +26,6 @@ from ibis.common.patterns import replace
 from ibis.config import options
 from ibis.expr.operations.udf import InputType
 from ibis.util import gen_name
-
-WHITESPACE = whitespace.encode("unicode-escape").decode()
 
 
 @replace(p.Limit)
@@ -686,13 +683,13 @@ class PySparkCompiler(SQLGlotCompiler):
         return self._array_reduction(dtype=op.dtype, arg=arg, output=operator.truediv)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.anon.ltrim(arg, WHITESPACE)
+        return self.f.regexp_replace(arg, r"^\s+", "")
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.anon.rtrim(arg, WHITESPACE)
+        return self.f.regexp_replace(arg, r"\s+$", "")
 
     def visit_Strip(self, op, *, arg):
-        return self.f.anon.trim(arg, WHITESPACE)
+        return self.f.regexp_replace(arg, r"^\s+|\s+$", "")
 
 
 compiler = PySparkCompiler()

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -4,6 +4,7 @@ import calendar
 import itertools
 import operator
 import re
+from string import whitespace as WHITESPACE
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -85,9 +86,6 @@ class PySparkCompiler(SQLGlotCompiler):
         ops.EndsWith: "endswith",
         ops.Hash: "hash",
         ops.Log10: "log10",
-        ops.Strip: "trim",
-        ops.LStrip: "ltrim",
-        ops.RStrip: "rtrim",
         ops.MapLength: "size",
         ops.MapContains: "map_contains_key",
         ops.MapMerge: "map_concat",
@@ -684,6 +682,20 @@ class PySparkCompiler(SQLGlotCompiler):
 
     def visit_ArrayMean(self, op, *, arg):
         return self._array_reduction(dtype=op.dtype, arg=arg, output=operator.truediv)
+
+    def visit_LStrip(self, op, *, arg):
+        return self.f.anon.ltrim(arg, repr(WHITESPACE))
+
+    def visit_RStrip(self, op, *, arg):
+        return self.f.anon.rtrim(arg, repr(WHITESPACE))
+
+    def visit_Strip(self, op, *, arg):
+        # PySpark's `TRIM` didn't allow specifying characters to trim off, unlike
+        # PySpark's `RTRIM` and `LTRIM` which accept a set of characters to
+        # remove.
+        return self.f.anon.rtrim(
+            self.f.anon.ltrim(arg, repr(WHITESPACE)), repr(WHITESPACE)
+        )
 
 
 compiler = PySparkCompiler()

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -4,6 +4,7 @@ import calendar
 import itertools
 import operator
 import re
+from string import whitespace as WHITESPACE
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -683,13 +684,13 @@ class PySparkCompiler(SQLGlotCompiler):
         return self._array_reduction(dtype=op.dtype, arg=arg, output=operator.truediv)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, r"^\s+", "")
+        return self.f.regexp_replace(arg, rf"^[{WHITESPACE}]+", "")
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, r"\s+$", "")
+        return self.f.regexp_replace(arg, rf"[{WHITESPACE}]+$", "")
 
     def visit_Strip(self, op, *, arg):
-        return self.f.regexp_replace(arg, r"^\s+|\s+$", "")
+        return self.visit_RStrip(self.visit_LStrip(op, arg=arg), arg=arg)
 
 
 compiler = PySparkCompiler()

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -4,6 +4,7 @@ import calendar
 import itertools
 import operator
 import re
+from string import whitespace as WHITESPACE
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -85,9 +86,6 @@ class PySparkCompiler(SQLGlotCompiler):
         ops.EndsWith: "endswith",
         ops.Hash: "hash",
         ops.Log10: "log10",
-        ops.Strip: "trim",
-        ops.LStrip: "ltrim",
-        ops.RStrip: "rtrim",
         ops.MapLength: "size",
         ops.MapContains: "map_contains_key",
         ops.MapMerge: "map_concat",
@@ -684,6 +682,15 @@ class PySparkCompiler(SQLGlotCompiler):
 
     def visit_ArrayMean(self, op, *, arg):
         return self._array_reduction(dtype=op.dtype, arg=arg, output=operator.truediv)
+
+    def visit_LStrip(self, op, *, arg):
+        return self.f.regexp_replace(arg, rf"^[{WHITESPACE}]+", "")
+
+    def visit_RStrip(self, op, *, arg):
+        return self.f.regexp_replace(arg, rf"[{WHITESPACE}]+$", "")
+
+    def visit_Strip(self, op, *, arg):
+        return self.visit_RStrip(self.visit_LStrip(op, arg=arg), arg=arg)
 
 
 compiler = PySparkCompiler()

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -451,7 +451,7 @@ class PySparkCompiler(SQLGlotCompiler):
         return self.f.rtrim(self.f.concat(string.whitespace[:-2], VT, FF), arg)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.ltrim(self.f.concat(string.whitesapce[:-2], VT, FF), arg)
+        return self.f.ltrim(self.f.concat(string.whitespace[:-2], VT, FF), arg)
 
     def visit_StringFind(self, op, *, arg, substr, start, end):
         if end is not None:

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -4,6 +4,7 @@ import calendar
 import itertools
 import operator
 import re
+import string
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -438,6 +439,39 @@ class PySparkCompiler(SQLGlotCompiler):
             arg = sge.Distinct(expressions=[arg])
         return self.agg.array_agg(arg, order_by=order_by)
 
+    def visit_Strip(self, op, *, arg):
+        return self.f.trim(
+            arg,
+            sge.DPipe(
+                this=sge.Literal.string(string.whitespace[:-1]),
+                expression=sge.Chr(
+                    expressions=[sge.Literal.number(ord(string.whitespace[-1]))]
+                ),
+            ),
+        )
+
+    def visit_RStrip(self, op, *, arg):
+        return self.f.rtrim(
+            sge.DPipe(
+                this=sge.Literal.string(string.whitespace[:-1]),
+                expression=sge.Chr(
+                    expressions=[sge.Literal.number(ord(string.whitespace[-1]))]
+                ),
+            ),
+            arg,
+        )
+
+    def visit_LStrip(self, op, *, arg):
+        return self.f.ltrim(
+            sge.DPipe(
+                this=sge.Literal.string(string.whitespace[:-1]),
+                expression=sge.Chr(
+                    expressions=[sge.Literal.number(ord(string.whitespace[-1]))]
+                ),
+            ),
+            arg,
+        )
+
     def visit_StringFind(self, op, *, arg, substr, start, end):
         if end is not None:
             raise com.UnsupportedOperationError(
@@ -681,15 +715,6 @@ class PySparkCompiler(SQLGlotCompiler):
 
     def visit_ArrayMean(self, op, *, arg):
         return self._array_reduction(dtype=op.dtype, arg=arg, output=operator.truediv)
-
-    def visit_LStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, r"^\s+", "")
-
-    def visit_RStrip(self, op, *, arg):
-        return self.f.regexp_replace(arg, r"\s+$", "")
-
-    def visit_Strip(self, op, *, arg):
-        return self.f.regexp_replace(arg, r"^\s+|\s+$", "")
 
 
 compiler = PySparkCompiler()

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -28,6 +28,11 @@ from ibis.config import options
 from ibis.expr.operations.udf import InputType
 from ibis.util import gen_name
 
+# String escaping inside SQL string literals is dialect-sensitive; using
+# the `CHR()` function fixes issues with specific whitespace characters.
+VT = sge.Chr(expressions=[sge.Literal.number(ord("\v"))])
+FF = sge.Chr(expressions=[sge.Literal.number(ord("\f"))])
+
 
 @replace(p.Limit)
 def offset_to_filter(_):
@@ -440,37 +445,13 @@ class PySparkCompiler(SQLGlotCompiler):
         return self.agg.array_agg(arg, order_by=order_by)
 
     def visit_Strip(self, op, *, arg):
-        return self.f.trim(
-            arg,
-            sge.DPipe(
-                this=sge.Literal.string(string.whitespace[:-1]),
-                expression=sge.Chr(
-                    expressions=[sge.Literal.number(ord(string.whitespace[-1]))]
-                ),
-            ),
-        )
+        return self.f.trim(arg, self.f.concat(string.whitespace[:-2], VT, FF))
 
     def visit_RStrip(self, op, *, arg):
-        return self.f.rtrim(
-            sge.DPipe(
-                this=sge.Literal.string(string.whitespace[:-1]),
-                expression=sge.Chr(
-                    expressions=[sge.Literal.number(ord(string.whitespace[-1]))]
-                ),
-            ),
-            arg,
-        )
+        return self.f.rtrim(self.f.concat(string.whitespace[:-2], VT, FF), arg)
 
     def visit_LStrip(self, op, *, arg):
-        return self.f.ltrim(
-            sge.DPipe(
-                this=sge.Literal.string(string.whitespace[:-1]),
-                expression=sge.Chr(
-                    expressions=[sge.Literal.number(ord(string.whitespace[-1]))]
-                ),
-            ),
-            arg,
-        )
+        return self.f.ltrim(self.f.concat(string.whitesapce[:-2], VT, FF), arg)
 
     def visit_StringFind(self, op, *, arg, substr, start, end):
         if end is not None:

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1144,8 +1144,9 @@ def string_temp_table(backend, con):
                 "aBc",
                 "🐍",
                 "ÉéÈèêç",
+                "fluff",
             ],
-            "index_col": [0, 1, 2, 3, 4, 5, 6],
+            "index_col": [0, 1, 2, 3, 4, 5, 6, 7],
         }
     )
 

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1144,7 +1144,7 @@ def string_temp_table(backend, con):
                 "aBc",
                 "🐍",
                 "ÉéÈèêç",
-                "fluf\f",
+                "fluff",
             ],
             "index_col": [0, 1, 2, 3, 4, 5, 6, 7],
         }

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1144,7 +1144,7 @@ def string_temp_table(backend, con):
                 "aBc",
                 "🐍",
                 "ÉéÈèêç",
-                "fluff",
+                "fluf\f",
             ],
             "index_col": [0, 1, 2, 3, 4, 5, 6, 7],
         }

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1144,9 +1144,10 @@ def string_temp_table(backend, con):
                 "aBc",
                 "🐍",
                 "ÉéÈèêç",
-                "fluff",
+                "fluf\f",
+                "'fluf\f'",
             ],
-            "index_col": [0, 1, 2, 3, 4, 5, 6, 7],
+            "index_col": [0, 1, 2, 3, 4, 5, 6, 7, 8],
         }
     )
 
@@ -1278,7 +1279,7 @@ def string_temp_table(backend, con):
         ),
         param(
             lambda t: t.string_col.find_in_set(["aBc", "123"]),
-            lambda _: pd.Series([-1, -1, -1, 1, 0, -1, -1, -1], name="tmp"),
+            lambda _: pd.Series([-1, -1, -1, 1, 0, -1, -1, -1, -1], name="tmp"),
             id="find_in_set",
             marks=[
                 pytest.mark.notyet(
@@ -1307,7 +1308,7 @@ def string_temp_table(backend, con):
         ),
         param(
             lambda t: t.string_col.find_in_set(["abc, 123"]),
-            lambda _: pd.Series([-1, -1, -1, -1, -1, -1, -1, -1], name="tmp"),
+            lambda _: pd.Series([-1, -1, -1, -1, -1, -1, -1, -1, -1], name="tmp"),
             id="find_in_set_w_comma",
             marks=[
                 pytest.mark.notyet(

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1307,7 +1307,7 @@ def string_temp_table(backend, con):
         ),
         param(
             lambda t: t.string_col.find_in_set(["abc, 123"]),
-            lambda _: pd.Series([-1, -1, -1, -1, -1, -1, -1], name="tmp"),
+            lambda _: pd.Series([-1, -1, -1, -1, -1, -1, -1, -1], name="tmp"),
             id="find_in_set_w_comma",
             marks=[
                 pytest.mark.notyet(

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1145,9 +1145,8 @@ def string_temp_table(backend, con):
                 "🐍",
                 "ÉéÈèêç",
                 "fluf\f",
-                "'fluf\f'",
             ],
-            "index_col": [0, 1, 2, 3, 4, 5, 6, 7, 8],
+            "index_col": [0, 1, 2, 3, 4, 5, 6, 7],
         }
     )
 
@@ -1279,7 +1278,7 @@ def string_temp_table(backend, con):
         ),
         param(
             lambda t: t.string_col.find_in_set(["aBc", "123"]),
-            lambda _: pd.Series([-1, -1, -1, 1, 0, -1, -1, -1, -1], name="tmp"),
+            lambda _: pd.Series([-1, -1, -1, 1, 0, -1, -1, -1], name="tmp"),
             id="find_in_set",
             marks=[
                 pytest.mark.notyet(
@@ -1308,7 +1307,7 @@ def string_temp_table(backend, con):
         ),
         param(
             lambda t: t.string_col.find_in_set(["abc, 123"]),
-            lambda _: pd.Series([-1, -1, -1, -1, -1, -1, -1, -1, -1], name="tmp"),
+            lambda _: pd.Series([-1, -1, -1, -1, -1, -1, -1, -1], name="tmp"),
             id="find_in_set_w_comma",
             marks=[
                 pytest.mark.notyet(
@@ -1348,25 +1347,11 @@ def string_temp_table(backend, con):
             lambda t: t.string_col.lstrip(),
             lambda t: t.str.lstrip(),
             id="lstrip",
-            marks=[
-                pytest.mark.notyet(
-                    ["pyspark", "databricks"],
-                    raises=AssertionError,
-                    reason="Spark SQL LTRIM doesn't accept characters to trim",
-                ),
-            ],
         ),
         param(
             lambda t: t.string_col.rstrip(),
             lambda t: t.str.rstrip(),
             id="rstrip",
-            marks=[
-                pytest.mark.notyet(
-                    ["pyspark", "databricks"],
-                    raises=AssertionError,
-                    reason="Spark SQL RTRIM doesn't accept characters to trim",
-                ),
-            ],
         ),
         param(
             lambda t: t.string_col.strip(),
@@ -1425,6 +1410,7 @@ def test_string_methods_accents_and_emoji(
     │ aBc        │
     │ 🐍         │
     │ ÉéÈèêç     │
+    │ fluf\f     │
     └────────────┘
     """
     t = string_temp_table

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1278,7 +1278,7 @@ def string_temp_table(backend, con):
         ),
         param(
             lambda t: t.string_col.find_in_set(["aBc", "123"]),
-            lambda _: pd.Series([-1, -1, -1, 1, 0, -1, -1], name="tmp"),
+            lambda _: pd.Series([-1, -1, -1, 1, 0, -1, -1, -1], name="tmp"),
             id="find_in_set",
             marks=[
                 pytest.mark.notyet(

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1308,7 +1308,7 @@ def string_temp_table(backend, con):
         ),
         param(
             lambda t: t.string_col.find_in_set(["abc, 123"]),
-            lambda _: pd.Series([-1, -1, -1, -1, -1, -1, -1, -1], name="tmp"),
+            lambda _: pd.Series([-1, -1, -1, -1, -1, -1, -1, -1, -1], name="tmp"),
             id="find_in_set_w_comma",
             marks=[
                 pytest.mark.notyet(

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1279,7 +1279,7 @@ def string_temp_table(backend, con):
         ),
         param(
             lambda t: t.string_col.find_in_set(["aBc", "123"]),
-            lambda _: pd.Series([-1, -1, -1, 1, 0, -1, -1, -1], name="tmp"),
+            lambda _: pd.Series([-1, -1, -1, 1, 0, -1, -1, -1, -1], name="tmp"),
             id="find_in_set",
             marks=[
                 pytest.mark.notyet(

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1145,8 +1145,9 @@ def string_temp_table(backend, con):
                 "🐍",
                 "ÉéÈèêç",
                 "fluf\f",
+                "\vvv\v",
             ],
-            "index_col": [0, 1, 2, 3, 4, 5, 6, 7],
+            "index_col": [0, 1, 2, 3, 4, 5, 6, 7, 8],
         }
     )
 
@@ -1411,6 +1412,7 @@ def test_string_methods_accents_and_emoji(
     │ 🐍         │
     │ ÉéÈèêç     │
     │ fluf\f     │
+    │ \vvv\v     │
     └────────────┘
     """
     t = string_temp_table


### PR DESCRIPTION
## Description of changes

String escaping inside SQL string literals is dialect-sensitive; using the `CHR()` function fixes issues with specific whitespace characters.

As an added bonus, this fixes two xfails on the PySpark side.

## Issues closed

* Resolves #11894