### PR TITLE
feat(snowflake): support VECTOR type via Array(length=N)

### DIFF
--- a/ibis/backends/snowflake/converter.py
+++ b/ibis/backends/snowflake/converter.py
@@ -110,6 +110,16 @@ else:
 
         @classmethod
         def convert_column(cls, column: pa.Array, dtype: dt.DataType) -> pa.Array:
+            # Fixed-length numeric arrays (e.g. Snowflake VECTOR(FLOAT, N))
+            # deserialize natively to pyarrow ``fixed_size_list<element>[N]``
+            # via the Snowflake Python connector. They are not JSON-encoded
+            # and so should bypass the JSON-extension wrapping below; without
+            # this guard, the JSON-extension path tries to cast the
+            # ``fixed_size_list`` column to ``utf8`` and raises
+            # ``ArrowNotImplementedError: Unsupported cast from
+            # fixed_size_list<...> to utf8``.
+            if dtype.is_array() and dtype.length is not None:
+                return column
             if (
                 dtype.is_json()
                 or dtype.is_array()
@@ -124,6 +134,11 @@ else:
 
         @classmethod
         def convert_scalar(cls, scalar: pa.Scalar, dtype: dt.DataType) -> pa.Scalar:
+            # Same fixed-size-list pass-through as ``convert_column``: VECTOR
+            # scalars are already native fixed-length pyarrow lists and
+            # don't need the JSON-string extension wrap.
+            if dtype.is_array() and dtype.length is not None:
+                return scalar
             if (
                 dtype.is_json()
                 or dtype.is_array()

--- a/ibis/backends/snowflake/tests/test_datatypes.py
+++ b/ibis/backends/snowflake/tests/test_datatypes.py
@@ -24,6 +24,14 @@ dtypes = [
     ("BINARY", dt.binary),
     ("TIME", dt.time),
     ("BOOLEAN", dt.boolean),
+    # VECTOR(<element>, <dimension>): fixed-length numeric vectors.
+    # https://docs.snowflake.com/en/sql-reference/data-types-vector
+    # FLOAT/INT inside VECTOR are documented as 32-bit, so the element
+    # type narrows to Float32/Int32 even though scalar Snowflake FLOAT
+    # otherwise resolves to Float64.
+    ("VECTOR(FLOAT, 4)", dt.Array(dt.Float32(nullable=False), length=4)),
+    ("VECTOR(FLOAT, 512)", dt.Array(dt.Float32(nullable=False), length=512)),
+    ("VECTOR(INT, 8)", dt.Array(dt.Int32(nullable=False), length=8)),
 ]
 
 
@@ -78,6 +86,11 @@ user_dtypes = [
     ("VARIANT", dt.json),
     ("OBJECT", dt.Map(dt.string, dt.json)),
     ("ARRAY", dt.Array(dt.json)),
+    # VECTOR round-trip via CREATE TEMP TABLE: exercises the full path
+    # from Snowflake's information-schema-style metadata back through
+    # ``SnowflakeType.from_string``.
+    ("VECTOR(FLOAT, 4)", dt.Array(dt.Float32(nullable=False), length=4)),
+    ("VECTOR(INT, 8)", dt.Array(dt.Int32(nullable=False), length=8)),
 ]
 
 
@@ -121,6 +134,39 @@ def test_extract_timestamp_from_table(con, snowflake_type, ibis_type):
 
     t = con.table(name)
     assert t.schema() == expected_schema
+
+
+def test_vector_column_pyarrow_passthrough_for_fixed_size_arrays():
+    """``SnowflakePyArrowData.convert_column`` must pass fixed-length array
+    columns through unchanged.
+
+    Snowflake's VECTOR(<element>, <dimension>) deserializes natively to
+    pyarrow ``fixed_size_list<element>[length]`` via the Snowflake Python
+    connector. Without the fixed-size-list pass-through, the converter
+    routes the column through the JSON-extension wrapping path -- which
+    raises ``ArrowNotImplementedError: Unsupported cast from
+    fixed_size_list<...> to utf8`` because the storage type of
+    ``PYARROW_JSON_TYPE`` is ``utf8``.
+
+    This test exercises the converter directly with a synthetic
+    fixed-size-list pyarrow column and the matching
+    ``Array(Float32, length=N)`` ibis dtype, so it runs without any
+    Snowflake connection.
+    """
+    import pyarrow as pa
+
+    from ibis.backends.snowflake.converter import SnowflakePyArrowData
+
+    column = pa.array(
+        [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]],
+        type=pa.list_(pa.float32(), list_size=4),
+    )
+    dtype = dt.Array(dt.Float32(nullable=False), length=4)
+
+    result = SnowflakePyArrowData.convert_column(column, dtype)
+
+    assert result is column, "fixed-size-list columns should pass through unchanged"
+    assert result.to_pylist() == [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]
 
 
 def test_array_discovery(con):

--- a/ibis/backends/snowflake/tests/test_datatypes.py
+++ b/ibis/backends/snowflake/tests/test_datatypes.py
@@ -24,6 +24,14 @@ dtypes = [
     ("BINARY", dt.binary),
     ("TIME", dt.time),
     ("BOOLEAN", dt.boolean),
+    # VECTOR(<element>, <dimension>): fixed-length numeric vectors.
+    # https://docs.snowflake.com/en/sql-reference/data-types-vector
+    # FLOAT/INT inside VECTOR are documented as 32-bit, so the element
+    # type narrows to Float32/Int32 even though scalar Snowflake FLOAT
+    # otherwise resolves to Float64.
+    ("VECTOR(FLOAT, 4)", dt.Array(dt.Float32(nullable=False), length=4)),
+    ("VECTOR(FLOAT, 512)", dt.Array(dt.Float32(nullable=False), length=512)),
+    ("VECTOR(INT, 8)", dt.Array(dt.Int32(nullable=False), length=8)),
 ]
 
 
@@ -78,6 +86,11 @@ user_dtypes = [
     ("VARIANT", dt.json),
     ("OBJECT", dt.Map(dt.string, dt.json)),
     ("ARRAY", dt.Array(dt.json)),
+    # VECTOR round-trip via CREATE TEMP TABLE: exercises the full path
+    # from Snowflake's information-schema-style metadata back through
+    # ``SnowflakeType.from_string``.
+    ("VECTOR(FLOAT, 4)", dt.Array(dt.Float32(nullable=False), length=4)),
+    ("VECTOR(INT, 8)", dt.Array(dt.Int32(nullable=False), length=8)),
 ]
 
 
@@ -121,6 +134,116 @@ def test_extract_timestamp_from_table(con, snowflake_type, ibis_type):
 
     t = con.table(name)
     assert t.schema() == expected_schema
+
+
+compiled_vector_dtypes = [
+    param(dt.Array(dt.Float32(nullable=False), length=4), "VECTOR(FLOAT, 4)", id="f32"),
+    param(dt.Array(dt.Int32(nullable=False), length=8), "VECTOR(INT, 8)", id="i32"),
+    # Snowflake VECTOR elements are 32-bit only, so wider element types narrow.
+    param(dt.Array(dt.float64, length=3), "VECTOR(FLOAT, 3)", id="f64-narrows"),
+    param(dt.Array(dt.int64, length=3), "VECTOR(INT, 3)", id="i64-narrows"),
+]
+
+
+@pytest.mark.parametrize(("ibis_type", "snowflake_type"), compiled_vector_dtypes)
+def test_compile_fixed_length_numeric_array_to_vector(ibis_type, snowflake_type):
+    """Fixed-length numeric arrays compile back to VECTOR.
+
+    The parse direction is covered by ``test_parse``; this is the other half, and
+    unlike ``test_extract_type_from_table_query`` it needs no Snowflake connection.
+
+    Note the last two cases: VECTOR only has 32-bit element types, so a 64-bit element
+    narrows rather than erroring. That is the only way to express such an array in
+    Snowflake at all, but it is silent, so it is pinned here deliberately.
+    """
+    assert SnowflakeType.to_string(ibis_type) == snowflake_type
+
+
+non_vector_dtypes = [
+    param(dt.Array(dt.string), id="variable-length-string"),
+    param(dt.Array(dt.float32), id="variable-length-float"),
+    param(dt.Array(dt.string, length=4), id="fixed-length-string"),
+    param(dt.Array(dt.Struct({"a": dt.int64}), length=2), id="fixed-length-struct"),
+    param(dt.Array(dt.Array(dt.int64), length=2), id="fixed-length-nested-array"),
+]
+
+
+@pytest.mark.parametrize("ibis_type", non_vector_dtypes)
+def test_non_numeric_and_variable_length_arrays_still_compile_to_array(ibis_type):
+    """Only fixed-length *numeric* arrays may become VECTOR.
+
+    Snowflake's VECTOR accepts INT and FLOAT elements only, so emitting VECTOR for a
+    fixed-length array of any other element type would produce invalid DDL. Variable-
+    length arrays must keep compiling to the existing JSON-backed ARRAY.
+    """
+    assert SnowflakeType.to_string(ibis_type) == "ARRAY"
+
+
+def test_vector_with_non_numeric_element_falls_back_to_the_default_mapping():
+    """A VECTOR whose element is neither INT nor FLOAT uses the ordinary scalar mapping.
+
+    Snowflake will not produce one -- VECTOR is documented as INT or FLOAT only -- so
+    this is the defensive branch of the parser rather than a shape seen in the wild.
+
+    It is deliberately not round-trippable: the result compiles back to ARRAY, not
+    VECTOR, because Snowflake has no way to express a fixed-length string vector.
+    """
+    parsed = SnowflakeType.from_string("VECTOR(VARCHAR, 4)")
+
+    assert parsed == dt.Array(dt.string, length=4)
+    assert SnowflakeType.to_string(parsed) == "ARRAY"
+
+
+def test_vector_scalar_pyarrow_passthrough_for_fixed_size_arrays():
+    """``convert_scalar`` needs the same guard as ``convert_column``.
+
+    A single VECTOR value arrives as a native fixed-length pyarrow scalar, so routing it
+    through the JSON-extension wrap fails the same way the column path did.
+    """
+    import pyarrow as pa
+
+    from ibis.backends.snowflake.converter import SnowflakePyArrowData
+
+    scalar = pa.scalar([1.0, 2.0, 3.0, 4.0], type=pa.list_(pa.float32(), list_size=4))
+    dtype = dt.Array(dt.Float32(nullable=False), length=4)
+
+    result = SnowflakePyArrowData.convert_scalar(scalar, dtype)
+
+    assert result is scalar, "fixed-size-list scalars should pass through unchanged"
+    assert result.as_py() == [1.0, 2.0, 3.0, 4.0]
+
+
+def test_vector_column_pyarrow_passthrough_for_fixed_size_arrays():
+    """``SnowflakePyArrowData.convert_column`` must pass fixed-length array
+    columns through unchanged.
+
+    Snowflake's VECTOR(<element>, <dimension>) deserializes natively to
+    pyarrow ``fixed_size_list<element>[length]`` via the Snowflake Python
+    connector. Without the fixed-size-list pass-through, the converter
+    routes the column through the JSON-extension wrapping path -- which
+    raises ``ArrowNotImplementedError: Unsupported cast from
+    fixed_size_list<...> to utf8`` because the storage type of
+    ``PYARROW_JSON_TYPE`` is ``utf8``.
+
+    This test exercises the converter directly with a synthetic
+    fixed-size-list pyarrow column and the matching
+    ``Array(Float32, length=N)`` ibis dtype, so it runs without any
+    Snowflake connection.
+    """
+    import pyarrow as pa
+
+    from ibis.backends.snowflake.converter import SnowflakePyArrowData
+
+    column = pa.array(
+        [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]],
+        type=pa.list_(pa.float32(), list_size=4),
+    )
+    dtype = dt.Array(dt.Float32(nullable=False), length=4)
+
+    result = SnowflakePyArrowData.convert_column(column, dtype)
+
+    assert result is column, "fixed-size-list columns should pass through unchanged"
+    assert result.to_pylist() == [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]
 
 
 def test_array_discovery(con):

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -929,11 +929,61 @@ class SnowflakeType(SqlglotType):
         return dt.Array(dt.json, nullable=nullable)
 
     @classmethod
+    def _from_sqlglot_VECTOR(
+        cls,
+        value_type: sge.DataType,
+        length: sge.DataTypeParam,
+        nullable: bool | None = None,
+    ) -> dt.Array:
+        # Snowflake VECTOR(<element>, <dimension>) stores fixed-length numeric
+        # vectors. Element types are documented at
+        # https://docs.snowflake.com/en/sql-reference/data-types-vector:
+        #   - INT   -> 32-bit signed integer
+        #   - FLOAT -> 32-bit single-precision floating-point
+        #
+        # sqlglot normalizes Snowflake's VECTOR-element FLOAT to Type.DOUBLE
+        # in its parsed DataType AST, so we don't fall back to
+        # ``cls.to_ibis(value_type)`` for FLOAT/INT here -- that would
+        # resolve to Float64/Int64 via the default scalar mappings.
+        # Underlying VECTOR elements are also not null per Snowflake's
+        # storage model, hence ``nullable=False`` on the inner dtype.
+        type_name = value_type.this.name
+        if type_name in ("FLOAT", "DOUBLE"):
+            element_type: dt.DataType = dt.Float32(nullable=False)
+        elif type_name in ("INT", "BIGINT", "INTEGER", "SMALLINT", "TINYINT"):
+            element_type = dt.Int32(nullable=False)
+        else:
+            element_type = cls.to_ibis(value_type)
+        return dt.Array(
+            element_type,
+            length=int(length.this.this),
+            nullable=nullable,
+        )
+
+    @classmethod
     def _from_ibis_JSON(cls, dtype: dt.JSON) -> sge.DataType:
         return sge.DataType(this=typecode.VARIANT)
 
     @classmethod
     def _from_ibis_Array(cls, dtype: dt.Array) -> sge.DataType:
+        if dtype.length is not None and (
+            dtype.value_type.is_floating() or dtype.value_type.is_integer()
+        ):
+            # Fixed-length numeric arrays round-trip to Snowflake VECTOR.
+            # ``VECTOR(<element>, <dimension>)`` only accepts INT or FLOAT
+            # elements (mapped from the inner ibis dtype below); other
+            # element types fall back to ARRAY (variable-length JSON-backed).
+            element_typecode = (
+                typecode.FLOAT if dtype.value_type.is_floating() else typecode.INT
+            )
+            return sge.DataType(
+                this=typecode.VECTOR,
+                expressions=[
+                    sge.DataType(this=element_typecode, nested=False),
+                    sge.DataTypeParam(this=sge.Literal.number(dtype.length)),
+                ],
+                nested=False,
+            )
         return sge.DataType(this=typecode.ARRAY, nested=True)
 
     @classmethod


### PR DESCRIPTION
## Summary

Snowflake's [`VECTOR(<element>, <dimension>)`](https://docs.snowflake.com/en/sql-reference/data-types-vector) type stores fixed-length numeric vectors used by AI/ML workloads. The Snowflake Python connector already deserializes VECTOR columns to native pyarrow `fixed_size_list<element>[length]`, but ibis had no VECTOR -> ibis dtype mapping, so the column came back typed as `utf8` (via the `Unknown -> string` fallback) and `SnowflakePyArrowData.convert_column` crashed downstream with:

```
pyarrow.lib.ArrowNotImplementedError: Unsupported cast from
fixed_size_list<element: float not null>[N] to utf8 using function cast_string
```

This PR adds three pieces:

1. **`SnowflakeType._from_sqlglot_VECTOR`** parses Snowflake VECTOR into `dt.Array(<element>, length=<dimension>)`. Per the Snowflake docs, element types are 32-bit (`INT` -> 32-bit signed integer, `FLOAT` -> 32-bit single-precision floating-point). sqlglot normalizes the VECTOR-element FLOAT to `Type.DOUBLE` in its DataType AST, so we narrow to `Float32`/`Int32` rather than falling back to the default scalar mappings (which would give Float64/Int64). VECTOR elements are also not nullable per Snowflake's storage model, hence `nullable=False` on the inner dtype.

2. **`SnowflakePyArrowData.convert_column` / `convert_scalar`** now pass fixed-length array columns through unchanged. Without this guard, the JSON-extension wrapping path tries to cast the `fixed_size_list<...>` data to `utf8` (the storage type of `PYARROW_JSON_TYPE`) and raises `ArrowNotImplementedError`.

3. **`SnowflakeType._from_ibis_Array`** round-trips fixed-length numeric Arrays back to `VECTOR(<element>, <dimension>)`. Other fixed-length element types (e.g. strings, structs) and variable-length arrays continue to compile to `ARRAY` (the existing JSON-backed variant-array).

## Test plan

* `ibis/backends/snowflake/tests/test_datatypes.py::test_parse` adds three parametrized VECTOR cases (`VECTOR(FLOAT, 4)`, `VECTOR(FLOAT, 512)`, `VECTOR(INT, 8)`).
* `test_extract_type_from_table_query` adds two parametrized VECTOR cases that round-trip through a live Snowflake `CREATE TEMP TABLE`.
* New `test_vector_column_pyarrow_passthrough_for_fixed_size_arrays` exercises the converter directly with a synthetic pyarrow `fixed_size_list<float32>[4]` column -- no Snowflake connection needed -- and asserts both pass-through identity and value preservation.

Locally:

```
$ pytest ibis/backends/snowflake/tests/test_datatypes.py -v -k "test_parse or test_vector_column_pyarrow"
======================== 18 passed in 0.05s =========================
```

(The `test_extract_type_from_table_query` parametrized cases are gated on a live Snowflake connection and will run in CI.)

## Notes

* Same pattern shape as the previous Snowflake compiler PR I shipped a few months ago, [#11940](https://github.com/ibis-project/ibis/pull/11940) (which added `visit_HexDigest` for `SHA2/MD5`).
* Discovered while exercising a real PROD Snowflake table with a `VECTOR(FLOAT, 512)` column (an embedding store) through `ibis.snowflake.to_polars()`.

Made with Cursor

Made with [Cursor](https://cursor.com)