### PR TITLE
fix(impala): accept username alias

### DIFF
--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -103,6 +103,7 @@ class Backend(SQLBackend, HasCurrentDatabase, NoExampleLoader):
         use_ssl: bool = False,
         ca_cert: str | Path | None = None,
         user: str | None = None,
+        username: str | None = None,
         password: str | None = None,
         auth_mechanism: Literal["NOSASL", "PLAIN", "GSSAPI", "LDAP"] = "NOSASL",
         kerberos_service_name: str = "impala",
@@ -128,6 +129,8 @@ class Backend(SQLBackend, HasCurrentDatabase, NoExampleLoader):
             this argument is `None`, then certificate validation is skipped.
         user
             LDAP user to authenticate
+        username
+            Alias for `user`
         password
             LDAP password to authenticate
         auth_mechanism
@@ -157,6 +160,8 @@ class Backend(SQLBackend, HasCurrentDatabase, NoExampleLoader):
         """
         if ca_cert is not None:
             params["ca_cert"] = str(ca_cert)
+        if user is None:
+            user = username
 
         # make sure the connection works
         con = impyla.connect(

--- a/ibis/backends/impala/tests/test_client.py
+++ b/ibis/backends/impala/tests/test_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 from contextlib import closing
+from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
@@ -13,6 +14,20 @@ from ibis.tests.util import assert_equal
 
 pytest.importorskip("impala")
 thrift = pytest.importorskip("thrift")
+
+
+def test_connect_accepts_username_alias():
+    with patch("ibis.backends.impala.impyla.connect") as connect:
+        connection = connect.return_value
+        cursor = connection.cursor.return_value
+        cursor.__enter__ = Mock(return_value=cursor)
+        cursor.__exit__ = Mock(return_value=None)
+
+        ibis.impala.connect(host="example.com", username="user", password="pass")
+
+    connect.assert_called_once()
+    assert connect.call_args.kwargs["user"] == "user"
+    assert connect.call_args.kwargs["password"] == "pass"
 
 
 def test_run_sql(con, test_data_db):


### PR DESCRIPTION
## Summary

This lets the Impala backend accept `username` as an alias for `user` when connecting.

The backend still passes the value through to impyla as `user`, matching the parameter expected by the underlying client. If both `user` and `username` are provided, the explicit `user` value keeps precedence.

Fixes #11774

## Testing

```console
$ pytest ibis/backends/impala/tests/test_client.py -k username_alias -q
.                                                                        [100%]
1 passed, 22 deselected in 0.58s
```
