### PR TITLE
fix(mssql): render bare Stddev as STDEV instead of STDEVP

### DIFF
--- a/ibis/backends/sql/dialects.py
+++ b/ibis/backends/sql/dialects.py
@@ -360,8 +360,6 @@ class MSSQL(TSQL):
     class Generator(TSQL.Generator):
         TRANSFORMS = TSQL.Generator.TRANSFORMS.copy() | {
             sge.ApproxDistinct: rename_func("approx_count_distinct"),
-            # T-SQL's bare STDEV is the sample standard deviation, so a bare
-            # Stddev node must round-trip back to STDEV, not STDEVP.
             sge.Stddev: rename_func("stdev"),
             sge.StddevPop: rename_func("stdevp"),
             sge.StddevSamp: rename_func("stdev"),

--- a/ibis/backends/sql/dialects.py
+++ b/ibis/backends/sql/dialects.py
@@ -360,7 +360,9 @@ class MSSQL(TSQL):
     class Generator(TSQL.Generator):
         TRANSFORMS = TSQL.Generator.TRANSFORMS.copy() | {
             sge.ApproxDistinct: rename_func("approx_count_distinct"),
-            sge.Stddev: rename_func("stdevp"),
+            # T-SQL's bare STDEV is the sample standard deviation, so a bare
+            # Stddev node must round-trip back to STDEV, not STDEVP.
+            sge.Stddev: rename_func("stdev"),
             sge.StddevPop: rename_func("stdevp"),
             sge.StddevSamp: rename_func("stdev"),
             sge.Variance: rename_func("var"),

--- a/ibis/backends/sql/tests/test_compiler.py
+++ b/ibis/backends/sql/tests/test_compiler.py
@@ -4,7 +4,7 @@ import sqlglot as sg
 
 import ibis
 from ibis import _
-from ibis.backends.sql.dialects import Trino
+from ibis.backends.sql.dialects import MSSQL, Trino
 
 
 def test_window_with_row_number_compiles():
@@ -26,3 +26,17 @@ def test_transpile_join():
         "SELECT * FROM t1 JOIN t2 ON x = y", read="duckdb", write=Trino
     )
     assert "CROSS JOIN" not in result
+
+
+def test_mssql_stdev_roundtrips_to_sample():
+    # GH #12057: the bare Stddev node is T-SQL's sample STDEV, so rendering it
+    # as STDEVP silently changed the statistic on a same-dialect round trip
+    (result,) = sg.transpile(
+        "SELECT STDEV([x]) AS [s] FROM [t]", read=MSSQL, write=MSSQL
+    )
+    assert result == "SELECT STDEV([x]) AS [s] FROM [t]"
+
+    (result,) = sg.transpile(
+        "SELECT STDEVP([x]) AS [s] FROM [t]", read=MSSQL, write=MSSQL
+    )
+    assert result == "SELECT STDEVP([x]) AS [s] FROM [t]"

--- a/ibis/backends/sql/tests/test_compiler.py
+++ b/ibis/backends/sql/tests/test_compiler.py
@@ -36,7 +36,9 @@ def test_mssql_stdev_roundtrips_to_sample():
     )
     assert result == "SELECT STDEV([x]) AS [s] FROM [t]"
 
-    (result,) = sg.transpile(
-        "SELECT STDEVP([x]) AS [s] FROM [t]", read=MSSQL, write=MSSQL
-    )
-    assert result == "SELECT STDEVP([x]) AS [s] FROM [t]"
+
+def test_mssql_std_emits_distinct_functions():
+    # the two ibis spellings must not collapse onto the same T-SQL function
+    t = ibis.table({"x": "float"}, name="t")
+    assert "STDEV(" in ibis.to_sql(t.x.std(how="sample"), dialect="mssql")
+    assert "STDEVP(" in ibis.to_sql(t.x.std(how="pop"), dialect="mssql")


### PR DESCRIPTION
## Description of changes

The MSSQL generator mapped `sge.Stddev` to `STDEVP` (population), but sqlglot parses a bare T-SQL `STDEV` — which is the *sample* standard deviation — into that node. Round-tripping T-SQL through the MSSQL dialect therefore rewrote `STDEV` to `STDEVP`, silently changing the statistic for raw SQL passed to `Backend.sql()`. `sge.StddevPop` already renders `STDEVP`, so the bare node now renders `STDEV`, matching vanilla sqlglot's `tsql` dialect.

Regression test added to `ibis/backends/sql/tests/test_compiler.py`; it fails on the current code and passes with the fix.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.

## Issues closed

* Resolves #12057
