### PR TITLE
fix(types): annotate table cache as cached table

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -4130,7 +4130,7 @@ class Table(Expr, FixedTextJupyterMixin):
         """
         return self.execute(params=params, limit=limit, **kwargs)
 
-    def cache(self) -> Table:
+    def cache(self) -> "CachedTable":
         """Cache the provided expression.
 
         All subsequent operations on the returned expression will be performed

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pickle
 import re
+from typing import get_type_hints
 
 import pytest
 from pytest import param
@@ -20,7 +21,7 @@ from ibis.common.exceptions import ExpressionError, IntegrityError, RelationErro
 from ibis.expr import api
 from ibis.expr.rewrites import simplify
 from ibis.expr.tests.test_newrels import join_tables
-from ibis.expr.types import Column, Table
+from ibis.expr.types import CachedTable, Column, Table
 from ibis.tests.util import assert_equal, assert_pickle_roundtrip
 
 
@@ -52,6 +53,10 @@ def setops_table_baz(set_ops_schema_bottom):
 @pytest.fixture
 def setops_relation_error_message():
     return "Table schemas must be equal for set operations"
+
+
+def test_cache_return_annotation():
+    assert get_type_hints(Table.cache)["return"] is CachedTable
 
 
 def test_empty_schema():


### PR DESCRIPTION
## Summary

This updates the `Table.cache()` return annotation so type resolution points to `CachedTable`.

`CachedTable` is defined later in the module, so the annotation needs to remain a forward reference. The added regression test resolves the type hint and verifies that it points to `CachedTable`.

Fixes #11920

## Testing

```console
$ pytest ibis/tests/expr/test_table.py -k cache_return_annotation -q
.                                                                        [100%]
1 passed, 201 deselected in 0.97s
```
