### PR TITLE
fix(sql): preserve RECURSIVE keyword when rebuilding WITH clause

### DIFF
--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -687,6 +687,11 @@ class SQLGlotCompiler(abc.ABC):
                 alias=sg.to_identifier(aliases[cte], quoted=self.quoted), this=this
             )
             merged_ctes.append(modified_cte)
+
+        # Capture the recursive flag before the With node is discarded
+        with_node = out.args.get(WITH_ARG)
+        is_recursive = with_node is not None and bool(with_node.args.get("recursive"))
+
         merged_ctes.extend(out.ctes)
         out.args.pop(WITH_ARG, None)
 
@@ -700,6 +705,10 @@ class SQLGlotCompiler(abc.ABC):
             merged_ctes,
             out,
         )
+
+        # Restore the recursive flag on the rebuilt With node
+        if is_recursive and WITH_ARG in out.args:
+            out.args[WITH_ARG].set("recursive", True)
 
         return out
 
@@ -1622,6 +1631,10 @@ class SQLGlotCompiler(abc.ABC):
             ),
             *compiled_query.ctes,
         ]
+        # Capture the recursive flag before the With node is discarded
+        with_node = compiled_query.args.get(WITH_ARG)
+        is_recursive = with_node is not None and bool(with_node.args.get("recursive"))
+
         compiled_ibis_expr.args.pop(WITH_ARG, None)
         compiled_query.args.pop(WITH_ARG, None)
 
@@ -1632,6 +1645,10 @@ class SQLGlotCompiler(abc.ABC):
             ctes,
             compiled_query,
         )
+
+        # Restore the recursive flag on the rebuilt With node
+        if is_recursive and WITH_ARG in parsed.args:
+            parsed.args[WITH_ARG].set("recursive", True)
 
         # generate the SQL string
         return parsed.sql(dialect)

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -386,3 +386,33 @@ def test_scalar_dot_sql(con):
     sql = sg.select(sge.convert(1).as_("a")).sql(con.dialect)
     expr = con.sql(sql).as_scalar()
     assert expr.type().is_numeric()
+
+
+@pytest.mark.notimpl(["druid", "polars"])
+@pytest.mark.notyet(
+    ["impala"], reason="Impala does not support recursive CTEs"
+)
+@pytest.mark.notyet(
+    ["flink"], reason="Flink does not support recursive CTEs"
+)
+def test_con_dot_sql_recursive_cte(con):
+    """Verify that WITH RECURSIVE is preserved through ibis compilation (GH #11949)."""
+    sql = sg.parse_one(
+        """
+        WITH RECURSIVE counter(n) AS (
+            SELECT 1 AS n
+            UNION ALL
+            SELECT n + 1 FROM counter WHERE n < 3
+        )
+        SELECT n FROM counter ORDER BY n
+        """,
+        read="duckdb",
+    ).sql(con.dialect)
+
+    expr = con.sql(sql)
+
+    assert "RECURSIVE" in ibis.to_sql(expr, dialect=con.name)
+
+    result = expr.execute()
+    expected = pd.DataFrame({"n": [1, 2, 3]})
+    tm.assert_frame_equal(result, expected, check_dtype=False)

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -389,12 +389,28 @@ def test_scalar_dot_sql(con):
 
 
 @pytest.mark.notimpl(["druid", "polars"])
+@pytest.mark.notyet(["impala"], reason="Impala does not support recursive CTEs")
+@pytest.mark.notyet(["flink"], reason="Flink does not support recursive CTEs")
+@pytest.mark.notyet(["pyspark"], reason="PySpark does not support recursive CTEs")
 @pytest.mark.notyet(
-    ["impala"], reason="Impala does not support recursive CTEs"
+    ["oracle"],
+    reason="Oracle does not use the RECURSIVE keyword in recursive CTEs and "
+    "sqlglot's oracle dialect still emits it, causing a syntax error",
 )
 @pytest.mark.notyet(
-    ["flink"], reason="Flink does not support recursive CTEs"
+    ["mssql"],
+    reason="T-SQL does not include a RECURSIVE keyword in recursive CTEs, "
+    "so the generated SQL never contains the literal string 'RECURSIVE'",
 )
+@pytest.mark.notyet(
+    ["materialize"],
+    reason="Materialize uses WITH MUTUALLY RECURSIVE syntax, not WITH RECURSIVE",
+)
+@pytest.mark.notyet(["risingwave"], reason="RisingWave does not support recursive CTEs")
+@pytest.mark.notyet(
+    ["singlestoredb"], reason="SingleStoreDB does not support recursive CTEs"
+)
+@pytest.mark.notyet(["exasol"], reason="Exasol does not support recursive CTEs")
 def test_con_dot_sql_recursive_cte(con):
     """Verify that WITH RECURSIVE is preserved through ibis compilation (GH #11949)."""
     sql = sg.parse_one(


### PR DESCRIPTION

<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

translate() and add_query_to_expr() in SQLGlotCompiler rebuild the WITH clause by extracting CTEs from the existing With node and then popping the node entirely via out.args.pop(WITH_ARG, None). This discards the recursive=True flag on the node, so the reconstructed WITH clause never includes RECURSIVE.

Fix: capture is_recursive from the With node before the pop, then restore the flag on the rebuilt node after the reduce

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

## Issues closed
 * Resolves #11949
<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
