### PR TITLE
fix(polars): exclude nulls from nunique and approx_nunique

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -746,9 +746,7 @@ _reductions = {
     ops.All: "all",
     ops.Any: "any",
     ops.ApproxMedian: "median",
-    ops.ApproxCountDistinct: "approx_n_unique",
     ops.Count: "count",
-    ops.CountDistinct: "n_unique",
     ops.Max: "max",
     ops.Mean: "mean",
     ops.Median: "median",
@@ -1408,6 +1406,23 @@ def execute_aliased_relation(op, *, ctx: pl.SQLContext, **kw):
 @translate.register(ops.Reference)
 def execute_reference(op, **kw):
     return translate(op.parent, **kw)
+
+
+@translate.register(ops.CountDistinct)
+def execute_count_distinct(op, **kw):
+    arg = translate(op.arg, **kw)
+    if op.where is not None:
+        arg = arg.filter(translate(op.where, **kw))
+    # polars' n_unique counts null as a distinct value, COUNT(DISTINCT) does not
+    return arg.drop_nulls().n_unique()
+
+
+@translate.register(ops.ApproxCountDistinct)
+def execute_approx_count_distinct(op, **kw):
+    arg = translate(op.arg, **kw)
+    if op.where is not None:
+        arg = arg.filter(translate(op.where, **kw))
+    return arg.drop_nulls().approx_n_unique()
 
 
 @translate.register(ops.CountDistinctStar)

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -746,9 +746,7 @@ _reductions = {
     ops.All: "all",
     ops.Any: "any",
     ops.ApproxMedian: "median",
-    ops.ApproxCountDistinct: "approx_n_unique",
     ops.Count: "count",
-    ops.CountDistinct: "n_unique",
     ops.Max: "max",
     ops.Mean: "mean",
     ops.Median: "median",
@@ -1409,6 +1407,23 @@ def execute_aliased_relation(op, *, ctx: pl.SQLContext, **kw):
 @translate.register(ops.Reference)
 def execute_reference(op, **kw):
     return translate(op.parent, **kw)
+
+
+@translate.register(ops.CountDistinct)
+def execute_count_distinct(op, **kw):
+    arg = translate(op.arg, **kw)
+    if op.where is not None:
+        arg = arg.filter(translate(op.where, **kw))
+    # polars' n_unique counts null as a distinct value, COUNT(DISTINCT) does not
+    return arg.drop_nulls().n_unique()
+
+
+@translate.register(ops.ApproxCountDistinct)
+def execute_approx_count_distinct(op, **kw):
+    arg = translate(op.arg, **kw)
+    if op.where is not None:
+        arg = arg.filter(translate(op.where, **kw))
+    return arg.drop_nulls().approx_n_unique()
 
 
 @translate.register(ops.CountDistinctStar)

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1848,3 +1848,11 @@ def test_empty_sum(con):
 
     result = con.to_pyarrow(t.x.sum(where=t.x > 1)).as_py()
     assert result is None
+
+
+def test_nunique_ignores_nulls(con):
+    t = ibis.memtable({"x": ["a", "b", "a", None]}, schema={"x": "string"})
+    assert con.execute(t.x.nunique()) == 2
+
+    t = ibis.memtable({"x": [None, None]}, schema={"x": "string"})
+    assert con.execute(t.x.nunique()) == 0


### PR DESCRIPTION
## Description of changes

`nunique` and `approx_nunique` count nulls on the polars backend but not on the SQL backends:

```python
t = ibis.memtable({"x": ["a", "b", "a", None]}, schema={"x": "string"})
t.x.nunique()         # duckdb 2, polars 3
t.x.approx_nunique()  # duckdb 2, polars 3
```

An all-null column shows the same split: 0 on the SQL backends, 1 on polars.

The polars compiler maps `CountDistinct` to polars' `n_unique` and `ApproxCountDistinct` to `approx_n_unique`, and both treat null as a distinct value. The SQL backends compile to `COUNT(DISTINCT ...)`, which ignores nulls. The shared backend tests already assume nulls are excluded, using `.dropna().nunique()` and `.nunique()` as the expected values, so polars is the odd one out. The existing tests do not catch it because the column they aggregate has no nulls.

This gives both ops their own translation that drops nulls before counting, following the `CountDistinctStar` handler next to them, and adds a test with a null and an all-null column. `approx_nunique` is not in that test because its result is approximate and already xfailed for exactness on some backends.

polars is the only backend with its own compiler, so nothing else changes here: the rest go through the SQL compiler and already ignore nulls.

I checked that duckdb and polars agree afterwards for null, all-null and no-null columns, for `where=` (including a null in the predicate), for `group_by(...).agg(...)`, and across int, float, bool, string, date, timestamp, decimal, array and struct columns. Those are the two backends I can run locally, so if another one needs a mark here, happy to add it