### PR TITLE
fix(flink): translate strftime into a Java pattern

### DIFF
--- a/ibis/backends/sql/compilers/flink.py
+++ b/ibis/backends/sql/compilers/flink.py
@@ -110,8 +110,6 @@ class FlinkCompiler(SQLGlotCompiler):
         ops.RegexSearch: "regexp",
         ops.StrRight: "right",
         ops.StringLength: "char_length",
-        ops.StringToDate: "to_date",
-        ops.StringToTimestamp: "to_timestamp",
         ops.TypeOf: "typeof",
     }
 
@@ -224,6 +222,23 @@ class FlinkCompiler(SQLGlotCompiler):
 
         expr = sge.Values(expressions=expressions, alias=alias)
         return sg.select(*columns).from_(expr)
+
+    def _java_time_format(self, format_str) -> str:
+        # Flink's TO_DATE/TO_TIMESTAMP take a Java (SimpleDateFormat) pattern,
+        # e.g. `yyyy-MM-dd`, not a Python strftime format.
+        if not isinstance(format_str, ops.Literal):
+            raise com.UnsupportedOperationError(
+                f"format string must be a literal; got: {type(format_str).__name__}"
+            )
+        return sg.time.format_time(
+            format_str.value, Flink.INVERSE_TIME_MAPPING, Flink.INVERSE_TIME_TRIE
+        )
+
+    def visit_StringToDate(self, op, *, arg, format_str):
+        return self.f.anon.to_date(arg, self._java_time_format(op.format_str))
+
+    def visit_StringToTimestamp(self, op, *, arg, format_str):
+        return self.f.anon.to_timestamp(arg, self._java_time_format(op.format_str))
 
     def visit_NonNullLiteral(self, op, *, value, dtype):
         if dtype.is_binary():

--- a/ibis/backends/sql/compilers/flink.py
+++ b/ibis/backends/sql/compilers/flink.py
@@ -224,8 +224,7 @@ class FlinkCompiler(SQLGlotCompiler):
         return sg.select(*columns).from_(expr)
 
     def _java_time_format(self, format_str) -> str:
-        # Flink's TO_DATE/TO_TIMESTAMP take a Java (SimpleDateFormat) pattern,
-        # e.g. `yyyy-MM-dd`, not a Python strftime format.
+        # TO_DATE/TO_TIMESTAMP take a Java pattern (`yyyy-MM-dd`), not strftime
         if not isinstance(format_str, ops.Literal):
             raise com.UnsupportedOperationError(
                 f"format string must be a literal; got: {type(format_str).__name__}"

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1275,11 +1275,6 @@ def test_integer_to_timestamp(backend, con, unit):
                     ),
                     raises=SnowflakeProgrammingError,
                 ),
-                pytest.mark.never(
-                    ["flink"],
-                    raises=ValueError,
-                    reason="Datetime formatting style is not supported.",
-                ),
             ],
         ),
         param(
@@ -1390,11 +1385,6 @@ def test_string_as_date_with_format(con):
         param(
             "%m/%d/%y",
             id="mysql_format",
-            marks=pytest.mark.never(
-                ["flink"],
-                raises=ValueError,
-                reason="Datetime formatting style is not supported.",
-            ),
         ),
         param(
             "MM/dd/yy",

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1365,6 +1365,24 @@ def test_string_as_timestamp_with_time(con):
     assert result.replace(tzinfo=None) == datetime.datetime(2021, 1, 2, 3, 4, 5)
 
 
+@pytest.mark.notyet(
+    ["materialize"],
+    raises=PsycoPgInternalError,
+    reason="Materialize doesn't have to_date() function",
+)
+@pytest.mark.notimpl(
+    ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
+    raises=com.OperationNotDefinedError,
+)
+def test_string_as_date_with_format(con):
+    # Flink mangled the format and returned a wrong date for padded input.
+    expr = ibis.literal("2021-01-02").as_date("%Y-%m-%d")
+    result = con.execute(expr)
+    if isinstance(result, (pd.Timestamp, datetime.datetime)):
+        result = result.date()
+    assert result == datetime.date(2021, 1, 2)
+
+
 @pytest.mark.parametrize(
     "fmt",
     [

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1359,8 +1359,8 @@ def test_string_as_timestamp(alltypes, fmt):
     raises=com.OperationNotDefinedError,
 )
 def test_string_as_temporal_with_format(con, method, value, fmt):
-    # `%M` (minutes) collides with the month-name token in MySQL/Trino-family
-    # formats, and Flink needs a Java pattern rather than a strftime one.
+    # `%M` (minutes) reads as a month name in MySQL/Trino-family formats, where
+    # it silently returned NULL; Flink needs a Java pattern, not a strftime one.
     expr = getattr(ibis.literal(value), method)(fmt)
     assert con.execute(expr).strftime(fmt) == value
 

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1340,42 +1340,29 @@ def test_string_as_timestamp(alltypes, fmt):
         assert val.strftime("%m/%d/%y") == result["date_string_col"][i]
 
 
+@pytest.mark.parametrize(
+    ("method", "value", "fmt"),
+    [
+        param("as_date", "2021-01-02", "%Y-%m-%d", id="date"),
+        param(
+            "as_timestamp", "2021-01-02 03:04:05", "%Y-%m-%d %H:%M:%S", id="timestamp"
+        ),
+    ],
+)
 @pytest.mark.notyet(
     ["materialize"],
     raises=PsycoPgInternalError,
-    reason="Materialize doesn't support to_timestamp(text, format) - backend limitation",
-)
-@pytest.mark.notimpl(
-    ["clickhouse", "sqlite", "datafusion", "mssql", "druid"],
-    raises=com.OperationNotDefinedError,
-)
-@pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError)
-def test_string_as_timestamp_with_time(con):
-    # Regression test: a format with a time component exercises ``%M`` (minutes),
-    # which collides with the month-name token in MySQL/Trino-family format codes
-    # (minutes is ``%i``).  Previously MySQL/Trino/SingleStoreDB read the minutes
-    # field as a month name and silently returned NULL (or errored on Trino).
-    expr = ibis.literal("2021-01-02 03:04:05").as_timestamp("%Y-%m-%d %H:%M:%S")
-    result = con.execute(expr)
-    assert result.replace(tzinfo=None) == datetime.datetime(2021, 1, 2, 3, 4, 5)
-
-
-@pytest.mark.notyet(
-    ["materialize"],
-    raises=PsycoPgInternalError,
-    reason="Materialize doesn't have to_date() function",
+    reason="Materialize doesn't support to_date/to_timestamp with a format",
 )
 @pytest.mark.notimpl(
     ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
     raises=com.OperationNotDefinedError,
 )
-def test_string_as_date_with_format(con):
-    # Flink mangled the format and returned a wrong date for padded input.
-    expr = ibis.literal("2021-01-02").as_date("%Y-%m-%d")
-    result = con.execute(expr)
-    if isinstance(result, (pd.Timestamp, datetime.datetime)):
-        result = result.date()
-    assert result == datetime.date(2021, 1, 2)
+def test_string_as_temporal_with_format(con, method, value, fmt):
+    # `%M` (minutes) collides with the month-name token in MySQL/Trino-family
+    # formats, and Flink needs a Java pattern rather than a strftime one.
+    expr = getattr(ibis.literal(value), method)(fmt)
+    assert con.execute(expr).strftime(fmt) == value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description of changes

`as_date`/`as_timestamp` silently returned a wrong result on Flink:

```pycon
>>> con.execute(ibis.literal("2021-01-02").as_date("%Y-%m-%d"))
datetime.date(5471, 9, 27)
```

The format string was going through sqlglot with `dialect=Flink`, which re-parses it as if it were already a Java pattern. Translate it to a Java pattern explicitly instead, the same way the Impala compiler does. Two `never` markers started XPASSing as a result and are dropped.

Merge-order note: #12021 marks two new tests `notyet(["flink"])` for this exact bug, so whichever lands second needs those markers rechecked.
