### PR TITLE
fix(mysql,trino,singlestoredb): translate minutes token in strftime

### DIFF
--- a/docker/spark-connect/conf.properties
+++ b/docker/spark-connect/conf.properties
@@ -4,7 +4,6 @@ spark.sql.catalog.local.type=hadoop
 spark.sql.catalog.local.warehouse=warehouse
 spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog
 spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
-spark.sql.legacy.timeParserPolicy=LEGACY
 spark.sql.session.timeZone=UTC
 spark.sql.streaming.schemaInference=true
 spark.ui.enabled=false

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_cast_float_to_int/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_cast_float_to_int/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  CAST(trunc(`t0`.`double_col`) AS INT64) AS `Cast_double_col_int64`
+  CAST(TRUNC(`t0`.`double_col`) AS INT64) AS `Cast_double_col_int64`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/snapshots/test_sql/test_strftime_translates_python_format_codes/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_sql/test_strftime_translates_python_format_codes/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  FROM_UNIXTIME(UNIX_TIMESTAMP(CAST(`t0`.`timestamp_col` AS STRING)), 'MM/dd/yyyy') AS `Strftime(timestamp_col, '%m/%d/%Y')`
+FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/test_sql.py
+++ b/ibis/backends/impala/tests/test_sql.py
@@ -300,3 +300,10 @@ def test_group_by_with_window_preserves_range(snapshot):
 
     result = ibis.impala.compile(expr)
     snapshot.assert_match(result, "out.sql")
+
+
+# https://github.com/ibis-project/ibis/issues/12004
+def test_strftime_translates_python_format_codes(con, snapshot):
+    expr = con.table("functional_alltypes").timestamp_col.strftime("%m/%d/%Y")
+    result = ibis.to_sql(expr, dialect="impala")
+    snapshot.assert_match(result, "out.sql")

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -662,10 +662,7 @@ GO"""
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
 
-        properties = []
-
         if temp:
-            properties.append(sge.TemporaryProperty())
             catalog, db = None, None
 
         if obj is not None:
@@ -690,33 +687,23 @@ GO"""
 
         quoted = self.compiler.quoted
         raw_table = sg.table(temp_name, catalog=catalog, db=db, quoted=False)
+        # A global temporary table is identified by a `##` prefix on the name,
+        # not by a `TEMPORARY` property.
+        target_table = sg.table(
+            "##" * bool(temp) + temp_name, catalog=catalog, db=db, quoted=quoted
+        )
         target = sge.Schema(
-            this=sg.table(
-                "#" * bool(temp) + temp_name, catalog=catalog, db=db, quoted=quoted
-            ),
+            this=target_table,
             expressions=schema.to_sqlglot_column_defs(self.dialect),
         )
 
-        create_stmt = sge.Create(
-            kind="TABLE",
-            this=target,
-            properties=sge.Properties(expressions=properties),
-        )
+        create_stmt = sge.Create(kind="TABLE", this=target)
 
         this = sg.table(name, catalog=catalog, db=db, quoted=quoted)
         raw_this = sg.table(name, catalog=catalog, db=db, quoted=False)
         with self._safe_ddl(create_stmt) as cur:
             if query is not None:
-                # You can specify that a table is temporary for the sqlglot `Create` but not
-                # for the subsequent `Insert`, so we need to shove a `#` in
-                # front of the table identifier.
-                _table = sg.table(
-                    "##" * bool(temp) + temp_name,
-                    catalog=catalog,
-                    db=db,
-                    quoted=self.compiler.quoted,
-                )
-                insert_stmt = sge.Insert(this=_table, expression=query).sql(
+                insert_stmt = sge.Insert(this=target_table, expression=query).sql(
                     self.dialect
                 )
                 cur.execute(insert_stmt)

--- a/ibis/backends/sql/compilers/clickhouse.py
+++ b/ibis/backends/sql/compilers/clickhouse.py
@@ -627,7 +627,10 @@ class ClickHouseCompiler(SQLGlotCompiler):
 
         func = sge.Lambda(this=body, expressions=expressions)
 
-        return self.f.arrayMap(func, *args)
+        # ClickHouse's arrayMap takes a lambda plus a variable number of
+        # arrays, but sqlglot's generic ArrayMap expression caps it at two
+        # arguments; go through `anon` to bypass that arity check.
+        return self.f.anon.arrayMap(func, *args)
 
     def visit_ArrayFilter(self, op, *, arg, param, body, index):
         expressions = [param]
@@ -639,7 +642,8 @@ class ClickHouseCompiler(SQLGlotCompiler):
 
         func = sge.Lambda(this=body, expressions=expressions)
 
-        return self.f.arrayFilter(func, *args)
+        # Same arity issue as visit_ArrayMap: bypass via anon.
+        return self.f.anon.arrayFilter(func, *args)
 
     def visit_ArrayRemove(self, op, *, arg, other):
         x = sg.to_identifier(util.gen_name("x"))

--- a/ibis/backends/sql/compilers/flink.py
+++ b/ibis/backends/sql/compilers/flink.py
@@ -110,8 +110,6 @@ class FlinkCompiler(SQLGlotCompiler):
         ops.RegexSearch: "regexp",
         ops.StrRight: "right",
         ops.StringLength: "char_length",
-        ops.StringToDate: "to_date",
-        ops.StringToTimestamp: "to_timestamp",
         ops.TypeOf: "typeof",
     }
 
@@ -224,6 +222,23 @@ class FlinkCompiler(SQLGlotCompiler):
 
         expr = sge.Values(expressions=expressions, alias=alias)
         return sg.select(*columns).from_(expr)
+
+    def _java_time_format(self, format_str) -> str:
+        # Flink's TO_DATE/TO_TIMESTAMP take a Java (SimpleDateFormat) pattern,
+        # e.g. `yyyy-MM-dd`, not a Python strftime format.
+        if not isinstance(format_str, ops.Literal):
+            raise com.UnsupportedOperationError(
+                f"format string must be a literal; got: {type(format_str).__name__}"
+            )
+        return sg.time.format_time(
+            format_str.value, Flink.INVERSE_TIME_MAPPING, Flink.INVERSE_TIME_TRIE
+        )
+
+    def visit_StringToDate(self, op, *, arg, format_str):
+        return self.f.anon.to_date(arg, self._java_time_format(op.format_str))
+
+    def visit_StringToTimestamp(self, op, *, arg, format_str):
+        return self.f.anon.to_timestamp(arg, self._java_time_format(op.format_str))
 
     def visit_NonNullLiteral(self, op, *, value, dtype):
         if dtype.is_binary():

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -235,7 +235,7 @@ class ImpalaCompiler(SQLGlotCompiler):
                 f"got: {type(op.format_str).__name__}"
             )
         format_str = sg.time.format_time(
-            op.format_str.value, {v: k for k, v in Impala.TIME_MAPPING.items()}
+            op.format_str.value, Impala.INVERSE_TIME_MAPPING, Impala.INVERSE_TIME_TRIE
         )
         return self.f.anon.from_unixtime(
             self.f.unix_timestamp(self.cast(arg, dt.string)), format_str

--- a/ibis/backends/sql/compilers/mysql.py
+++ b/ibis/backends/sql/compilers/mysql.py
@@ -97,7 +97,6 @@ class MySQLCompiler(SQLGlotCompiler):
         ops.ExtractWeekOfYear: "weekofyear",
         ops.ExtractEpochSeconds: "unix_timestamp",
         ops.ExtractDayOfYear: "dayofyear",
-        ops.Strftime: "date_format",
         ops.Log2: "log2",
     }
 

--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -79,7 +79,6 @@ class TrinoCompiler(SQLGlotCompiler):
         ops.Log10: "log10",
         ops.IsNan: "is_nan",
         ops.IsInf: "is_infinite",
-        ops.Strftime: "date_format",
         ops.ExtractEpochSeconds: "to_unixtime",
         ops.ExtractWeekOfYear: "week_of_year",
         ops.ExtractDayOfYear: "day_of_year",

--- a/ibis/backends/sql/tests/test_datatypes.py
+++ b/ibis/backends/sql/tests/test_datatypes.py
@@ -131,5 +131,5 @@ def test_unknown_repr():
         sge.DataType(this=sge.DataType.Type.USERDEFINED, kind='"MySchema"."MyEnum"')
     )
     result = str(dtype)
-    expected = 'unknown(DataType(this=Type.USERDEFINED, kind="MySchema"."MyEnum"))'
+    expected = 'unknown(DataType(this=DType.USERDEFINED, kind="MySchema"."MyEnum"))'
     assert result == expected

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1151,6 +1151,16 @@ def test_strftime(backend, alltypes, df, expr_fn, pandas_pattern):
     backend.assert_series_equal(result, expected)
 
 
+@pytest.mark.notimpl(["druid", "exasol"], raises=com.OperationNotDefinedError)
+def test_strftime_with_time(con):
+    # Regression test: a format with a time component exercises ``%M`` (minutes),
+    # which collides with the month-name token in MySQL/Trino-family format codes
+    # (minutes is ``%i``).  Previously MySQL/Trino/SingleStoreDB emitted the month
+    # name in the minutes position (e.g. "03:January:05").
+    expr = ibis.timestamp("2021-01-02 03:04:05").strftime("%Y-%m-%d %H:%M:%S")
+    assert con.execute(expr) == "2021-01-02 03:04:05"
+
+
 unit_factors = {"s": 10**9, "ms": 10**6, "us": 10**3, "ns": 1}
 
 

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1275,11 +1275,6 @@ def test_integer_to_timestamp(backend, con, unit):
                     ),
                     raises=SnowflakeProgrammingError,
                 ),
-                pytest.mark.never(
-                    ["flink"],
-                    raises=ValueError,
-                    reason="Datetime formatting style is not supported.",
-                ),
             ],
         ),
         param(
@@ -1389,11 +1384,6 @@ def test_string_as_date_with_format(con):
         param(
             "%m/%d/%y",
             id="mysql_format",
-            marks=pytest.mark.never(
-                ["flink"],
-                raises=ValueError,
-                reason="Datetime formatting style is not supported.",
-            ),
         ),
         param(
             "MM/dd/yy",

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1331,10 +1331,9 @@ def test_integer_to_timestamp(backend, con, unit):
     reason="Materialize doesn't support to_timestamp(text, format) - backend limitation",
 )
 @pytest.mark.notimpl(
-    ["clickhouse", "sqlite", "datafusion", "mssql", "druid"],
+    ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
     raises=com.OperationNotDefinedError,
 )
-@pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError)
 def test_string_as_timestamp(alltypes, fmt):
     table = alltypes
     result = table.mutate(date=table.date_string_col.as_timestamp(fmt)).execute()
@@ -1422,10 +1421,9 @@ def test_string_as_timestamp_with_time(con):
     reason="Materialize doesn't have to_date() function - backend limitation",
 )
 @pytest.mark.notimpl(
-    ["clickhouse", "sqlite", "datafusion", "mssql", "druid"],
+    ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
     raises=com.OperationNotDefinedError,
 )
-@pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError)
 def test_string_as_date(alltypes, fmt):
     table = alltypes
     result = table.mutate(date=table.date_string_col.as_date(fmt)).execute()
@@ -1434,6 +1432,57 @@ def test_string_as_date(alltypes, fmt):
     # format string assumes that we are using pandas' strftime
     for i, val in enumerate(result["date"]):
         assert val.strftime("%m/%d/%y") == result["date_string_col"][i]
+
+
+# https://github.com/ibis-project/ibis/issues/12004
+@pytest.mark.notyet(
+    ["materialize"],
+    raises=PsycoPgInternalError,
+    reason="Materialize doesn't have to_date() function - backend limitation",
+)
+@pytest.mark.notimpl(
+    ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notyet(
+    ["flink"],
+    raises=AssertionError,
+    reason="Flink misinterprets strftime-style format strings, producing a wrong date",
+)
+def test_string_as_date_single_digit_month_day(con):
+    expr = ibis.literal("1/2/2021").as_date("%m/%d/%Y")
+    result = con.execute(expr)
+    expected = datetime.date(2021, 1, 2)
+    if isinstance(result, (pd.Timestamp, datetime.datetime)):
+        result = result.date()
+    assert result == expected
+
+
+# https://github.com/ibis-project/ibis/issues/12004
+@pytest.mark.notyet(
+    ["materialize"],
+    raises=PsycoPgInternalError,
+    reason="Materialize doesn't have to_date() function - backend limitation",
+)
+@pytest.mark.notimpl(
+    ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notyet(
+    ["flink"],
+    raises=AssertionError,
+    reason="Flink misinterprets strftime-style format strings, producing a wrong date",
+)
+def test_string_as_date_single_digit_month_day_column(con):
+    # con.sql() creates a column (not a literal), then .as_date() is applied.
+    t0 = con.sql("SELECT '1/1/2026' AS raw_date")
+    # Use t0.columns[0] to handle backends that uppercase column names (e.g. Oracle)
+    t1 = t0.mutate(parsed_date=t0[t0.columns[0]].as_date("%m/%d/%Y"))
+    result = t1.execute().at[0, "parsed_date"]
+    expected = datetime.date(2026, 1, 1)
+    if isinstance(result, (pd.Timestamp, datetime.datetime)):
+        result = result.date()
+    assert result == expected
 
 
 @pytest.mark.notyet(

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1152,6 +1152,15 @@ def test_strftime(backend, alltypes, df, expr_fn, pandas_pattern):
 
 
 @pytest.mark.notimpl(["druid", "exasol"], raises=com.OperationNotDefinedError)
+@pytest.mark.notyet(
+    ["clickhouse"],
+    raises=AssertionError,
+    reason=(
+        "sqlglot's ClickHouse dialect has an empty TIME_MAPPING, so canonical "
+        "`%M` (minutes) passes through to `formatDateTime`, which reads it as "
+        "the full month name; ClickHouse spells minutes `%i`"
+    ),
+)
 def test_strftime_with_time(con):
     # Regression test: a format with a time component exercises ``%M`` (minutes),
     # which collides with the month-name token in MySQL/Trino-family format codes
@@ -1462,11 +1471,6 @@ def test_string_as_date(alltypes, fmt):
     ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
     raises=com.OperationNotDefinedError,
 )
-@pytest.mark.notyet(
-    ["flink"],
-    raises=AssertionError,
-    reason="Flink misinterprets strftime-style format strings, producing a wrong date",
-)
 def test_string_as_date_single_digit_month_day(con):
     expr = ibis.literal("1/2/2021").as_date("%m/%d/%Y")
     result = con.execute(expr)
@@ -1485,11 +1489,6 @@ def test_string_as_date_single_digit_month_day(con):
 @pytest.mark.notimpl(
     ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
     raises=com.OperationNotDefinedError,
-)
-@pytest.mark.notyet(
-    ["flink"],
-    raises=AssertionError,
-    reason="Flink misinterprets strftime-style format strings, producing a wrong date",
 )
 def test_string_as_date_single_digit_month_day_column(con):
     # con.sql() creates a column (not a literal), then .as_date() is applied.

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1364,6 +1364,24 @@ def test_string_as_timestamp_with_time(con):
     assert result.replace(tzinfo=None) == datetime.datetime(2021, 1, 2, 3, 4, 5)
 
 
+@pytest.mark.notyet(
+    ["materialize"],
+    raises=PsycoPgInternalError,
+    reason="Materialize doesn't have to_date() function",
+)
+@pytest.mark.notimpl(
+    ["clickhouse", "sqlite", "datafusion", "mssql", "druid", "exasol"],
+    raises=com.OperationNotDefinedError,
+)
+def test_string_as_date_with_format(con):
+    # Flink mangled the format and returned a wrong date for padded input.
+    expr = ibis.literal("2021-01-02").as_date("%Y-%m-%d")
+    result = con.execute(expr)
+    if isinstance(result, (pd.Timestamp, datetime.datetime)):
+        result = result.date()
+    assert result == datetime.date(2021, 1, 2)
+
+
 @pytest.mark.parametrize(
     "fmt",
     [

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -358,9 +358,9 @@ class Schema(Concrete, Coercible, MapSet[str, dt.DataType]):
         >>> columns
         [ColumnDef(
           this=Identifier(this='a', quoted=True),
-          kind=DataType(this=Type.BIGINT)), ColumnDef(
+          kind=DataType(this=DType.BIGINT)), ColumnDef(
           this=Identifier(this='b', quoted=True),
-          kind=DataType(this=Type.VARCHAR),
+          kind=DataType(this=DType.VARCHAR),
           constraints=[
             ColumnConstraint(
               kind=NotNullColumnConstraint())])]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -267,7 +267,7 @@ sortedcontainers==2.4.0
 soupsieve==2.8.3
 sphobjinv==2.3.1.3
 sqlalchemy==2.0.46
-sqlglot==30.13.0
+sqlglot==30.14.0
 sqlparams==6.2.0
 stack-data==0.6.3
 statsmodels==0.14.6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -267,7 +267,7 @@ sortedcontainers==2.4.0
 soupsieve==2.8.3
 sphobjinv==2.3.1.3
 sqlalchemy==2.0.46
-sqlglot==28.9.0
+sqlglot==30.13.0
 sqlparams==6.2.0
 stack-data==0.6.3
 statsmodels==0.14.6

--- a/uv.lock
+++ b/uv.lock
@@ -7121,11 +7121,11 @@ wheels = [
 
 [[package]]
 name = "sqlglot"
-version = "30.13.0"
+version = "30.14.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/62/6d5bd3169478b7f09e08ab3e50175d486a9e7f3a419b88fc9280ba564ab1/sqlglot-30.13.0.tar.gz", hash = "sha256:f0a6eb79de2fd6efe2689f8cf197caa4f08bfe77c7880315616fa4420b8ba2bf", size = 5932385, upload-time = "2026-07-20T20:16:54.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/cd/39a94f0f98076ee8e7c7c38fd4bba8d7845b0c629ff967057c64ef2c0989/sqlglot-30.14.0.tar.gz", hash = "sha256:df2ef5d2b8ca814313781f4ff35bf63e58f821ef517eeddbd523c19a61fa9bb9", size = 5944410, upload-time = "2026-07-27T11:23:30.698Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/2f/2076eca54f6a8ed1c86301bdb4bb2ae4181b0c1c4dbc041062ca997dc1b2/sqlglot-30.13.0-py3-none-any.whl", hash = "sha256:08f87ff7b052246d61b731628c8c2db0bc91f2c9e69f5ba68a1d160a9f5b49b1", size = 719120, upload-time = "2026-07-20T20:16:53.248Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ec/a729883ceda22dcd9117ce182f64d884bf494e72c4dfce00c2ad0a5978e1/sqlglot-30.14.0-py3-none-any.whl", hash = "sha256:fc768e24889d63a5e1237dea7ad305e5ffb4356a98b0bed828f89591ebcd3636", size = 719007, upload-time = "2026-07-27T11:23:28.637Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -7121,11 +7121,11 @@ wheels = [
 
 [[package]]
 name = "sqlglot"
-version = "28.9.0"
+version = "30.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/72/cc50543a479a65f4ec24bef0e71529254686a1334c57cb1daebadfc29672/sqlglot-28.9.0.tar.gz", hash = "sha256:5648eaa2d038b5a0bc345f223f375315cfc6a27b2852d4eeaa1b8aaaabccdd2c", size = 5736988, upload-time = "2026-02-02T16:04:45.794Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/62/6d5bd3169478b7f09e08ab3e50175d486a9e7f3a419b88fc9280ba564ab1/sqlglot-30.13.0.tar.gz", hash = "sha256:f0a6eb79de2fd6efe2689f8cf197caa4f08bfe77c7880315616fa4420b8ba2bf", size = 5932385, upload-time = "2026-07-20T20:16:54.873Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/21/ee7d2798ff1f59cd5ca53063a728022da53552cbc0c63d05e120e9c9b794/sqlglot-28.9.0-py3-none-any.whl", hash = "sha256:044fbe85fd2dc0a9d8ea4adb2beefa7ff26fa2320849b08f5c5f3859d7973260", size = 595704, upload-time = "2026-02-02T16:04:43.531Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/2f/2076eca54f6a8ed1c86301bdb4bb2ae4181b0c1c4dbc041062ca997dc1b2/sqlglot-30.13.0-py3-none-any.whl", hash = "sha256:08f87ff7b052246d61b731628c8c2db0bc91f2c9e69f5ba68a1d160a9f5b49b1", size = 719120, upload-time = "2026-07-20T20:16:53.248Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #12021 and #12026.** This branch contains their commits verbatim so the whole `as_date`/`as_timestamp`/`strftime` family can be exercised together against sqlglot 30.14.0. Review only the last two commits; the first five belong to the PRs below and should merge there first.
>
> | commits | PR |
> |---|---|
> | `fix(impala)`, `chore(deps): … 28.9.0 to 30.13.0`, `test(temporal)` | #12021 |
> | `fix(flink)`, `test(flink)` | #12026 |
> | `fix(mysql,trino,singlestoredb)`, `chore(deps): … 30.13.0 to 30.14.0` | **this PR** |

## Description

`strftime` with a time component silently emits the **wrong value** on MySQL/Trino/SingleStoreDB:

```python
con.execute(ibis.timestamp("2021-01-02 03:04:05").strftime("%Y-%m-%d %H:%M:%S"))
# -> "2021-01-02 03:January:05"   (the month, in the minutes position)
```

### Root cause (same as #12025, opposite direction)

`ops.Strftime` was routed through `self.f.date_format(arg, fmt, dialect=…)` via `SIMPLE_OPS`. Passing `dialect=` makes sqlglot re-parse the format string *as if it were dialect-native*, so Python's `%M` (minutes) is read as the dialect's `%M` (month name). Compiled SQL was `DATE_FORMAT(t, '%Y-%m-%d %H:%M:%s')` — that `%M` formats the month.

### Fix

The base compiler already has a correct `visit_Strftime` that builds `sge.TimeToStr` directly. mysql/trino's `SIMPLE_OPS` entry was *overriding* it with the buggy parse-converting version. Dropping the entry restores the base behavior:

```
DATE_FORMAT(t, '%Y-%m-%d %T')   (%T = %H:%i:%s)   ✓  mysql / trino / singlestoredb
```

It's a pure 2-line deletion; `DATE_FORMAT` is the same function these backends already emitted, just with the correct format (no SQL-shape change). SingleStoreDB inherits the fix from MySQL.

Adds `test_strftime_with_time` — the existing `test_strftime` only uses `"%Y%m%d"` (date-only), which is why this slipped through.

### sqlglot 30.14.0

Bumps the lock from 30.13.0 (as set by #12021). 30.14.0 carries tobymao/sqlglot#7925, which makes Hive-family `HH`/`mm`/`ss` lax the way #7773 did for `MM`/`dd` — so Spark/Databricks now emit `yyyy-M-d H:m:s` and single-digit **time** parses under the strict parser. That closes the remaining half of the #12004 family.

Verified locally on the full stack:

| backend | expression | compiled |
|---|---|---|
| mysql / trino / singlestoredb | `strftime("%Y-%m-%d %H:%M:%S")` | `DATE_FORMAT(…, '%Y-%m-%d %T')` |
| mysql / trino | `as_timestamp("%Y-%m-%d %H:%M:%S")` | `STR_TO_DATE` / `DATE_PARSE(…, '%Y-%m-%d %T')` |
| pyspark / databricks | `as_timestamp("%Y-%m-%d %H:%M:%S")` | `TO_TIMESTAMP(…, 'yyyy-M-d H:m:s')` |
| flink | `as_timestamp("%Y-%m-%d %H:%M:%S")` | `TO_TIMESTAMP(…, 'yyyy-MM-dd HH:mm:ss')` |

No ibis-side fallout from the bump: the compiler and expression suites give identical results on 30.13.0 and 30.14.0. The `%T` composite-shorthand caveat flagged in #7925 does **not** apply — it only bites when transpiling *from* a strict Hive-family dialect, and ibis always builds from canonical tokens.

### Open

- Nothing yet exercises single-digit **time**; that test belongs with the #12004 coverage in #12021.
- #12021 marks its two single-digit tests `notyet(["flink"], raises=AssertionError, reason="Flink misinterprets strftime-style format strings")`. #12026 fixes that misinterpretation, so with both stacked here CI will show whether those markers now XPASS and need dropping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
