### PR TITLE
fix(sql): preserve RECURSIVE keyword when rebuilding WITH clause

### DIFF
--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -687,6 +687,11 @@ class SQLGlotCompiler(abc.ABC):
                 alias=sg.to_identifier(aliases[cte], quoted=self.quoted), this=this
             )
             merged_ctes.append(modified_cte)
+
+        # Capture the recursive flag before the With node is discarded
+        with_node = out.args.get(WITH_ARG)
+        is_recursive = with_node is not None and bool(with_node.args.get("recursive"))
+
         merged_ctes.extend(out.ctes)
         out.args.pop(WITH_ARG, None)
 
@@ -700,6 +705,10 @@ class SQLGlotCompiler(abc.ABC):
             merged_ctes,
             out,
         )
+
+        # Restore the recursive flag on the rebuilt With node
+        if is_recursive and WITH_ARG in out.args:
+            out.args[WITH_ARG].set("recursive", True)
 
         return out
 
@@ -1622,6 +1631,10 @@ class SQLGlotCompiler(abc.ABC):
             ),
             *compiled_query.ctes,
         ]
+        # Capture the recursive flag before the With node is discarded
+        with_node = compiled_query.args.get(WITH_ARG)
+        is_recursive = with_node is not None and bool(with_node.args.get("recursive"))
+
         compiled_ibis_expr.args.pop(WITH_ARG, None)
         compiled_query.args.pop(WITH_ARG, None)
 
@@ -1632,6 +1645,10 @@ class SQLGlotCompiler(abc.ABC):
             ctes,
             compiled_query,
         )
+
+        # Restore the recursive flag on the rebuilt With node
+        if is_recursive and WITH_ARG in parsed.args:
+            parsed.args[WITH_ARG].set("recursive", True)
 
         # generate the SQL string
         return parsed.sql(dialect)

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -440,6 +440,14 @@ class PySparkCompiler(SQLGlotCompiler):
             arg = sge.Distinct(expressions=[arg])
         return self.agg.array_agg(arg, order_by=order_by)
 
+    def visit_StringToDate(self, op, *, arg, format_str):
+        # Remap %m/%d to %-m/%-d so sqlglot emits Spark's M/d (lenient)
+        # instead of MM/dd (strict 2-digit), allowing single-digit values.
+        if isinstance(format_str, sge.Literal) and "%" in format_str.this:
+            fmt = format_str.this.replace("%m", "%-m").replace("%d", "%-d")
+            format_str = sge.Literal.string(fmt)
+        return sge.StrToDate(this=arg, format=format_str)
+
     def visit_StringFind(self, op, *, arg, substr, start, end):
         if end is not None:
             raise com.UnsupportedOperationError(

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -386,3 +386,33 @@ def test_scalar_dot_sql(con):
     sql = sg.select(sge.convert(1).as_("a")).sql(con.dialect)
     expr = con.sql(sql).as_scalar()
     assert expr.type().is_numeric()
+
+
+@pytest.mark.notimpl(["druid", "polars"])
+@pytest.mark.notyet(
+    ["impala"], reason="Impala does not support recursive CTEs"
+)
+@pytest.mark.notyet(
+    ["flink"], reason="Flink does not support recursive CTEs"
+)
+def test_con_dot_sql_recursive_cte(con):
+    """Verify that WITH RECURSIVE is preserved through ibis compilation (GH #11949)."""
+    sql = sg.parse_one(
+        """
+        WITH RECURSIVE counter(n) AS (
+            SELECT 1 AS n
+            UNION ALL
+            SELECT n + 1 FROM counter WHERE n < 3
+        )
+        SELECT n FROM counter ORDER BY n
+        """,
+        read="duckdb",
+    ).sql(con.dialect)
+
+    expr = con.sql(sql)
+
+    assert "RECURSIVE" in ibis.to_sql(expr, dialect=con.name)
+
+    result = expr.execute()
+    expected = pd.DataFrame({"n": [1, 2, 3]})
+    tm.assert_frame_equal(result, expected, check_dtype=False)

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1411,13 +1411,27 @@ def test_string_as_date(alltypes, fmt):
         assert val.strftime("%m/%d/%y") == result["date_string_col"][i]
 
 
-@pytest.mark.pyspark
-def test_string_as_date_single_digit_pyspark(con):
-    # Regression test for https://github.com/ibis-project/ibis/issues/12004
-    # Spark's MM/dd require leading zeros; M/d accept single-digit values.
-    t = con.sql("SELECT '1/1/2026' AS raw_date")
-    result = t.mutate(parsed=t.raw_date.as_date("%m/%d/%Y")).execute()
-    assert result["parsed"][0].date() == datetime.date(2026, 1, 1)
+@pytest.mark.notyet(
+    ["materialize"],
+    raises=PsycoPgInternalError,
+    reason="Materialize doesn't have to_date() function - backend limitation",
+)
+@pytest.mark.notimpl(
+    ["clickhouse", "sqlite", "datafusion", "mssql", "druid"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(
+    ["flink", "impala"],
+    raises=AssertionError,
+    reason="Java SimpleDateFormat MM/dd is strict; single-digit values return wrong results",
+)
+def test_string_as_date_single_digit(con):
+    expr = ibis.literal("1/1/2026").as_date("%m/%d/%Y")
+    result = con.execute(expr)
+    if isinstance(result, datetime.datetime):
+        result = result.date()
+    assert result == datetime.date(2026, 1, 1)
 
 
 @pytest.mark.notyet(

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1411,6 +1411,15 @@ def test_string_as_date(alltypes, fmt):
         assert val.strftime("%m/%d/%y") == result["date_string_col"][i]
 
 
+@pytest.mark.pyspark
+def test_string_as_date_single_digit_pyspark(con):
+    # Regression test for https://github.com/ibis-project/ibis/issues/12004
+    # Spark's MM/dd require leading zeros; M/d accept single-digit values.
+    t = con.sql("SELECT '1/1/2026' AS raw_date")
+    result = t.mutate(parsed=t.raw_date.as_date("%m/%d/%Y")).execute()
+    assert result["parsed"][0].date() == datetime.date(2026, 1, 1)
+
+
 @pytest.mark.notyet(
     [
         "pyspark",


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

translate() and add_query_to_expr() in SQLGlotCompiler rebuild the WITH clause by extracting CTEs from the existing With node and then popping the node entirely via out.args.pop (WITH_ARG, None). This discards the recursive=True flag on the node, so the reconstructed WITH clause never includes RECURSIVE.

Fix: capture is_recursive from the With node before the pop, then restore the flag on the rebuilt node after the reduce

## Issues closed

Resolves #11949
<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
