### PR TITLE
fix(impala): fix syntax error in `alter_partition`

### DIFF
--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -1303,7 +1303,7 @@ class Backend(SQLBackend, HasCurrentDatabase, NoExampleLoader):
 
         for field, values in alterations:
             if values is not None:
-                stmt = ddl.AlterPartition(qname, spec, part_schema, **{field, values})
+                stmt = ddl.AlterPartition(qname, spec, part_schema, **{field: values})
                 self._safe_exec_sql(stmt)
 
     def table_stats(self, name, database=None):

--- a/ibis/backends/impala/tests/test_partition.py
+++ b/ibis/backends/impala/tests/test_partition.py
@@ -162,6 +162,28 @@ def test_add_drop_partition_no_location(con, temp_table):
     assert len(con.list_partitions(temp_table)) == 1
 
 
+def test_alter_partition_location(con, temp_table):
+    schema = ibis.schema([("foo", "string"), ("year", "int32"), ("month", "int16")])
+    con.create_table(
+        temp_table,
+        schema=schema,
+        partition=["year", "month"],
+        tbl_properties={"transactional": "false"},
+    )
+
+    part = {"year": 2007, "month": 4}
+
+    con.add_partition(temp_table, part)
+
+    path = f"/tmp/{util.guid()}"
+
+    con.alter_partition(temp_table, part, location=path)
+
+    # only the first row is the partition; the second is the `Total` row
+    location = con.list_partitions(temp_table)["Location"].iloc[0]
+    assert location.endswith(path)
+
+
 def test_add_drop_partition_owned_by_impala(con, temp_table):
     schema = ibis.schema([("foo", "string"), ("year", "int32"), ("month", "int16")])
     con.create_table(


### PR DESCRIPTION
## Description of changes

Code had a typo always leading to `TypeError: AlterPartition() argument after ** must be a mapping, not set` at runtime`. It was present since the original implementation in https://github.com/ibis-project/ibis/pull/9840.
Which is a syntax error in Python, though not the one that would prevent a compilation, so it went unnoticed.

Fixed by replacing set with intended dict, and added a test that exercises this behavior.