### PR TITLE
fix(clickhouse): forward secure flag to clickhouse_connect client

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -152,6 +152,7 @@ class Backend(SupportsTempTables, SQLBackend, CanCreateDatabase, DirectExampleLo
             query_limit=0,
             compress=compression,
             settings=settings,
+            secure=bool(secure),
             **kwargs,
         )
 

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -98,7 +98,7 @@ class Backend(SupportsTempTables, SQLBackend, CanCreateDatabase, DirectExampleLo
         user: str = "default",
         password: str = "",
         client_name: str = "ibis",
-        secure: bool | None = None,
+        secure: bool = False,
         compression: str | bool = True,
         settings: Mapping[str, Any] | None = None,
         **kwargs: Any,
@@ -152,7 +152,7 @@ class Backend(SupportsTempTables, SQLBackend, CanCreateDatabase, DirectExampleLo
             query_limit=0,
             compress=compression,
             settings=settings,
-            secure=bool(secure),
+            secure=secure,
             **kwargs,
         )
 


### PR DESCRIPTION
`do_connect` accepted `secure` but only used it to choose the default port, it never passed it to `clickhouse_connect.get_client`, so the client defaulted to plain HTTP and failed with a connection reset on TLS-only endpoints using a non-standard port.