### PR TITLE
chore(athena): add Ibis to the user agent string

### DIFF
--- a/ibis/backends/athena/__init__.py
+++ b/ibis/backends/athena/__init__.py
@@ -338,6 +338,17 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
         **config: Any,
     ) -> None:
         """Create an Ibis client connected to an Amazon Athena instance."""
+        from botocore.config import Config
+
+        # advertise Ibis in the user agent sent to AWS, preserving any
+        # user-supplied botocore Config and its existing user_agent_extra
+        boto_config = config.get("config") or Config()
+        config["config"] = boto_config.merge(
+            Config(
+                user_agent_extra=f"ibis/{ibis.__version__} {boto_config.user_agent_extra or ''}".strip()
+            )
+        )
+
         self.con = pyathena.connect(
             s3_staging_dir=s3_staging_dir,
             cursor_class=cursor_class,

--- a/ibis/backends/athena/tests/test_client.py
+++ b/ibis/backends/athena/tests/test_client.py
@@ -7,6 +7,54 @@ from ibis.backends.tests.errors import PyAthenaOperationalError
 from ibis.util import gen_name
 
 
+@pytest.fixture
+def mock_connect(mocker):
+    """Patch out ``pyathena.connect`` and return the captured mock.
+
+    The mocked connection's cursor is wired up so the queries ``do_connect``
+    issues after connecting (``current_catalog``/``current_database``) succeed,
+    and ``fsspec`` is patched so no real S3 filesystem is created.
+    """
+    connect = mocker.patch.object(ibis.backends.athena.pyathena, "connect")
+    cursor = connect.return_value.cursor.return_value.__enter__.return_value
+    cursor.execute.return_value.fetchall.return_value = [("value",)]
+
+    mocker.patch.object(ibis.backends.athena.fsspec, "filesystem")
+    return connect
+
+
+def test_user_agent_set_by_default(mock_connect):
+    ibis.athena.connect(s3_staging_dir="s3://bucket/staging")
+
+    _, kwargs = mock_connect.call_args
+    assert kwargs["config"].user_agent_extra == f"ibis/{ibis.__version__}"
+
+
+def test_user_agent_prepended_to_user_supplied(mock_connect):
+    from botocore.config import Config
+
+    ibis.athena.connect(
+        s3_staging_dir="s3://bucket/staging",
+        config=Config(user_agent_extra="myapp/1.0"),
+    )
+
+    _, kwargs = mock_connect.call_args
+    assert kwargs["config"].user_agent_extra == f"ibis/{ibis.__version__} myapp/1.0"
+
+
+def test_user_agent_preserves_other_config(mock_connect):
+    from botocore.config import Config
+
+    ibis.athena.connect(
+        s3_staging_dir="s3://bucket/staging",
+        config=Config(region_name="us-east-1"),
+    )
+
+    _, kwargs = mock_connect.call_args
+    assert kwargs["config"].region_name == "us-east-1"
+    assert kwargs["config"].user_agent_extra == f"ibis/{ibis.__version__}"
+
+
 def test_create_and_drop_database(con):
     name = gen_name("db")
 


### PR DESCRIPTION
## Description of changes

This adds `ibis/<version>` to the user agent string sent when an Athena query is run through PyAthena.

The motivation for this is that it allows us in the Amazon Athena team to do internal reporting on integrations. We already break down usage by PyAthena, but would also like to break that usage down further and understand the popularity of Ibis.