### PR TITLE
fix(backends): handle single-digit month/day in pyspark to_date

### DIFF
--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -440,6 +440,14 @@ class PySparkCompiler(SQLGlotCompiler):
             arg = sge.Distinct(expressions=[arg])
         return self.agg.array_agg(arg, order_by=order_by)
 
+    def visit_StringToDate(self, op, *, arg, format_str):
+        # Remap %m/%d to %-m/%-d so sqlglot emits Spark's M/d (lenient)
+        # instead of MM/dd (strict 2-digit), allowing single-digit values.
+        if isinstance(format_str, sge.Literal) and "%" in format_str.this:
+            fmt = format_str.this.replace("%m", "%-m").replace("%d", "%-d")
+            format_str = sge.Literal.string(fmt)
+        return sge.StrToDate(this=arg, format=format_str)
+
     def visit_StringFind(self, op, *, arg, substr, start, end):
         if end is not None:
             raise com.UnsupportedOperationError(

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -444,14 +444,6 @@ class PySparkCompiler(SQLGlotCompiler):
             arg = sge.Distinct(expressions=[arg])
         return self.agg.array_agg(arg, order_by=order_by)
 
-    def visit_StringToDate(self, op, *, arg, format_str):
-        # Remap %m/%d to %-m/%-d so sqlglot emits Spark's M/d (lenient)
-        # instead of MM/dd (strict 2-digit), allowing single-digit values.
-        if isinstance(format_str, sge.Literal) and "%" in format_str.this:
-            fmt = format_str.this.replace("%m", "%-m").replace("%d", "%-d")
-            format_str = sge.Literal.string(fmt)
-        return sge.StrToDate(this=arg, format=format_str)
-
     def visit_Strip(self, op, *, arg):
         return self.f.trim(arg, self.f.concat(string.whitespace[:-2], VT, FF))
 

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1411,13 +1411,27 @@ def test_string_as_date(alltypes, fmt):
         assert val.strftime("%m/%d/%y") == result["date_string_col"][i]
 
 
-@pytest.mark.pyspark
-def test_string_as_date_single_digit_pyspark(con):
-    # Regression test for https://github.com/ibis-project/ibis/issues/12004
-    # Spark's MM/dd require leading zeros; M/d accept single-digit values.
-    t = con.sql("SELECT '1/1/2026' AS raw_date")
-    result = t.mutate(parsed=t.raw_date.as_date("%m/%d/%Y")).execute()
-    assert result["parsed"][0].date() == datetime.date(2026, 1, 1)
+@pytest.mark.notyet(
+    ["materialize"],
+    raises=PsycoPgInternalError,
+    reason="Materialize doesn't have to_date() function - backend limitation",
+)
+@pytest.mark.notimpl(
+    ["clickhouse", "sqlite", "datafusion", "mssql", "druid"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(
+    ["flink", "impala"],
+    raises=AssertionError,
+    reason="Java SimpleDateFormat MM/dd is strict; single-digit values return wrong results",
+)
+def test_string_as_date_single_digit(con):
+    expr = ibis.literal("1/1/2026").as_date("%m/%d/%Y")
+    result = con.execute(expr)
+    if isinstance(result, datetime.datetime):
+        result = result.date()
+    assert result == datetime.date(2026, 1, 1)
 
 
 @pytest.mark.notyet(

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1411,6 +1411,15 @@ def test_string_as_date(alltypes, fmt):
         assert val.strftime("%m/%d/%y") == result["date_string_col"][i]
 
 
+@pytest.mark.pyspark
+def test_string_as_date_single_digit_pyspark(con):
+    # Regression test for https://github.com/ibis-project/ibis/issues/12004
+    # Spark's MM/dd require leading zeros; M/d accept single-digit values.
+    t = con.sql("SELECT '1/1/2026' AS raw_date")
+    result = t.mutate(parsed=t.raw_date.as_date("%m/%d/%Y")).execute()
+    assert result["parsed"][0].date() == datetime.date(2026, 1, 1)
+
+
 @pytest.mark.notyet(
     [
         "pyspark",


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->
Spark's TO_DATE uses Java SimpleDateFormat where MM/dd require leading zeros, so dates like 1/1/2026 with format %m/%d/%Y return NaT.

Remapping %m/%d to %-m/%-d before sqlglot's format conversion produces Spark's M/d, which accepts both 1 and 2 digit values.

## Issues closed

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
Resolves #12004