### PR TITLE
fix(snowflake): align columns, fix nested Arrow IO

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -456,7 +456,10 @@ $$ {defn["source"]} $$"""
         limit: int | str | None = None,
         **kwargs: Any,
     ) -> pa.Table:
-        from ibis.backends.snowflake.converter import SnowflakePyArrowData
+        from ibis.backends.snowflake.converter import (
+            SnowflakePyArrowData,
+            source_schema,
+        )
 
         self._run_pre_execute_hooks(expr)
 
@@ -466,7 +469,11 @@ $$ {defn["source"]} $$"""
 
         ibis_schema = expr.as_table().schema()
         if res is None:
-            res = ibis_schema.to_pyarrow().empty_table()
+            # the connector returns None rather than an empty table for a
+            # zero-row result; stand in for it with the schema snowflake would
+            # have sent, since the natively-typed one can't be wrapped in the
+            # JSON extension type below
+            res = source_schema(ibis_schema).empty_table()
         else:
             # snowflake can rewrite the aliases we asked for server-side, for
             # example when QUOTED_IDENTIFIERS_IGNORE_CASE is enabled, so align

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import functools
 import glob
 import itertools
 import json
@@ -465,9 +464,14 @@ $$ {defn["source"]} $$"""
         with self._safe_raw_sql(sql) as cur:
             res = cur.fetch_arrow_all()
 
-        target_schema = expr.as_table().schema().to_pyarrow()
+        ibis_schema = expr.as_table().schema()
         if res is None:
-            res = target_schema.empty_table()
+            res = ibis_schema.to_pyarrow().empty_table()
+        else:
+            # snowflake can rewrite the aliases we asked for server-side, for
+            # example when QUOTED_IDENTIFIERS_IGNORE_CASE is enabled, so align
+            # the result on position rather than on name
+            res = res.rename_columns(list(ibis_schema.names))
 
         return expr.__pyarrow_result__(res, data_mapper=SnowflakePyArrowData)
 
@@ -490,13 +494,15 @@ $$ {defn["source"]} $$"""
         self._run_pre_execute_hooks(expr)
         sql = self.compile(expr, limit=limit, params=params)
         target_schema = expr.as_table().schema()
-        converter = functools.partial(
-            SnowflakePandasData.convert_table, schema=target_schema
-        )
+
+        def convert(df: pd.DataFrame) -> pd.DataFrame:
+            # see the comment in `to_pyarrow` about positional alignment
+            df.columns = list(target_schema.names)
+            return SnowflakePandasData.convert_table(df, target_schema)
 
         with self._safe_raw_sql(sql) as cur:
             yield from map(
-                expr.__pandas_result__, map(converter, cur.fetch_pandas_batches())
+                expr.__pandas_result__, map(convert, cur.fetch_pandas_batches())
             )
 
     def to_pyarrow_batches(

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -515,9 +515,14 @@ $$ {defn["source"]} $$"""
         chunk_size: int = 1_000_000,
         **kwargs: Any,
     ) -> pa.ipc.RecordBatchReader:
+        from ibis.backends.snowflake.converter import source_schema
+
         self._run_pre_execute_hooks(expr)
         sql = self.compile(expr, limit=limit, params=params, **kwargs)
-        target_schema = expr.as_table().schema().to_pyarrow()
+        # cast to what snowflake actually sends, not to the nested arrow types
+        # the ibis schema maps to: VARIANT, ARRAY and OBJECT arrive as JSON
+        # strings, and `string -> list/map/struct` is not an implemented cast
+        target_schema = source_schema(expr.as_table().schema())
 
         return pa.ipc.RecordBatchReader.from_batches(
             target_schema,
@@ -527,7 +532,7 @@ $$ {defn["source"]} $$"""
         )
 
     def _make_batch_iter(
-        self, sql: str, *, target_schema: sch.Schema, chunk_size: int
+        self, sql: str, *, target_schema: pa.Schema, chunk_size: int
     ) -> Iterator[pa.RecordBatch]:
         with self._safe_raw_sql(sql) as cur:
             yield from itertools.chain.from_iterable(

--- a/ibis/backends/snowflake/converter.py
+++ b/ibis/backends/snowflake/converter.py
@@ -87,10 +87,37 @@ else:
 
 
 try:
-    from ibis.formats.pyarrow import PyArrowData
+    from ibis.formats.pyarrow import PyArrowData, PyArrowType
 except ModuleNotFoundError:
     pass
 else:
+
+    def _is_json_encoded(dtype: dt.DataType) -> bool:
+        """Return whether snowflake hands back `dtype` as a JSON-encoded string."""
+        return (
+            dtype.is_json() or dtype.is_array() or dtype.is_map() or dtype.is_struct()
+        )
+
+    def source_schema(schema: Schema) -> pa.Schema:
+        """Return the pyarrow schema snowflake actually sends for `schema`.
+
+        Identical to `PyArrowSchema.from_ibis` except that JSON-encoded columns
+        arrive as strings: snowflake has no typed wire format for VARIANT,
+        ARRAY or OBJECT, so it serializes them and the nested arrow types the
+        ibis schema maps to never appear on the wire.
+        """
+        return pa.schema(
+            [
+                pa.field(
+                    name,
+                    pa.string()
+                    if _is_json_encoded(dtype)
+                    else PyArrowType.from_ibis(dtype),
+                    nullable=dtype.nullable,
+                )
+                for name, dtype in schema.items()
+            ]
+        )
 
     class SnowflakePyArrowData(PyArrowData):
         @classmethod
@@ -110,12 +137,7 @@ else:
 
         @classmethod
         def convert_column(cls, column: pa.Array, dtype: dt.DataType) -> pa.Array:
-            if (
-                dtype.is_json()
-                or dtype.is_array()
-                or dtype.is_map()
-                or dtype.is_struct()
-            ):
+            if _is_json_encoded(dtype):
                 if isinstance(column, pa.ChunkedArray):
                     column = column.combine_chunks()
 
@@ -124,11 +146,6 @@ else:
 
         @classmethod
         def convert_scalar(cls, scalar: pa.Scalar, dtype: dt.DataType) -> pa.Scalar:
-            if (
-                dtype.is_json()
-                or dtype.is_array()
-                or dtype.is_map()
-                or dtype.is_struct()
-            ):
+            if _is_json_encoded(dtype):
                 return pa.ExtensionScalar.from_storage(PYARROW_JSON_TYPE, scalar)
             return super().convert_scalar(scalar, dtype)

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -444,11 +444,8 @@ def test_insert_dict_variants(con):
 
 
 def test_nested_types_empty_result(con):
-    # a zero-row result is the eager path's problem specifically: the connector
-    # returns None from `fetch_arrow_all`, so `to_pyarrow` has to build a
-    # stand-in table, and a natively-typed one can't carry the JSON extension
-    # wrapping. `to_pyarrow_batches` never receives a batch to cast, so it was
-    # always fine -- the asserted schemas below pin that asymmetry
+    # only `to_pyarrow` is affected -- it builds a stand-in table when the
+    # connector returns None; the batches path never gets a batch to cast
     from ibis.backends.snowflake.converter import PYARROW_JSON_TYPE
 
     lit = ibis.struct({"a": [1, 2, 3]}).cast("struct<a: array<int>>")
@@ -465,8 +462,7 @@ def test_nested_types_empty_result(con):
 
 
 def test_nested_types_stream_as_json_text(con, tmp_path):
-    # the batches path casts to what snowflake sends, so nested columns arrive
-    # as JSON strings rather than as the arrow types the ibis schema maps to
+    # snowflake sends nested values as JSON text and the batches path keeps it
     raw = {"a": [1, 2, 3], "b": "456"}
     lit = ibis.struct(raw).cast("struct<a: array<int>, b: json>")
     t = (
@@ -481,12 +477,11 @@ def test_nested_types_stream_as_json_text(con, tmp_path):
     assert batched.schema.field("lit").type == pa.string()
     assert json.loads(batched["lit"][0].as_py()) == raw
 
-    # which is exactly what lets CSV work, with no override needed
     out = tmp_path / "nested.csv"
     con.to_csv(t, out)
     assert json.loads(pcsv.read_csv(out)["lit"][0].as_py()) == raw
 
-    # meanwhile the eager path still wraps, which is what `repr` depends on
+    # the eager path still wraps, which is what `repr` depends on
     assert con.to_pyarrow(t)["lit"][0].as_py() == raw
 
 
@@ -499,9 +494,8 @@ def ignore_case_con():
 
 
 def test_mixed_case_columns_ignore_case(ignore_case_con):
-    # under QUOTED_IDENTIFIERS_IGNORE_CASE snowflake folds the quoted aliases
-    # we emit to uppercase server-side, so results come back with names that
-    # don't match the ibis schema
+    # snowflake folds our quoted aliases to uppercase under this session
+    # parameter, so results come back with names the ibis schema doesn't have
     expected = pd.DataFrame({"errorCode": [1, 2, 3], "eventType": list("abc")})
     t = ibis.memtable(expected)
 
@@ -511,9 +505,8 @@ def test_mixed_case_columns_ignore_case(ignore_case_con):
     assert arrow.column_names == names
     tm.assert_frame_equal(arrow.to_pandas(), expected)
 
-    # `reader.schema` is computed client-side before the query runs, so it
-    # proves nothing on its own -- drain the reader to exercise the server
-    # round trip that actually does the folding
+    # `reader.schema` is computed client-side, so drain the reader to
+    # actually exercise the server round trip
     with ignore_case_con.to_pyarrow_batches(t) as reader:
         batched = reader.read_all()
     assert batched.column_names == names

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -442,6 +442,34 @@ def test_insert_dict_variants(con):
     assert len(t.execute()) == 4
 
 
+@pytest.fixture(scope="session")
+def ignore_case_con():
+    # a dedicated connection, because `_setup_session` mutates the session
+    return ibis.connect(
+        _get_url(), session_parameters={"QUOTED_IDENTIFIERS_IGNORE_CASE": True}
+    )
+
+
+def test_mixed_case_columns_ignore_case(ignore_case_con):
+    # under QUOTED_IDENTIFIERS_IGNORE_CASE snowflake folds the quoted aliases
+    # we emit to uppercase server-side, so results come back with names that
+    # don't match the ibis schema
+    expected = pd.DataFrame({"errorCode": [1, 2, 3], "eventType": list("abc")})
+    t = ibis.memtable(expected)
+
+    names = list(expected.columns)
+
+    assert ignore_case_con.to_pyarrow(t).column_names == names
+
+    with ignore_case_con.to_pyarrow_batches(t) as reader:
+        assert reader.schema.names == names
+
+    tm.assert_frame_equal(ignore_case_con.to_pandas(t), expected)
+
+    batches = list(ignore_case_con.to_pandas_batches(t))
+    tm.assert_frame_equal(pd.concat(batches, ignore_index=True), expected)
+
+
 @h.given(
     column_name=st.text(
         st.characters(

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -17,6 +17,7 @@ from pytest import param
 
 import ibis
 import ibis.common.exceptions as com
+from ibis.backends.snowflake.converter import PYARROW_JSON_TYPE
 from ibis.backends.snowflake.tests.conftest import _get_url
 from ibis.util import gen_name
 
@@ -444,10 +445,8 @@ def test_insert_dict_variants(con):
 
 
 def test_nested_types_empty_result(con):
-    # only `to_pyarrow` is affected -- it builds a stand-in table when the
-    # connector returns None; the batches path never gets a batch to cast
-    from ibis.backends.snowflake.converter import PYARROW_JSON_TYPE
-
+    # only `to_pyarrow` is affected: it builds a stand-in table when the
+    # connector returns None, while the batches path never gets a batch to cast
     lit = ibis.struct({"a": [1, 2, 3]}).cast("struct<a: array<int>>")
     t = con.tables.functional_alltypes.mutate(lit=lit).limit(0).select("id", "lit")
 

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -9,6 +9,7 @@ import hypothesis.strategies as st
 import pandas as pd
 import pandas.testing as tm
 import pyarrow as pa
+import pyarrow.csv as pcsv
 import pytest
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -443,18 +444,50 @@ def test_insert_dict_variants(con):
 
 
 def test_nested_types_empty_result(con):
-    # the connector returns None from `fetch_arrow_all` for a zero-row result;
-    # standing in for it with natively-typed empty columns blows up when the
-    # JSON extension wrapping is applied
+    # a zero-row result is the eager path's problem specifically: the connector
+    # returns None from `fetch_arrow_all`, so `to_pyarrow` has to build a
+    # stand-in table, and a natively-typed one can't carry the JSON extension
+    # wrapping. `to_pyarrow_batches` never receives a batch to cast, so it was
+    # always fine -- the asserted schemas below pin that asymmetry
+    from ibis.backends.snowflake.converter import PYARROW_JSON_TYPE
+
     lit = ibis.struct({"a": [1, 2, 3]}).cast("struct<a: array<int>>")
     t = con.tables.functional_alltypes.mutate(lit=lit).limit(0).select("id", "lit")
 
     eager = con.to_pyarrow(t)
     assert len(eager) == 0
+    assert eager.schema.field("lit").type == PYARROW_JSON_TYPE
 
     with con.to_pyarrow_batches(t) as reader:
         batched = reader.read_all()
     assert len(batched) == 0
+    assert batched.schema.field("lit").type == pa.string()
+
+
+def test_nested_types_stream_as_json_text(con, tmp_path):
+    # the batches path casts to what snowflake sends, so nested columns arrive
+    # as JSON strings rather than as the arrow types the ibis schema maps to
+    raw = {"a": [1, 2, 3], "b": "456"}
+    lit = ibis.struct(raw).cast("struct<a: array<int>, b: json>")
+    t = (
+        con.tables.functional_alltypes.mutate(lit=lit)
+        .order_by("id")
+        .limit(1)
+        .select("id", "lit")
+    )
+
+    with con.to_pyarrow_batches(t) as reader:
+        batched = reader.read_all()
+    assert batched.schema.field("lit").type == pa.string()
+    assert json.loads(batched["lit"][0].as_py()) == raw
+
+    # which is exactly what lets CSV work, with no override needed
+    out = tmp_path / "nested.csv"
+    con.to_csv(t, out)
+    assert json.loads(pcsv.read_csv(out)["lit"][0].as_py()) == raw
+
+    # meanwhile the eager path still wraps, which is what `repr` depends on
+    assert con.to_pyarrow(t)["lit"][0].as_py() == raw
 
 
 @pytest.fixture(scope="session")

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -442,6 +442,21 @@ def test_insert_dict_variants(con):
     assert len(t.execute()) == 4
 
 
+def test_nested_types_empty_result(con):
+    # the connector returns None from `fetch_arrow_all` for a zero-row result;
+    # standing in for it with natively-typed empty columns blows up when the
+    # JSON extension wrapping is applied
+    lit = ibis.struct({"a": [1, 2, 3]}).cast("struct<a: array<int>>")
+    t = con.tables.functional_alltypes.mutate(lit=lit).limit(0).select("id", "lit")
+
+    eager = con.to_pyarrow(t)
+    assert len(eager) == 0
+
+    with con.to_pyarrow_batches(t) as reader:
+        batched = reader.read_all()
+    assert len(batched) == 0
+
+
 @pytest.fixture(scope="session")
 def ignore_case_con():
     # a dedicated connection, because `_setup_session` mutates the session
@@ -459,10 +474,17 @@ def test_mixed_case_columns_ignore_case(ignore_case_con):
 
     names = list(expected.columns)
 
-    assert ignore_case_con.to_pyarrow(t).column_names == names
+    arrow = ignore_case_con.to_pyarrow(t)
+    assert arrow.column_names == names
+    tm.assert_frame_equal(arrow.to_pandas(), expected)
 
+    # `reader.schema` is computed client-side before the query runs, so it
+    # proves nothing on its own -- drain the reader to exercise the server
+    # round trip that actually does the folding
     with ignore_case_con.to_pyarrow_batches(t) as reader:
-        assert reader.schema.names == names
+        batched = reader.read_all()
+    assert batched.column_names == names
+    tm.assert_frame_equal(batched.to_pandas(), expected)
 
     tm.assert_frame_equal(ignore_case_con.to_pandas(t), expected)
 

--- a/ibis/backends/snowflake/tests/test_converter.py
+++ b/ibis/backends/snowflake/tests/test_converter.py
@@ -9,7 +9,7 @@ from ibis.backends.snowflake.converter import (
     SnowflakePyArrowData,
     source_schema,
 )
-from ibis.formats.pyarrow import PyArrowSchema
+from ibis.formats.pyarrow import PyArrowSchema, PyArrowType
 
 JSON_ENCODED = ["json", "array<int64>", "map<string, int64>", "struct<a: int64>"]
 
@@ -84,3 +84,19 @@ def test_eager_path_still_wraps_in_the_extension_type(dtype):
     converted = SnowflakePyArrowData.convert_table(raw, schema)
     assert converted.schema.field("x").type == PYARROW_JSON_TYPE
     assert converted["x"][0].as_py() == {"a": 1}
+
+
+@pytest.mark.parametrize("dtype", JSON_ENCODED)
+def test_extension_type_round_trips_lossily(dtype):
+    # array, map and struct are all wrapped in the same extension type, so a
+    # schema round trip collapses every one of them to `json`. that is lossy by
+    # construction -- the extension type carries no record of what it wrapped --
+    # and this pins the contract rather than leaving it implied
+    schema = ibis.schema({"x": dtype})
+    wrapped = SnowflakePyArrowData.convert_table(
+        pa.table({"x": pa.array(['{"a": 1}'])}), schema
+    )
+    assert wrapped.schema.field("x").type == PYARROW_JSON_TYPE
+
+    assert PyArrowSchema.to_ibis(wrapped.schema) == ibis.schema({"x": "json"})
+    assert PyArrowType.to_ibis(wrapped.schema.field("x").type) == ibis.dtype("json")

--- a/ibis/backends/snowflake/tests/test_converter.py
+++ b/ibis/backends/snowflake/tests/test_converter.py
@@ -70,7 +70,7 @@ def test_empty_table_survives_json_wrapping():
 
 
 def test_natively_typed_empty_table_would_not_survive():
-    # guards the reason the fix above is needed: the obvious stand-in raises
+    # the natively-typed stand-in raises, which is why the fix uses wire types
     schema = ibis.schema({"arr": "array<int64>"})
     with pytest.raises(TypeError, match="Incompatible storage type"):
         SnowflakePyArrowData.convert_table(schema.to_pyarrow().empty_table(), schema)
@@ -88,10 +88,9 @@ def test_eager_path_still_wraps_in_the_extension_type(dtype):
 
 @pytest.mark.parametrize("dtype", JSON_ENCODED)
 def test_extension_type_round_trips_lossily(dtype):
-    # array, map and struct are all wrapped in the same extension type, so a
-    # schema round trip collapses every one of them to `json`. that is lossy by
-    # construction -- the extension type carries no record of what it wrapped --
-    # and this pins the contract rather than leaving it implied
+    # array, map and struct all wrap into the same extension type, which keeps
+    # no record of what it wrapped, so a schema round trip collapses every one
+    # of them to `json`
     schema = ibis.schema({"x": dtype})
     wrapped = SnowflakePyArrowData.convert_table(
         pa.table({"x": pa.array(['{"a": 1}'])}), schema

--- a/ibis/backends/snowflake/tests/test_converter.py
+++ b/ibis/backends/snowflake/tests/test_converter.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+import ibis
+from ibis.backends.snowflake.converter import (
+    PYARROW_JSON_TYPE,
+    SnowflakePyArrowData,
+    source_schema,
+)
+from ibis.formats.pyarrow import PyArrowSchema
+
+JSON_ENCODED = ["json", "array<int64>", "map<string, int64>", "struct<a: int64>"]
+
+
+@pytest.mark.parametrize("dtype", JSON_ENCODED)
+def test_source_schema_sends_json_encoded_types_as_strings(dtype):
+    # snowflake serializes VARIANT/ARRAY/OBJECT, so the nested arrow types the
+    # ibis schema maps to never appear on the wire
+    schema = ibis.schema({"x": dtype})
+    assert source_schema(schema).field("x").type == pa.string()
+
+
+def test_source_schema_matches_base_for_scalar_types():
+    schema = ibis.schema(
+        {"i": "int64", "s": "string", "f": "float64", "b": "boolean", "t": "timestamp"}
+    )
+    assert source_schema(schema).equals(PyArrowSchema.from_ibis(schema))
+
+
+def test_source_schema_preserves_nullability():
+    schema = ibis.schema({"a": "!int64", "b": "int64", "c": "!json", "d": "json"})
+    assert [field.nullable for field in source_schema(schema)] == [
+        False,
+        True,
+        False,
+        True,
+    ]
+
+
+def test_source_schema_accepts_what_the_connector_sends():
+    # the batches path casts to this schema, so the cast must be a no-op for
+    # the JSON-encoded columns and a widening for the narrow integer types
+    # snowflake returns
+    schema = ibis.schema({"i": "int64", "js": "json", "arr": "array<int64>"})
+    raw = pa.table(
+        {
+            "i": pa.array([1, 2], pa.int8()),
+            "js": pa.array(['{"a": 1}', "null"]),
+            "arr": pa.array(["[1]", "[2]"]),
+        }
+    )
+    cast = raw.cast(source_schema(schema))
+    assert cast.schema.equals(source_schema(schema))
+    assert cast["arr"].to_pylist() == ["[1]", "[2]"]
+
+
+def test_empty_table_survives_json_wrapping():
+    # the connector returns None for a zero-row result; the stand-in has to use
+    # the wire types, because the extension wrapping rejects native nested
+    # arrays as storage
+    schema = ibis.schema(
+        {"i": "int64", "arr": "array<int64>", "m": "map<string, int64>"}
+    )
+    empty = source_schema(schema).empty_table()
+    converted = SnowflakePyArrowData.convert_table(empty, schema)
+    assert len(converted) == 0
+    assert converted.schema.field("arr").type == PYARROW_JSON_TYPE
+
+
+def test_natively_typed_empty_table_would_not_survive():
+    # guards the reason the fix above is needed: the obvious stand-in raises
+    schema = ibis.schema({"arr": "array<int64>"})
+    with pytest.raises(TypeError, match="Incompatible storage type"):
+        SnowflakePyArrowData.convert_table(schema.to_pyarrow().empty_table(), schema)
+
+
+@pytest.mark.parametrize("dtype", JSON_ENCODED)
+def test_eager_path_still_wraps_in_the_extension_type(dtype):
+    # the display path is unchanged: `repr` depends on `as_py` parsing the JSON
+    schema = ibis.schema({"x": dtype})
+    raw = pa.table({"x": pa.array(['{"a": 1}'])})
+    converted = SnowflakePyArrowData.convert_table(raw, schema)
+    assert converted.schema.field("x").type == PYARROW_JSON_TYPE
+    assert converted["x"][0].as_py() == {"a": 1}

--- a/ibis/formats/pyarrow.py
+++ b/ibis/formats/pyarrow.py
@@ -108,6 +108,14 @@ class PyArrowType(TypeMapper):
             return dt.Map(key_dtype, value_dtype, nullable=nullable)
         elif pa.types.is_dictionary(typ):
             return cls.to_ibis(typ.value_type)
+        elif isinstance(typ, pa.ExtensionType) and typ.extension_name == "ibis.json":
+            # the snowflake backend wraps JSON-encoded columns in a registered
+            # extension type whose storage is a JSON string; map it back so its
+            # own arrow output can be fed to `memtable` and friends
+            #
+            # this is lossy: array, map and struct columns are all wrapped in
+            # the same extension type, so they all come back as `json`
+            return dt.JSON(nullable=nullable)
         elif (
             isinstance(typ, pa.ExtensionType)
             and type(typ).__module__ == "geoarrow.types.type_pyarrow"

--- a/ibis/formats/tests/test_pyarrow.py
+++ b/ibis/formats/tests/test_pyarrow.py
@@ -197,6 +197,32 @@ def test_geo_gets_converted_to_geoarrow(ibis_type):
     )
 
 
+def test_ibis_json_extension_gets_converted_to_json():
+    # the snowflake backend returns JSON-encoded columns wrapped in a
+    # registered `ibis.json` extension type; without a case here, feeding that
+    # output back to `memtable` raises `TypeError: unhashable type: 'JSONType'`
+    converter = pytest.importorskip("ibis.backends.snowflake.converter")
+
+    assert PyArrowType.to_ibis(converter.PYARROW_JSON_TYPE) == dt.json
+    assert PyArrowType.to_ibis(converter.PYARROW_JSON_TYPE, nullable=False) == dt.JSON(
+        nullable=False
+    )
+
+
+def test_ibis_json_extension_roundtrips_through_memtable():
+    converter = pytest.importorskip("ibis.backends.snowflake.converter")
+
+    table = pa.table(
+        {
+            "i": pa.array([1]),
+            "js": pa.ExtensionArray.from_storage(
+                converter.PYARROW_JSON_TYPE, pa.array(['{"a": 1}'])
+            ),
+        }
+    )
+    assert ibis.memtable(table).schema() == ibis.schema({"i": "int64", "js": "json"})
+
+
 def test_geoarrow_gets_converted_to_geo():
     gat = pytest.importorskip("geoarrow.types")
 


### PR DESCRIPTION
## Description of changes

`to_pyarrow` looked up result columns by name, so it broke whenever Snowflake handed back different names than the ones we asked for. The usual trigger is `QUOTED_IDENTIFIERS_IGNORE_CASE`, where quoted aliases are folded to uppercase server-side:

```python
con = ibis.snowflake.connect(
    ..., session_parameters={"QUOTED_IDENTIFIERS_IGNORE_CASE": True}
)
t = con.table("MY_TABLE").rename({"errorCode": "ERRORCODE"})

t.head().to_pandas()           # works
t.head().to_pyarrow_batches()  # works
t.head().to_pyarrow()          # KeyError: 'Field "errorCode" does not exist in schema'
```

This PR aligns the result positionally instead, the way `_fetch_from_cursor` and `_make_batch_iter` already do here, and the way Athena and BigQuery do in their own `to_pyarrow`. `to_pandas_batches` was broken the same way for a different reason (it did no alignment at all), and raised `ValueError: schema names don't match input data columns`.

While checking whether the other paths were really fine, I found `to_pyarrow_batches` was broken for nested columns. It cast to `schema().to_pyarrow()`, but Snowflake has no typed wire format for VARIANT, ARRAY or OBJECT. Those arrive as JSON strings, and `string -> list/map/struct` isn't an implemented cast, so the batches path raised and took `to_parquet`, `to_parquet_dir`, `to_csv` and `to_delta` with it. Cast to what the connector actually sends instead. `to_csv` on nested columns now works, which it doesn't on any other backend, since PyArrow's CSV writer can't represent native nested types either.

Two smaller ones found along the way:

* `to_pyarrow` substituted a natively-typed empty table when the connector returned `None` for a zero-row result, so wrapping it in the JSON extension type raised `TypeError: Incompatible storage type`. Only the eager path is affected; the batches path never receives a batch to cast.
* `PyArrowType.to_ibis` had no case for the `ibis.json` extension type, so `ibis.memtable(con.to_pyarrow(t))` raised `TypeError: unhashable type: 'JSONType'`.

I first wrote the batches fix to route through `SnowflakePyArrowData`, tagging nested columns with the `ibis.json` extension type in both arrow paths so they'd agree. That version is on a branch, and compared against this one in a [comment below](https://github.com/ibis-project/ibis/pull/12060#issuecomment-5136555049). In short, it writes the extension type into Parquet, and the same file then reads back as `string` or as `extension<ibis.json>` depending on whether something in the reading process happened to import the Snowflake converter. This version keeps the extension type on the eager path where #7562 put it, at the cost of the two Arrow paths still disagreeing for `json` columns (which they already do on 12.0.0).

Snowflake CI is disabled (`disabled_manually`, last run 2026-01-24), so none of the backend tests here will run. Validated against a live account in a [comment below](https://github.com/ibis-project/ibis/pull/12060#issuecomment-5136179668). The two tests added to `ibis/formats/tests/test_pyarrow.py` are core tests and do run.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>