### PR TITLE
fix(postgres): cast float literals to their type instead of emitting bare numerics

### DIFF
--- a/ibis/backends/sql/compilers/postgres.py
+++ b/ibis/backends/sql/compilers/postgres.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import math
 import string
 import textwrap
 from functools import partial, reduce
@@ -651,6 +652,14 @@ $$""".format(
     def visit_NonNullLiteral(self, op, *, value, dtype):
         if dtype.is_binary():
             return self.cast("".join(map(r"\x{:0>2x}".format, value)), dt.binary)
+        elif dtype.is_floating():
+            if math.isnan(value) or math.isinf(value):
+                # let the default implementation wrap these in a cast
+                return None
+            # Postgres interprets bare numeric literals as `numeric` (decimal),
+            # which round-trips as `Decimal` instead of `float`; cast to the
+            # literal's actual type to preserve float semantics.
+            return self.cast(sge.convert(value), dtype)
         elif dtype.is_time():
             to_int32 = partial(self.cast, to=dt.int32)
             to_float64 = partial(self.cast, to=dt.float64)

--- a/ibis/backends/sql/tests/test_compiler.py
+++ b/ibis/backends/sql/tests/test_compiler.py
@@ -26,3 +26,20 @@ def test_transpile_join():
         "SELECT * FROM t1 JOIN t2 ON x = y", read="duckdb", write=Trino
     )
     assert "CROSS JOIN" not in result
+
+
+def test_postgres_float_literals_are_cast():
+    # GH #11947: Postgres interprets bare numeric literals as `numeric`,
+    # which executes as `Decimal` instead of `float`; float literals must
+    # be wrapped in a cast to their ibis type
+    t = ibis.table({"x": "float64"}, name="t")
+
+    expr = t.mutate(v=ibis.literal(0.5518, type="float64"))
+    sql = ibis.to_sql(expr, dialect="postgres")
+    assert "CAST(0.5518 AS DOUBLE PRECISION)" in sql
+
+    # non-finite values are still rendered as casted string literals
+    nan_sql = ibis.to_sql(
+        t.mutate(v=ibis.literal(float("nan"), type="float64")), dialect="postgres"
+    )
+    assert "CAST('NaN' AS DOUBLE PRECISION)" in nan_sql


### PR DESCRIPTION
## Description of changes

Fixes #11947.

On the Postgres backend, a float literal compiles to a bare numeric literal:

```sql
SELECT "t0"."x", 0.5518 AS "v" FROM "t" AS "t0"
```

Postgres types bare decimal literals as `numeric`, so the value comes back as `Decimal` and `to_pyarrow` fails with:

```
Could not convert Decimal('0.5518') with type decimal.Decimal: tried to convert to double
```

The Postgres compiler's `visit_NonNullLiteral` doesn't handle floating literals, so they fall through to `visit_DefaultLiteral`, which emits the value without a cast. This change handles finite floating literals in the Postgres compiler by wrapping them in a cast to the literal's ibis type:

```sql
SELECT "t0"."x", CAST(0.5518 AS DOUBLE PRECISION) AS "v" FROM "t" AS "t0"
```

NaN and infinity return `None` so the default implementation keeps rendering them as the existing casted string literals (`CAST('NaN' AS DOUBLE PRECISION)`).

Other backends are unaffected — the change is scoped to the Postgres compiler. DuckDB, for example, already infers `DOUBLE` for bare float literals, which is why the issue only reproduces on Postgres.

## Tests

- Added `test_postgres_float_literals_are_cast` (compile-only, no server needed) covering the finite-float cast and the NaN rendering.
- `pytest ibis/backends/sql/tests`: the new test passes; the only failures are `test_unknown_repr` and `test_window_with_row_number_compiles`, which fail identically on a clean `main` checkout in my environment (pre-existing, unrelated).
