### PR TITLE
fix(ci): only checkout PR branch for conventional commits when non-fork

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -23,7 +23,10 @@ jobs:
       - name: checkout code to pick up commitlint configuration
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          # If the PR is from a fork, grab the commitlint configuration from
+          # our main branch.  If the PR is from a local branch, grab the code
+          # from that branch.
+          ref: ${{ github.event.pull_request.head.repo.fork && github.event.repository.default_branch || github.event.pull_request.head.sha }}
 
       - name: run commitlint
         id: lint


### PR DESCRIPTION
## Description of changes

Since this fires on `pull_request_target`, we want to make sure it doesn't try
to check out code from an unknown source. In the event that we need to update
the conventional commits config, a maintainer can push up the changes to a
non-fork branch and PR there to test. This should also allow the checks to
proceed without requiring setting `allow-unsafe-pr-checkout: true`, which
seems, you know, unsafe.

