### PR TITLE
fix: compile log without base as natural log

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -704,6 +704,8 @@ def clip(op, **kw):
 @translate.register(ops.Log)
 def log(op, **kw):
     arg = translate(op.arg, **kw)
+    if op.base is None:
+        return arg.log()
     return arg.log(base=_literal_value(op.base))
 
 

--- a/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -443,7 +443,7 @@ class BigQueryCompiler(SQLGlotCompiler):
         return self.f.log(arg, 2)
 
     def visit_Log(self, op, *, arg, base):
-        if base is None:
+        if op.base is None:
             return self.f.ln(arg)
         return self.f.log(arg, base)
 

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -147,7 +147,7 @@ class ImpalaCompiler(SQLGlotCompiler):
         return self.f[how](arg)
 
     def visit_Log(self, op, *, arg, base):
-        if base is None:
+        if op.base is None:
             return self.f.ln(arg)
         return self.f.log(base, arg)
 

--- a/ibis/backends/sql/compilers/mssql.py
+++ b/ibis/backends/sql/compilers/mssql.py
@@ -406,7 +406,7 @@ class MSSQLCompiler(SQLGlotCompiler):
         return self.f.log(arg, 2)
 
     def visit_Log(self, op, *, arg, base):
-        if base is None:
+        if op.base is None:
             return self.f.log(arg)
         return self.f.log(arg, base)
 

--- a/ibis/backends/sql/compilers/oracle.py
+++ b/ibis/backends/sql/compilers/oracle.py
@@ -217,6 +217,8 @@ class OracleCompiler(SQLGlotCompiler):
         return arg.eq(self.NAN)
 
     def visit_Log(self, op, *, arg, base):
+        if op.base is None:
+            return self.f.ln(arg)
         return self.f.log(base, arg)
 
     def visit_IsInf(self, op, *, arg):

--- a/ibis/backends/sql/compilers/postgres.py
+++ b/ibis/backends/sql/compilers/postgres.py
@@ -451,7 +451,7 @@ $$""".format(
         )
 
     def visit_Log(self, op, *, arg, base):
-        if base is not None:
+        if op.base is not None:
             if not op.base.dtype.is_decimal():
                 base = self.cast(base, dt.decimal)
         else:

--- a/ibis/backends/sql/compilers/risingwave.py
+++ b/ibis/backends/sql/compilers/risingwave.py
@@ -85,6 +85,11 @@ class RisingWaveCompiler(PostgresCompiler):
     def visit_DateNow(self, op):
         return self.cast(sge.CurrentTimestamp(), dt.date)
 
+    def visit_Log(self, op, *, arg, base):
+        if op.base is None:
+            return self.f.ln(arg)
+        return super().visit_Log(op, arg=arg, base=base)
+
     def visit_Cast(self, op, *, arg, to):
         if to.is_json():
             return self.f.to_jsonb(arg)

--- a/ibis/backends/sql/compilers/snowflake.py
+++ b/ibis/backends/sql/compilers/snowflake.py
@@ -382,6 +382,8 @@ $$""",
         )
 
     def visit_Log(self, op, *, arg, base):
+        if op.base is None:
+            return self.f.ln(arg)
         return self.f.log(base, arg)
 
     def visit_RandomScalar(self, op):

--- a/ibis/backends/sql/compilers/sqlite.py
+++ b/ibis/backends/sql/compilers/sqlite.py
@@ -99,7 +99,7 @@ class SQLiteCompiler(SQLGlotCompiler):
 
     def visit_Log(self, op, *, arg, base):
         func = self.f.anon.log
-        if base is None:
+        if op.base is None:
             base = math.e
         return func(base, arg)
 

--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -415,6 +415,8 @@ class TrinoCompiler(SQLGlotCompiler):
             return None
 
     def visit_Log(self, op, *, arg, base):
+        if op.base is None:
+            return self.f.ln(arg)
         return self.f.log(base, arg)
 
     def visit_MapGet(self, op, *, arg, key, default):

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -821,6 +821,11 @@ def test_isnan_isinf(
             ],
         ),
         param(
+            L(5.556).log(),
+            math.log(5.556),
+            id="log-natural",
+        ),
+        param(
             L(5.556).ln(),
             math.log(5.556),
             id="ln",


### PR DESCRIPTION
## Description of changes

Fixes `.log()` without an explicit base so it is treated as natural log instead of passing a missing base through as `NULL`.

The issue is visible in Snowflake SQL generation, where `table.value.log()` compiled to `LOG(NULL, value)`, and in Polars execution, where the result came back as `NaN`. This change checks the original operation (`op.base`) when deciding whether a base was provided, instead of relying on the already-translated backend argument.

This also updates the Polars compiler to call `arg.log()` for the natural-log case and adds focused regression coverage for Snowflake SQL generation and Polars execution.

## Issues closed

* Resolves #11997

## Testing

```sh
.\.venv\Scripts\pytest ibis\backends\snowflake\tests\test_compiler.py::test_log_without_base_uses_natural_log
# 1 passed

.\.venv\Scripts\pytest ibis\backends\polars\tests\test_client.py::test_log_without_base_uses_natural_log
# 1 passed

.\.venv\Scripts\ruff format --check ibis\backends\polars\compiler.py ibis\backends\polars\tests\test_client.py ibis\backends\sql\compilers\bigquery\__init__.py ibis\backends\sql\compilers\impala.py ibis\backends\sql\compilers\mssql.py ibis\backends\sql\compilers\oracle.py ibis\backends\sql\compilers\postgres.py ibis\backends\sql\compilers\snowflake.py ibis\backends\sql\compilers\sqlite.py ibis\backends\sql\compilers\trino.py ibis\backends\tests\test_numeric.py ibis\backends\snowflake\tests\test_compiler.py
# 12 files already formatted

.\.venv\Scripts\ruff check ibis\backends\polars\compiler.py ibis\backends\polars\tests\test_client.py ibis\backends\sql\compilers\bigquery\__init__.py ibis\backends\sql\compilers\impala.py ibis\backends\sql\compilers\mssql.py ibis\backends\sql\compilers\oracle.py ibis\backends\sql\compilers\postgres.py ibis\backends\sql\compilers\snowflake.py ibis\backends\sql\compilers\sqlite.py ibis\backends\sql\compilers\trino.py ibis\backends\tests\test_numeric.py ibis\backends\snowflake\tests\test_compiler.py
# All checks passed

git diff --check
# clean
```