### PR TITLE
feat(bigquery): support JSON array operations

### DIFF
--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -122,6 +122,32 @@ def test_cast_float_to_int(alltypes, df):
     tm.assert_series_equal(result, expected, check_names=False, check_index=False)
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("[1, 2]", [1, 2], id="array"),
+        pytest.param(None, None, id="null"),
+    ],
+)
+def test_cast_string_to_json(con, value, expected):
+    expr = ibis.literal(value, type="string").cast("json")
+
+    assert con.execute(expr) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("[1, 2]", [1, 2], id="valid"),
+        pytest.param("not json", None, id="malformed"),
+    ],
+)
+def test_try_cast_string_to_json(con, value, expected):
+    expr = ibis.literal(value).try_cast("json")
+
+    assert con.execute(expr) == expected
+
+
 def test_has_partitions(alltypes, parted_alltypes, con):
     col = con.partition_column
     assert col not in alltypes.columns

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -167,6 +167,27 @@ def test_json_array_null(con, value):
     assert con.execute(expr.isnull())
 
 
+def test_json_array_relation(con):
+    payload = ibis.literal(
+        '[{"name":"first","status":"ready"},{"name":"second","status":"done"}]'
+    )
+    items = payload.cast("json").array.unnest().name("item").as_table()
+    expr = items.select(
+        name=items.item["name"].str,
+        status=items.item["status"].str,
+    )
+
+    result = con.execute(expr).sort_values("name").reset_index(drop=True)
+    expected = pd.DataFrame(
+        {
+            "name": ["first", "second"],
+            "status": ["ready", "done"],
+        }
+    )
+
+    tm.assert_frame_equal(result, expected)
+
+
 def test_has_partitions(alltypes, parted_alltypes, con):
     col = con.partition_column
     assert col not in alltypes.columns

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -148,6 +148,25 @@ def test_try_cast_string_to_json(con, value, expected):
     assert con.execute(expr) == expected
 
 
+def test_json_empty_array(con):
+    expr = ibis.literal("[]").cast("json").array
+
+    assert con.execute(expr) == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(None, id="null"),
+        pytest.param("{}", id="non-array"),
+    ],
+)
+def test_json_array_null(con, value):
+    expr = ibis.literal(value, type="string").cast("json").array
+
+    assert con.execute(expr.isnull())
+
+
 def test_has_partitions(alltypes, parted_alltypes, con):
     col = con.partition_column
     assert col not in alltypes.columns

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_cast_string_to_json/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_cast_string_to_json/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  PARSE_JSON(`t0`.`payload`) AS `Cast_payload_json`
+FROM `events` AS `t0`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_json_array/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_json_array/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  JSON_QUERY_ARRAY(`t0`.`payload`) AS `ToJSONArray_payload`
+FROM `events` AS `t0`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_json_array_relation/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_json_array_relation/out.sql
@@ -1,0 +1,21 @@
+WITH `items` AS (
+  SELECT
+    IF(pos = pos_2, `item`, NULL) AS `item`
+  FROM `events` AS `t0`
+  CROSS JOIN UNNEST(GENERATE_ARRAY(0, GREATEST(ARRAY_LENGTH(JSON_QUERY_ARRAY(PARSE_JSON(`t0`.`payload`)))) - 1)) AS pos
+  CROSS JOIN UNNEST(JSON_QUERY_ARRAY(PARSE_JSON(`t0`.`payload`))) AS `item` WITH OFFSET AS pos_2
+  WHERE
+    pos = pos_2
+    OR (
+      pos > (
+        ARRAY_LENGTH(JSON_QUERY_ARRAY(PARSE_JSON(`t0`.`payload`))) - 1
+      )
+      AND pos_2 = (
+        ARRAY_LENGTH(JSON_QUERY_ARRAY(PARSE_JSON(`t0`.`payload`))) - 1
+      )
+    )
+)
+SELECT
+  safe.string(`t2`.`item`['name']) AS `name`,
+  safe.string(`t2`.`item`['status']) AS `status`
+FROM `items` AS `t2`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_try_cast_string_to_json/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_try_cast_string_to_json/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  SAFE.PARSE_JSON(`t0`.`payload`) AS `TryCast_payload`
+FROM `events` AS `t0`

--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -147,6 +147,17 @@ def test_json_array(snapshot):
     snapshot.assert_match(to_sql(t.payload.array), "out.sql")
 
 
+def test_json_array_relation(snapshot):
+    t = ibis.table({"payload": "string"}, name="events")
+    items = t.select(item=t.payload.cast("json").array.unnest()).alias("items")
+    expr = items.select(
+        name=items.item["name"].str,
+        status=items.item["status"].str,
+    )
+
+    snapshot.assert_match(to_sql(expr), "out.sql")
+
+
 @pytest.mark.parametrize(
     ("case", "dtype"),
     [

--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -141,6 +141,12 @@ def test_try_cast_string_to_json(snapshot):
     snapshot.assert_match(to_sql(t.payload.try_cast("json")), "out.sql")
 
 
+def test_json_array(snapshot):
+    t = ibis.table({"payload": "json"}, name="events")
+
+    snapshot.assert_match(to_sql(t.payload.array), "out.sql")
+
+
 @pytest.mark.parametrize(
     ("case", "dtype"),
     [

--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -129,6 +129,18 @@ def test_literal_string(case, snapshot):
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
+def test_cast_string_to_json(snapshot):
+    t = ibis.table({"payload": "string"}, name="events")
+
+    snapshot.assert_match(to_sql(t.payload.cast("json")), "out.sql")
+
+
+def test_try_cast_string_to_json(snapshot):
+    t = ibis.table({"payload": "string"}, name="events")
+
+    snapshot.assert_match(to_sql(t.payload.try_cast("json")), "out.sql")
+
+
 @pytest.mark.parametrize(
     ("case", "dtype"),
     [

--- a/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -638,6 +638,9 @@ class BigQueryCompiler(SQLGlotCompiler):
             return self.f.anon["SAFE.PARSE_JSON"](arg)
         return super().visit_TryCast(op, arg=arg, to=to)
 
+    def visit_ToJSONArray(self, op, *, arg):
+        return self.f.anon["JSON_QUERY_ARRAY"](arg)
+
     def visit_JSONGetItem(self, op, *, arg, index):
         return arg[index]
 

--- a/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -611,7 +611,9 @@ class BigQueryCompiler(SQLGlotCompiler):
 
     def visit_Cast(self, op, *, arg, to):
         from_ = op.arg.dtype
-        if from_.is_timestamp() and to.is_integer():
+        if from_.is_string() and to.is_json():
+            return self.f.parse_json(arg)
+        elif from_.is_timestamp() and to.is_integer():
             return self.f.unix_micros(arg)
         elif from_.is_numeric() and to.is_timestamp():
             if from_.is_integer():
@@ -630,6 +632,11 @@ class BigQueryCompiler(SQLGlotCompiler):
         elif from_.is_floating() and to.is_integer():
             return self.cast(self.f.trunc(arg), dt.int64)
         return super().visit_Cast(op, arg=arg, to=to)
+
+    def visit_TryCast(self, op, *, arg, to):
+        if op.arg.dtype.is_string() and to.is_json():
+            return self.f.anon["SAFE.PARSE_JSON"](arg)
+        return super().visit_TryCast(op, arg=arg, to=to)
 
     def visit_JSONGetItem(self, op, *, arg, index):
         return arg[index]


### PR DESCRIPTION
## Description of changes

- Compile string-to-JSON casts with `PARSE_JSON` and string-to-JSON try casts with `SAFE.PARSE_JSON`.
- Compile JSON array unwrapping with `JSON_QUERY_ARRAY`, enabling JSON arrays to participate in Ibis array operations such as `unnest`.
- Add compiler snapshots and BigQuery system coverage for valid, malformed, empty, null, non-array, and relational JSON-array cases.

## Testing

- `just ci-check "--extra bigquery" ibis/backends/bigquery/tests/unit` (`260 passed, 4 xfailed`)
- `uv run --group dev pre-commit run --files <changed files>`