### PR TITLE
fix(temporal): bump sqlglot to support M/d in date

### DIFF
--- a/docker/spark-connect/conf.properties
+++ b/docker/spark-connect/conf.properties
@@ -4,7 +4,6 @@ spark.sql.catalog.local.type=hadoop
 spark.sql.catalog.local.warehouse=warehouse
 spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog
 spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
-spark.sql.legacy.timeParserPolicy=LEGACY
 spark.sql.session.timeZone=UTC
 spark.sql.streaming.schemaInference=true
 spark.ui.enabled=false

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_cast_float_to_int/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_cast_float_to_int/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  CAST(trunc(`t0`.`double_col`) AS INT64) AS `Cast_double_col_int64`
+  CAST(TRUNC(`t0`.`double_col`) AS INT64) AS `Cast_double_col_int64`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/snapshots/test_sql/test_strftime_translates_python_format_codes/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_sql/test_strftime_translates_python_format_codes/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  FROM_UNIXTIME(UNIX_TIMESTAMP(CAST(`t0`.`timestamp_col` AS STRING)), 'MM/dd/yyyy') AS `Strftime(timestamp_col, '%m/%d/%Y')`
+FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/test_sql.py
+++ b/ibis/backends/impala/tests/test_sql.py
@@ -300,3 +300,10 @@ def test_group_by_with_window_preserves_range(snapshot):
 
     result = ibis.impala.compile(expr)
     snapshot.assert_match(result, "out.sql")
+
+
+# https://github.com/ibis-project/ibis/issues/12004
+def test_strftime_translates_python_format_codes(con, snapshot):
+    expr = con.table("functional_alltypes").timestamp_col.strftime("%m/%d/%Y")
+    result = ibis.to_sql(expr, dialect="impala")
+    snapshot.assert_match(result, "out.sql")

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -662,10 +662,7 @@ GO"""
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
 
-        properties = []
-
         if temp:
-            properties.append(sge.TemporaryProperty())
             catalog, db = None, None
 
         if obj is not None:
@@ -690,33 +687,23 @@ GO"""
 
         quoted = self.compiler.quoted
         raw_table = sg.table(temp_name, catalog=catalog, db=db, quoted=False)
+        # A global temporary table is identified by a `##` prefix on the name,
+        # not by a `TEMPORARY` property.
+        target_table = sg.table(
+            "##" * bool(temp) + temp_name, catalog=catalog, db=db, quoted=quoted
+        )
         target = sge.Schema(
-            this=sg.table(
-                "#" * bool(temp) + temp_name, catalog=catalog, db=db, quoted=quoted
-            ),
+            this=target_table,
             expressions=schema.to_sqlglot_column_defs(self.dialect),
         )
 
-        create_stmt = sge.Create(
-            kind="TABLE",
-            this=target,
-            properties=sge.Properties(expressions=properties),
-        )
+        create_stmt = sge.Create(kind="TABLE", this=target)
 
         this = sg.table(name, catalog=catalog, db=db, quoted=quoted)
         raw_this = sg.table(name, catalog=catalog, db=db, quoted=False)
         with self._safe_ddl(create_stmt) as cur:
             if query is not None:
-                # You can specify that a table is temporary for the sqlglot `Create` but not
-                # for the subsequent `Insert`, so we need to shove a `#` in
-                # front of the table identifier.
-                _table = sg.table(
-                    "##" * bool(temp) + temp_name,
-                    catalog=catalog,
-                    db=db,
-                    quoted=self.compiler.quoted,
-                )
-                insert_stmt = sge.Insert(this=_table, expression=query).sql(
+                insert_stmt = sge.Insert(this=target_table, expression=query).sql(
                     self.dialect
                 )
                 cur.execute(insert_stmt)

--- a/ibis/backends/sql/compilers/clickhouse.py
+++ b/ibis/backends/sql/compilers/clickhouse.py
@@ -627,7 +627,10 @@ class ClickHouseCompiler(SQLGlotCompiler):
 
         func = sge.Lambda(this=body, expressions=expressions)
 
-        return self.f.arrayMap(func, *args)
+        # ClickHouse's arrayMap takes a lambda plus a variable number of
+        # arrays, but sqlglot's generic ArrayMap expression caps it at two
+        # arguments; go through `anon` to bypass that arity check.
+        return self.f.anon.arrayMap(func, *args)
 
     def visit_ArrayFilter(self, op, *, arg, param, body, index):
         expressions = [param]
@@ -639,7 +642,8 @@ class ClickHouseCompiler(SQLGlotCompiler):
 
         func = sge.Lambda(this=body, expressions=expressions)
 
-        return self.f.arrayFilter(func, *args)
+        # Same arity issue as visit_ArrayMap: bypass via anon.
+        return self.f.anon.arrayFilter(func, *args)
 
     def visit_ArrayRemove(self, op, *, arg, other):
         x = sg.to_identifier(util.gen_name("x"))

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -235,7 +235,7 @@ class ImpalaCompiler(SQLGlotCompiler):
                 f"got: {type(op.format_str).__name__}"
             )
         format_str = sg.time.format_time(
-            op.format_str.value, {v: k for k, v in Impala.TIME_MAPPING.items()}
+            op.format_str.value, Impala.INVERSE_TIME_MAPPING, Impala.INVERSE_TIME_TRIE
         )
         return self.f.anon.from_unixtime(
             self.f.unix_timestamp(self.cast(arg, dt.string)), format_str

--- a/ibis/backends/sql/tests/test_datatypes.py
+++ b/ibis/backends/sql/tests/test_datatypes.py
@@ -131,5 +131,5 @@ def test_unknown_repr():
         sge.DataType(this=sge.DataType.Type.USERDEFINED, kind='"MySchema"."MyEnum"')
     )
     result = str(dtype)
-    expected = 'unknown(DataType(this=Type.USERDEFINED, kind="MySchema"."MyEnum"))'
+    expected = 'unknown(DataType(this=DType.USERDEFINED, kind="MySchema"."MyEnum"))'
     assert result == expected

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1331,10 +1331,9 @@ def test_integer_to_timestamp(backend, con, unit):
     reason="Materialize doesn't support to_timestamp(text, format) - backend limitation",
 )
 @pytest.mark.notimpl(
-    ["clickhouse", "sqlite", "datafusion", "mssql", "druid"],
+    ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
     raises=com.OperationNotDefinedError,
 )
-@pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError)
 def test_string_as_timestamp(alltypes, fmt):
     table = alltypes
     result = table.mutate(date=table.date_string_col.as_timestamp(fmt)).execute()
@@ -1422,10 +1421,9 @@ def test_string_as_timestamp_with_time(con):
     reason="Materialize doesn't have to_date() function - backend limitation",
 )
 @pytest.mark.notimpl(
-    ["clickhouse", "sqlite", "datafusion", "mssql", "druid"],
+    ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
     raises=com.OperationNotDefinedError,
 )
-@pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError)
 def test_string_as_date(alltypes, fmt):
     table = alltypes
     result = table.mutate(date=table.date_string_col.as_date(fmt)).execute()
@@ -1434,6 +1432,57 @@ def test_string_as_date(alltypes, fmt):
     # format string assumes that we are using pandas' strftime
     for i, val in enumerate(result["date"]):
         assert val.strftime("%m/%d/%y") == result["date_string_col"][i]
+
+
+# https://github.com/ibis-project/ibis/issues/12004
+@pytest.mark.notyet(
+    ["materialize"],
+    raises=PsycoPgInternalError,
+    reason="Materialize doesn't have to_date() function - backend limitation",
+)
+@pytest.mark.notimpl(
+    ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notyet(
+    ["flink"],
+    raises=AssertionError,
+    reason="Flink misinterprets strftime-style format strings, producing a wrong date",
+)
+def test_string_as_date_single_digit_month_day(con):
+    expr = ibis.literal("1/2/2021").as_date("%m/%d/%Y")
+    result = con.execute(expr)
+    expected = datetime.date(2021, 1, 2)
+    if isinstance(result, (pd.Timestamp, datetime.datetime)):
+        result = result.date()
+    assert result == expected
+
+
+# https://github.com/ibis-project/ibis/issues/12004
+@pytest.mark.notyet(
+    ["materialize"],
+    raises=PsycoPgInternalError,
+    reason="Materialize doesn't have to_date() function - backend limitation",
+)
+@pytest.mark.notimpl(
+    ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notyet(
+    ["flink"],
+    raises=AssertionError,
+    reason="Flink misinterprets strftime-style format strings, producing a wrong date",
+)
+def test_string_as_date_single_digit_month_day_column(con):
+    # con.sql() creates a column (not a literal), then .as_date() is applied.
+    t0 = con.sql("SELECT '1/1/2026' AS raw_date")
+    # Use t0.columns[0] to handle backends that uppercase column names (e.g. Oracle)
+    t1 = t0.mutate(parsed_date=t0[t0.columns[0]].as_date("%m/%d/%Y"))
+    result = t1.execute().at[0, "parsed_date"]
+    expected = datetime.date(2026, 1, 1)
+    if isinstance(result, (pd.Timestamp, datetime.datetime)):
+        result = result.date()
+    assert result == expected
 
 
 @pytest.mark.notyet(

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1434,55 +1434,43 @@ def test_string_as_date(alltypes, fmt):
         assert val.strftime("%m/%d/%y") == result["date_string_col"][i]
 
 
-# https://github.com/ibis-project/ibis/issues/12004
-@pytest.mark.notyet(
-    ["materialize"],
-    raises=PsycoPgInternalError,
-    reason="Materialize doesn't have to_date() function - backend limitation",
-)
-@pytest.mark.notimpl(
-    ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
-    raises=com.OperationNotDefinedError,
-)
-@pytest.mark.notyet(
-    ["flink"],
-    raises=AssertionError,
-    reason="Flink misinterprets strftime-style format strings, producing a wrong date",
-)
-def test_string_as_date_single_digit_month_day(con):
-    expr = ibis.literal("1/2/2021").as_date("%m/%d/%Y")
-    result = con.execute(expr)
-    expected = datetime.date(2021, 1, 2)
-    if isinstance(result, (pd.Timestamp, datetime.datetime)):
-        result = result.date()
-    assert result == expected
-
-
-# https://github.com/ibis-project/ibis/issues/12004
-@pytest.mark.notyet(
-    ["materialize"],
-    raises=PsycoPgInternalError,
-    reason="Materialize doesn't have to_date() function - backend limitation",
-)
-@pytest.mark.notimpl(
-    ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
-    raises=com.OperationNotDefinedError,
-)
-@pytest.mark.notyet(
-    ["flink"],
-    raises=AssertionError,
-    reason="Flink misinterprets strftime-style format strings, producing a wrong date",
-)
-def test_string_as_date_single_digit_month_day_column(con):
+def build_single_digit_date_col(con):
     # con.sql() creates a column (not a literal), then .as_date() is applied.
-    t0 = con.sql("SELECT '1/1/2026' AS raw_date")
-    # Use t0.columns[0] to handle backends that uppercase column names (e.g. Oracle)
-    t1 = t0.mutate(parsed_date=t0[t0.columns[0]].as_date("%m/%d/%Y"))
-    result = t1.execute().at[0, "parsed_date"]
-    expected = datetime.date(2026, 1, 1)
-    if isinstance(result, (pd.Timestamp, datetime.datetime)):
-        result = result.date()
-    assert result == expected
+    t = con.sql("SELECT '1/2/2021' AS raw_date")
+    # Use t.columns[0] to handle backends that uppercase column names (e.g. Oracle)
+    return t[t.columns[0]].as_date("%m/%d/%Y")
+
+
+# https://github.com/ibis-project/ibis/issues/12004
+@pytest.mark.parametrize(
+    "expr_fn",
+    [
+        param(lambda _: ibis.literal("1/2/2021").as_date("%m/%d/%Y"), id="literal"),
+        param(build_single_digit_date_col, id="column"),
+    ],
+)
+@pytest.mark.notyet(
+    ["materialize"],
+    raises=PsycoPgInternalError,
+    reason="Materialize doesn't have to_date() function - backend limitation",
+)
+@pytest.mark.notimpl(
+    ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notyet(
+    ["flink"],
+    raises=AssertionError,
+    reason="Flink misinterprets strftime-style format strings, producing a wrong date",
+)
+def test_string_as_date_single_digit_month_day(backend, con, expr_fn):
+    expr = expr_fn(con).name("parsed_date").as_table()
+    result = con.execute(expr)
+
+    golden = pd.Series([datetime.date(2021, 1, 2)], name="parsed_date").astype(
+        result.parsed_date.dtype
+    )
+    backend.assert_series_equal(golden, result.parsed_date)
 
 
 @pytest.mark.notyet(

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -358,9 +358,9 @@ class Schema(Concrete, Coercible, MapSet[str, dt.DataType]):
         >>> columns
         [ColumnDef(
           this=Identifier(this='a', quoted=True),
-          kind=DataType(this=Type.BIGINT)), ColumnDef(
+          kind=DataType(this=DType.BIGINT)), ColumnDef(
           this=Identifier(this='b', quoted=True),
-          kind=DataType(this=Type.VARCHAR),
+          kind=DataType(this=DType.VARCHAR),
           constraints=[
             ColumnConstraint(
               kind=NotNullColumnConstraint())])]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -267,7 +267,7 @@ sortedcontainers==2.4.0
 soupsieve==2.8.3
 sphobjinv==2.3.1.3
 sqlalchemy==2.0.46
-sqlglot==28.9.0
+sqlglot==30.13.0
 sqlparams==6.2.0
 stack-data==0.6.3
 statsmodels==0.14.6

--- a/uv.lock
+++ b/uv.lock
@@ -7121,11 +7121,11 @@ wheels = [
 
 [[package]]
 name = "sqlglot"
-version = "28.9.0"
+version = "30.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/72/cc50543a479a65f4ec24bef0e71529254686a1334c57cb1daebadfc29672/sqlglot-28.9.0.tar.gz", hash = "sha256:5648eaa2d038b5a0bc345f223f375315cfc6a27b2852d4eeaa1b8aaaabccdd2c", size = 5736988, upload-time = "2026-02-02T16:04:45.794Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/62/6d5bd3169478b7f09e08ab3e50175d486a9e7f3a419b88fc9280ba564ab1/sqlglot-30.13.0.tar.gz", hash = "sha256:f0a6eb79de2fd6efe2689f8cf197caa4f08bfe77c7880315616fa4420b8ba2bf", size = 5932385, upload-time = "2026-07-20T20:16:54.873Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/21/ee7d2798ff1f59cd5ca53063a728022da53552cbc0c63d05e120e9c9b794/sqlglot-28.9.0-py3-none-any.whl", hash = "sha256:044fbe85fd2dc0a9d8ea4adb2beefa7ff26fa2320849b08f5c5f3859d7973260", size = 595704, upload-time = "2026-02-02T16:04:43.531Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/2f/2076eca54f6a8ed1c86301bdb4bb2ae4181b0c1c4dbc041062ca997dc1b2/sqlglot-30.13.0-py3-none-any.whl", hash = "sha256:08f87ff7b052246d61b731628c8c2db0bc91f2c9e69f5ba68a1d160a9f5b49b1", size = 719120, upload-time = "2026-07-20T20:16:53.248Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description of changes

- Update Impala backend to use SQLGlot's own `INVERSE_TIME_MAPPING`/`INVERSE_TIME_TRIE` instead of manually inverting `TIME_MAPPING` (manual inversion silently drops keys since https://github.com/tobymao/sqlglot/pull/7773, breaking format strings like `%m`/`%d`.
  - `INVERSE_TIME_MAPPING` already existed, so this is backwards compatible with older versions of SQLGlot.
- Upgrade lock to SQLGlot 30.13.0, which contains the actual fix for #12004 on Spark/Databricks.
  - ClickHouse's arrayMap/arrayFilter with an index now hits an arity cap in SQLGlot's generic expression classes; route through self.f.anon to bypass it (output SQL unchanged, backwards compatible with older versions of SQLGlot).
  - MSSQL got its `##` global temp table prefix by writing one `#` and letting SQLGlot's tsql generator prepend the second. That double-prefixing was a SQLGlot bug — it also corrupted a legitimately quoted local temp `[#name]` into a global `[##name]` — fixed in 30.9.0 by https://github.com/tobymao/sqlglot/commit/a40dde9d3 (closes https://github.com/tobymao/sqlglot/issues/7657), after which our temp tables were created session-local and went invisible to the next pooled connection. Write `##` out in full and drop the `TemporaryProperty` (output SQL unchanged on both sides of that fix, backwards compatible with older versions of SQLGlot; the typed `Identifier(global_=True)` is *not*, it renders as invalid `##[name]` pre-30.9.0).
- Add regression tests for single-digit month/day parsing.
  - Also drop the Spark legacy time-parser config, so the strict parser actually exercises the fix.

## Issues closed

* Resolves #12004
