### PR TITLE
fix(expr): dispatch deferred reverse literal ops

### DIFF
--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -3185,7 +3185,7 @@ def _binop(op_class: type[ops.Value], left: Value | Any, right: Value | Any) -> 
     assert issubclass(op_class, ops.Value)
     try:
         node = op_class(left, right)
-    except (ValidationError, NotImplementedError):
+    except (ValidationError, NotImplementedError, com.InputTypeError):
         return NotImplemented
     else:
         return node.to_expr()

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -8,6 +8,7 @@ from public import public
 
 import ibis.expr.operations as ops
 from ibis import util
+from ibis.common.annotations import ValidationError
 from ibis.expr.types.generic import Column, Scalar, Value, _binop
 
 if TYPE_CHECKING:
@@ -1654,7 +1655,10 @@ class StringValue(Value):
         │ bcabca               │
         └──────────────────────┘
         """
-        return self.concat(other)
+        try:
+            return self.concat(other)
+        except ValidationError:
+            return NotImplemented
 
     def __radd__(self, other: str | StringValue | Deferred) -> StringValue:
         """Concatenate strings.

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -693,6 +693,24 @@ def test_chained_comparisons_not_allowed(table):
         0 < table.f < 1  # noqa: B015
 
 
+def test_deferred_reverse_numeric_literal_arithmetic():
+    table = ibis.table({"value": "int64"})
+
+    expr = table.select(result=ibis.literal(5) + _["value"])
+    expected = table.select(result=ibis.literal(5) + table.value)
+
+    assert_equal(expr, expected)
+
+
+def test_deferred_reverse_string_literal_concat():
+    table = ibis.table({"value": "string"})
+
+    expr = table.select(result=ibis.literal("prefix-") + _["value"])
+    expected = table.select(result=ibis.literal("prefix-") + table.value)
+
+    assert_equal(expr, expected)
+
+
 @pytest.mark.parametrize(
     "operation",
     [operator.add, operator.sub, operator.truediv],


### PR DESCRIPTION
## Summary

This fixes deferred expressions when a literal is on the left side of an operation and a deferred column reference is on the right side.

For numeric operations, `_binop` now returns `NotImplemented` for unresolved deferred input type errors so Python can dispatch to the deferred reverse operator. String concatenation follows the same pattern for validation failures in `StringValue.__add__`.

Fixes #11742

## Testing

```console
$ pytest ibis/tests/expr/test_value_exprs.py -k "deferred_reverse" -q
..                                                                       [100%]
2 passed, 725 deselected in 1.07s
```

```console
$ pytest ibis/tests/expr/test_value_exprs.py -k "deferred_reverse or binop_string_type_error" -q
ibis/tests/expr/test_value_exprs.py ..                                   [100%]
2 passed, 725 deselected in 0.81s
```
