### PR TITLE
docs(athena): fix pyathena link and use everywhere

### DIFF
--- a/docs/backends/athena.qmd
+++ b/docs/backends/athena.qmd
@@ -27,8 +27,8 @@ con = ibis.athena.connect(s3_staging_dir="s3://...")  # <1>
 ::: {.callout-note}
 ## At a **minimum**, the `s3_staging_dir` argument must be provided.
 
-This argument tells the underlying driver library--`pyathena`--and ultimately
-Athena itself where to dump query results.
+This argument tells the underlying driver library, [`pyathena`](https://pyathena.dev/),
+and ultimately Athena itself where to dump query results.
 :::
 
 1. Adjust other connection parameters as needed.
@@ -50,8 +50,8 @@ con = ibis.athena.connect(s3_staging_dir="s3://...")  # <1>
 ::: {.callout-note}
 ## At a **minimum**, the `s3_staging_dir` argument must be provided.
 
-This argument tells the underlying driver library--`pyathena`--and ultimately
-Athena itself where to dump query results.
+This argument tells the underlying driver library, [`pyathena`](https://pyathena.dev/),
+and ultimately Athena itself where to dump query results.
 :::
 
 1. Adjust other connection parameters as needed.
@@ -73,8 +73,8 @@ con = ibis.athena.connect(s3_staging_dir="s3://my-bucket/")  # <1>
 ::: {.callout-note}
 ## At a **minimum**, the `s3_staging_dir` argument must be provided.
 
-This argument tells the underlying driver library--`pyathena`--and ultimately
-Athena itself where to dump query results.
+This argument tells the underlying driver library, [`pyathena`](https://pyathena.dev/),
+and ultimately Athena itself where to dump query results.
 :::
 
 1. Adjust other connection parameters as needed.
@@ -94,9 +94,8 @@ con = ibis.athena.connect(
 ::: {.callout-note}
 ## At a **minimum**, the `s3_staging_dir` argument must be provided.
 
-This argument tells the underlying driver
-library--[`pyathena`](https://laughingman7743.github.io/PyAthena/)--and
-ultimately Athena itself where to dump query results.
+This argument tells the underlying driver library, [`pyathena`](https://pyathena.dev/),
+and ultimately Athena itself where to dump query results.
 :::
 
 ### Connection Parameters


### PR DESCRIPTION
## Description of changes

The PyAthena link was broken. It was also specified inconsistently, and the em dash didn't make sense to me grammatically (too dramatic; should be more parenthetical IMO).