### PR TITLE
fix(postgres): match pg18 Alpine toolchain

### DIFF
--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,11 +1,11 @@
 FROM postgis/postgis:18-3.6-alpine AS pgvector-builder
-RUN apk add --no-cache git build-base clang19 llvm19
+RUN apk add --no-cache git build-base clang21 llvm21-dev llvm21
 RUN git clone --branch v0.8.1 https://github.com/pgvector/pgvector.git /tmp/pgvector
 RUN make -C /tmp/pgvector -j "$(nproc)"
 RUN make -C /tmp/pgvector -j "$(nproc)" install
 
 FROM postgis/postgis:18-3.6-alpine
-RUN apk add --no-cache postgresql17-plpython3
+RUN apk add --no-cache postgresql18-plpython3
 COPY --from=pgvector-builder /usr/local/lib/postgresql/bitcode/vector.index.bc /usr/local/lib/postgresql/bitcode/vector.index.bc
 COPY --from=pgvector-builder /usr/local/lib/postgresql/vector.so /usr/local/lib/postgresql/vector.so
 COPY --from=pgvector-builder /usr/local/share/postgresql/extension /usr/local/share/postgresql/extension


### PR DESCRIPTION
## Description:

Issue #12033 reported that PostgreSQL backend jobs were failing while building the
`docker/postgres` image after the `postgis/postgis:18-3.6-alpine` base moved to
the PostgreSQL 18 Alpine toolchain.

This PR updates the pgvector builder image to use the matching PostgreSQL 18
Alpine LLVM/Clang packages (`clang21`, `llvm21`, `llvm21-dev`) and aligns the
installed `plpython3` package with PostgreSQL 18.

Closes #12033.

## Testing:

- `pre-commit run --files docker/postgres/Dockerfile`.
- `docker build --progress=plain -f docker/postgres/Dockerfile -t ibis-postgres-fixed docker/postgres`.
- Targeted PostgreSQL tests covering `test_pgvector_type_load` and
  `test_existing_plpython_udf` in WSL (`2 passed`).


### The validation screenshots of the tests run:

<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/ed2507b1-2758-452b-9e17-46256c2efab4" />

<img width="1600" height="760" alt="image" src="https://github.com/user-attachments/assets/138b3d31-ed06-4ef2-9dab-14de14960a41" />
