### PR TITLE
fix(trino): cast zip() result to named ROW so struct field access resolves

### DIFF
--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -510,7 +510,11 @@ class TrinoCompiler(SQLGlotCompiler):
 
         all_n, chunk = reduce(combine_zipped, chunks)
         assert all_n == len(op.dtype.value_type)
-        return chunk
+        # Trino's `zip`/`row` builds anonymous ROW fields, so downstream
+        # `struct.f1`/`struct.f2` access (e.g. inside a subsequent filter/map
+        # lambda) fails to resolve. Cast to the named struct type so the field
+        # names ibis assigns (f1, f2, ...) are carried on the ROW.
+        return self.cast(chunk, op.dtype)
 
     def visit_ExtractMicrosecond(self, op, *, arg):
         # trino only seems to store milliseconds, but the result of formatting

--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -302,3 +302,21 @@ def test_order_by_no_deference_literals(backend_name, snapshot):
     o = s.order_by("a", "i", "s")
     sql = ibis.to_sql(o, dialect=backend_name)
     snapshot.assert_match(sql, "out.sql")
+
+
+def test_trino_zip_struct_field_access_casts_to_named_row():
+    # Regression for #11971: on Trino, zip() builds anonymous ROW fields, so
+    # accessing a struct field (f1, f2, ...) inside a subsequent filter/map
+    # lambda compiled to unresolvable dot access (`param."f2"`). The zipped
+    # array must be cast to a named ROW type so those field names resolve.
+    t = ibis.table({"a": "string", "b": "string"}, name="t")
+    keys = ibis.array([ibis.literal("k1"), ibis.literal("k2")])
+    vals = ibis.array([_.a.cast("string"), _.b.cast("string")]).resolve(t)
+    zipped = keys.zip(vals)
+    filtered = zipped.filter(lambda s: s["f2"].notnull())
+    expr = t.select(filtered.map(lambda s: s["f2"]).name("m"))
+
+    sql = " ".join(ibis.to_sql(expr, dialect="trino").split())
+
+    assert "CAST(ZIP(" in sql
+    assert 'ARRAY(ROW("f1" VARCHAR, "f2" VARCHAR))' in sql


### PR DESCRIPTION
Fixes #11971

## Problem

On the Trino backend, `ArrayZip` compiles to `zip(...)` / `row(...)`, which produces ROWs with **anonymous** fields. Accessing a zipped struct's field by name (`f1`, `f2`, … per the `zip()` docstring) inside a subsequent `filter()`/`map()` lambda then compiled to dot access:

```sql
__ibis_param_s__ -> (__ibis_param_s__."f2") IS NOT NULL
```

which Trino rejects: `Column '__ibis_param_s__.f2' cannot be resolved`. This breaks the documented `zip()` usage pattern on Trino (numeric index access isn't offered by `StructValue.__getitem__`, so name access is the only API).

## Fix

Cast the zipped array to its named struct type so the field names ibis assigns are carried on the ROW:

```sql
CAST(ZIP(...) AS ARRAY(ROW("f1" VARCHAR, "f2" VARCHAR)))
```

With named ROW fields, `param."f2"` resolves. The cast only relabels fields (types are unchanged), so it's a no-op semantically apart from restoring the names.

## Tests

Added `test_trino_zip_struct_field_access_casts_to_named_row` (compile-level, no live backend) asserting the zip is cast to the named ROW. It fails on `main` and passes with this change. `ruff check` is clean.

```
pytest ibis/backends/tests/test_sql.py::test_trino_zip_struct_field_access_casts_to_named_row
```