### PR TITLE
fix(mysql,singlestoredb,trino): treat as_timestamp format as canonical

### DIFF
--- a/ibis/backends/sql/compilers/mysql.py
+++ b/ibis/backends/sql/compilers/mysql.py
@@ -98,7 +98,6 @@ class MySQLCompiler(SQLGlotCompiler):
         ops.ExtractEpochSeconds: "unix_timestamp",
         ops.ExtractDayOfYear: "dayofyear",
         ops.Strftime: "date_format",
-        ops.StringToTimestamp: "str_to_date",
         ops.Log2: "log2",
     }
 
@@ -217,6 +216,14 @@ class MySQLCompiler(SQLGlotCompiler):
             ),
             "%Y%m%d",
         )
+
+    def visit_StringToTimestamp(self, op, *, arg, format_str):
+        # Build StrToTime directly so the (Python strftime) format is treated as
+        # canonical and translated to MySQL's native codes by the generator.
+        # Routing through ``self.f.str_to_date`` re-parses the format as if it
+        # were already MySQL-native, which corrupts tokens that collide with
+        # Python's (e.g. ``%M`` = minutes in Python but month-name in MySQL).
+        return sge.StrToTime(this=arg, format=format_str)
 
     def visit_FindInSet(self, op, *, needle, values):
         return self.f.find_in_set(needle, self.f.concat_ws(",", values))

--- a/ibis/backends/sql/compilers/singlestoredb.py
+++ b/ibis/backends/sql/compilers/singlestoredb.py
@@ -305,8 +305,19 @@ class SingleStoreDBCompiler(MySQLCompiler):
 
         Use TIMESTAMP() function instead of STR_TO_DATE to get proper timestamp type.
         """
+        # Convert Python strftime format to MySQL/SingleStoreDB format: %M is
+        # minutes in Python but the month *name* in MySQL (minutes is %i); %S is
+        # seconds in Python but %s in MySQL.  Without this, STR_TO_DATE reads the
+        # minutes field as a month name and returns NULL.
+        if hasattr(format_str, "this") and isinstance(format_str.this, str):
+            mysql_format = format_str.this.replace("%M", "%i").replace("%S", "%s")
+        else:
+            mysql_format = str(format_str).replace("%M", "%i").replace("%S", "%s")
+
         # Use STR_TO_DATE to parse the string with the format, then wrap in TIMESTAMP()
-        parsed_date = sge.Anonymous(this="STR_TO_DATE", expressions=[arg, format_str])
+        parsed_date = sge.Anonymous(
+            this="STR_TO_DATE", expressions=[arg, sge.convert(mysql_format)]
+        )
         return sge.Anonymous(this="TIMESTAMP", expressions=[parsed_date])
 
     def visit_StringToTime(self, op, *, arg, format_str):

--- a/ibis/backends/sql/compilers/singlestoredb.py
+++ b/ibis/backends/sql/compilers/singlestoredb.py
@@ -300,26 +300,6 @@ class SingleStoreDBCompiler(MySQLCompiler):
         # Use Anonymous to force DATE() function instead of TO_DATE()
         return sge.Anonymous(this="DATE", expressions=[iso_date_string])
 
-    def visit_StringToTimestamp(self, op, *, arg, format_str):
-        """Convert string to timestamp in SingleStoreDB.
-
-        Use TIMESTAMP() function instead of STR_TO_DATE to get proper timestamp type.
-        """
-        # Convert Python strftime format to MySQL/SingleStoreDB format: %M is
-        # minutes in Python but the month *name* in MySQL (minutes is %i); %S is
-        # seconds in Python but %s in MySQL.  Without this, STR_TO_DATE reads the
-        # minutes field as a month name and returns NULL.
-        if hasattr(format_str, "this") and isinstance(format_str.this, str):
-            mysql_format = format_str.this.replace("%M", "%i").replace("%S", "%s")
-        else:
-            mysql_format = str(format_str).replace("%M", "%i").replace("%S", "%s")
-
-        # Use STR_TO_DATE to parse the string with the format, then wrap in TIMESTAMP()
-        parsed_date = sge.Anonymous(
-            this="STR_TO_DATE", expressions=[arg, sge.convert(mysql_format)]
-        )
-        return sge.Anonymous(this="TIMESTAMP", expressions=[parsed_date])
-
     def visit_StringToTime(self, op, *, arg, format_str):
         """Convert string to time in SingleStoreDB.
 

--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -79,7 +79,6 @@ class TrinoCompiler(SQLGlotCompiler):
         ops.Log10: "log10",
         ops.IsNan: "is_nan",
         ops.IsInf: "is_infinite",
-        ops.StringToTimestamp: "date_parse",
         ops.Strftime: "date_format",
         ops.ExtractEpochSeconds: "to_unixtime",
         ops.ExtractWeekOfYear: "week_of_year",
@@ -112,6 +111,14 @@ class TrinoCompiler(SQLGlotCompiler):
         ):
             return None
         return spec
+
+    def visit_StringToTimestamp(self, op, *, arg, format_str):
+        # Build StrToTime directly so the (Python strftime) format is treated as
+        # canonical and translated to Trino's native codes by the generator.
+        # Routing through ``self.f.date_parse`` re-parses the format as if it
+        # were already Trino-native, which corrupts tokens that collide with
+        # Python's (e.g. ``%M`` = minutes in Python but month-name in Trino).
+        return sge.StrToTime(this=arg, format=format_str)
 
     def visit_Correlation(self, op, *, left, right, how, where):
         if how == "sample":

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1357,13 +1357,7 @@ def test_string_as_timestamp_with_time(con):
     # field as a month name and silently returned NULL (or errored on Trino).
     expr = ibis.literal("2021-01-02 03:04:05").as_timestamp("%Y-%m-%d %H:%M:%S")
     result = con.execute(expr)
-    if isinstance(result, pd.Timestamp):
-        result = result.to_pydatetime()
-    # normalize tz-aware results to naive wall-clock; this checks parse
-    # correctness, not timezone semantics
-    if isinstance(result, datetime.datetime) and result.tzinfo is not None:
-        result = result.replace(tzinfo=None)
-    assert result == datetime.datetime(2021, 1, 2, 3, 4, 5)
+    assert result.replace(tzinfo=None) == datetime.datetime(2021, 1, 2, 3, 4, 5)
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1340,6 +1340,32 @@ def test_string_as_timestamp(alltypes, fmt):
         assert val.strftime("%m/%d/%y") == result["date_string_col"][i]
 
 
+@pytest.mark.notyet(
+    ["materialize"],
+    raises=PsycoPgInternalError,
+    reason="Materialize doesn't support to_timestamp(text, format) - backend limitation",
+)
+@pytest.mark.notimpl(
+    ["clickhouse", "sqlite", "datafusion", "mssql", "druid"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError)
+def test_string_as_timestamp_with_time(con):
+    # Regression test: a format with a time component exercises ``%M`` (minutes),
+    # which collides with the month-name token in MySQL/Trino-family format codes
+    # (minutes is ``%i``).  Previously MySQL/Trino/SingleStoreDB read the minutes
+    # field as a month name and silently returned NULL (or errored on Trino).
+    expr = ibis.literal("2021-01-02 03:04:05").as_timestamp("%Y-%m-%d %H:%M:%S")
+    result = con.execute(expr)
+    if isinstance(result, pd.Timestamp):
+        result = result.to_pydatetime()
+    # normalize tz-aware results to naive wall-clock; this checks parse
+    # correctness, not timezone semantics
+    if isinstance(result, datetime.datetime) and result.tzinfo is not None:
+        result = result.replace(tzinfo=None)
+    assert result == datetime.datetime(2021, 1, 2, 3, 4, 5)
+
+
 @pytest.mark.parametrize(
     "fmt",
     [

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1298,7 +1298,7 @@ def test_integer_to_timestamp(backend, con, unit):
                 ),
                 pytest.mark.never(
                     ["singlestoredb"],
-                    reason="TO_TIMESTAMP rejects the Java-style format string",
+                    reason="datetime formatting style not supported",
                     raises=SingleStoreDBOperationalError,
                 ),
                 pytest.mark.never(

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1292,9 +1292,14 @@ def test_integer_to_timestamp(backend, con, unit):
                     raises=GoogleBadRequest,
                 ),
                 pytest.mark.never(
-                    ["mysql", "singlestoredb"],
+                    ["mysql"],
                     reason="NaTType does not support strftime",
                     raises=ValueError,
+                ),
+                pytest.mark.never(
+                    ["singlestoredb"],
+                    reason="TO_TIMESTAMP rejects the Java-style format string",
+                    raises=SingleStoreDBOperationalError,
                 ),
                 pytest.mark.never(
                     ["trino"],


### PR DESCRIPTION
## Description of changes

The format for MySQL-syntax `exp.StringToTimpstamp` is _already_ canonical (i.e. Python `strftime` format), so it shouldn't be parsed from the backend dialect first.

Taking Trino as an example, you can see `%M` (MySQL month name) get parsed to `%B` (Python month name):

```pycon
> /Users/deepyaman/github/ibis-project/ibis/ibis/backends/sql/compilers/trino.py(124)visit_StringToTimestamp()
-> return self.f[_name](*kw.values())
(Pdb) _name
'date_parse'
(Pdb) kw
{'arg': Literal(this='2021-01-02 03:04:05', is_string=True), 'format_str': Literal(this='%Y-%m-%d %H:%M:%S', is_string=True)}
(Pdb) self.f.date_parse(*kw.values())
StrToTime(
  this=Literal(this='2021-01-02 03:04:05', is_string=True),
  format=Literal(this='%Y-%m-%d %H:%B:%S', is_string=True))
(Pdb) self.f.date_parse(*kw.values()).sql()
"STR_TO_TIME('2021-01-02 03:04:05', '%Y-%m-%d %H:%B:%S')"
```

After this fix, that parsing doesn't happen, so we keep the canonical `%M`:

```pycon
> /Users/deepyaman/github/ibis-project/ibis/ibis/backends/sql/compilers/trino.py(122)visit_StringToTimestamp()
-> return sge.StrToTime(this=arg, format=format_str)
(Pdb) sge.StrToTime(this=arg, format=format_str)
StrToTime(
  this=Literal(this='2021-01-02 03:04:05', is_string=True),
  format=Literal(this='%Y-%m-%d %H:%M:%S', is_string=True))
(Pdb) sge.StrToTime(this=arg, format=format_str).sql()
"STR_TO_TIME('2021-01-02 03:04:05', '%Y-%m-%d %H:%M:%S')"
```

## Issues closed

I didn't file an issue, but I asked Claude to draft it as a comment on another PR where I was investigating a broader set of timestamp-related behaviors: https://github.com/ibis-project/ibis/pull/12021#issuecomment-4760158003