### PR TITLE
fix(snowflake): convert Decimal columns to float64 instead of object dtype

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -477,6 +477,16 @@ $$ {defn["source"]} $$"""
         df = table.to_pandas(timestamp_as_object=True)
         df.columns = list(schema.names)
         return SnowflakePandasData.convert_table(df, schema)
+    
+    def execute(self, expr, /, *, params=None, limit=None, **kwargs):
+        self._run_pre_execute_hooks(expr)
+        table = expr.as_table()
+        sql = self.compile(table, params=params, limit=limit, **kwargs)
+        schema = table.schema()
+
+        with self._safe_raw_sql(sql) as cur:
+            result = self._fetch_from_cursor(cur, schema)
+        return expr.__pandas_result__(result, data_mapper=SnowflakePandasData)
 
     def to_pandas_batches(
         self,

--- a/ibis/backends/snowflake/converter.py
+++ b/ibis/backends/snowflake/converter.py
@@ -84,6 +84,10 @@ else:
         def convert_Struct(cls, s, dtype, pandas_type):
             raw_json_objects = cls.convert_JSON(s, dtype, pandas_type)
             return super().convert_Struct(raw_json_objects, dtype, pandas_type)
+        @classmethod
+        def convert_Decimal(cls, s, dtype, pandas_type):
+            result = s.astype("float64")
+            return result
 
 
 try:


### PR DESCRIPTION
## Issue

When querying a Snowflake table with `NUMBER(p, s)` columns where scale > 0 (e.g. `NUMBER(38, 8)`), the resulting pandas DataFrame has `object` dtype instead of `float64`: see #11990

```python
t = con.table("MY_TABLE")  # has NUMBER(38, 8) column
df = t.execute()
print(df["my_col"].dtype)  # object, expected float64
```

Snowflake returns `NUMBER(38, 8)` as `double` in Arrow format, so the data is already `float64` after `_fetch_from_cursor`. However `__pandas_result__` was defaulting to plain `PandasData` as the `data_mapper`, which runs `normalize_decimal` on every value — wrapping each `float64` in a Python `decimal.Decimal` object and producing `object` dtype.

## Fix

1. Override `execute()` in the Snowflake backend to pass `data_mapper=SnowflakePandasData` to `__pandas_result__`
2. Add `convert_Decimal` to `SnowflakePandasData` that casts to `float64` instead of running `normalize_decimal`

## Issues closed

* Resolves #11990