### PR TITLE
fix(docker): update build deps for postgis 18-3.6 / pgvector v0.8.5

### DIFF
--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:18-3.6-alpine AS pgvector-builder
-RUN apk add --no-cache git build-base clang19 llvm19
-RUN git clone --branch v0.8.1 https://github.com/pgvector/pgvector.git /tmp/pgvector
+RUN apk add --no-cache git build-base clang21 llvm21
+RUN git clone --branch v0.8.5 https://github.com/pgvector/pgvector.git /tmp/pgvector
 RUN make -C /tmp/pgvector -j "$(nproc)"
 RUN make -C /tmp/pgvector -j "$(nproc)" install
 


### PR DESCRIPTION
## Description of changes

The underlying Alpine version in postgis bumped up and removed the
`clang19` and `llvm19` packages.
Now we target `clang21` and `llvm21` -- additionally bumping the version
of `pgvector` we use, but we can roll that back if CI fails.

PR opened off a local branch to make sure the builds are reflective of the changes.
