### PR TITLE
fix(snowflake): align fetched columns positionally

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -496,7 +496,8 @@ $$ {defn["source"]} $$"""
         target_schema = expr.as_table().schema()
 
         def convert(df: pd.DataFrame) -> pd.DataFrame:
-            # see the comment in `to_pyarrow` about positional alignment
+            # snowflake can rewrite the aliases we asked for server-side, so
+            # align the result on position rather than on name
             df.columns = list(target_schema.names)
             return SnowflakePandasData.convert_table(df, target_schema)
 

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -495,7 +495,8 @@ $$ {defn["source"]} $$"""
         target_schema = expr.as_table().schema()
 
         def convert(df: pd.DataFrame) -> pd.DataFrame:
-            # see `to_pyarrow`; align on position rather than on name
+            # snowflake can rewrite the aliases we asked for, so align on
+            # position rather than on name
             df.columns = list(target_schema.names)
             return SnowflakePandasData.convert_table(df, target_schema)
 

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -494,7 +494,7 @@ $$ {defn["source"]} $$"""
         sql = self.compile(expr, limit=limit, params=params)
         target_schema = expr.as_table().schema()
 
-        def df_to_result(df: pd.DataFrame) -> pd.DataFrame | pd.Series | Any:
+        def format_result(df: pd.DataFrame) -> pd.DataFrame | pd.Series | Any:
             # snowflake can rewrite the aliases we asked for, so align on
             # position rather than on name
             df.columns = list(target_schema.names)
@@ -503,7 +503,7 @@ $$ {defn["source"]} $$"""
             )
 
         with self._safe_raw_sql(sql) as cur:
-            yield from map(df_to_result, cur.fetch_pandas_batches())
+            yield from map(format_result, cur.fetch_pandas_batches())
 
     def to_pyarrow_batches(
         self,

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import functools
 import glob
 import itertools
 import json
@@ -465,9 +464,14 @@ $$ {defn["source"]} $$"""
         with self._safe_raw_sql(sql) as cur:
             res = cur.fetch_arrow_all()
 
-        target_schema = expr.as_table().schema().to_pyarrow()
+        ibis_schema = expr.as_table().schema()
         if res is None:
-            res = target_schema.empty_table()
+            res = ibis_schema.to_pyarrow().empty_table()
+        else:
+            # snowflake can rewrite the aliases we asked for server-side, for
+            # example when QUOTED_IDENTIFIERS_IGNORE_CASE is enabled, so align
+            # the result on position rather than on name
+            res = res.rename_columns(list(ibis_schema.names))
 
         return expr.__pyarrow_result__(res, data_mapper=SnowflakePyArrowData)
 
@@ -490,13 +494,15 @@ $$ {defn["source"]} $$"""
         self._run_pre_execute_hooks(expr)
         sql = self.compile(expr, limit=limit, params=params)
         target_schema = expr.as_table().schema()
-        converter = functools.partial(
-            SnowflakePandasData.convert_table, schema=target_schema
-        )
+
+        def convert(df: pd.DataFrame) -> pd.DataFrame:
+            # see the comment in `to_pyarrow` about positional alignment
+            df.columns = list(target_schema.names)
+            return SnowflakePandasData.convert_table(df, target_schema)
 
         with self._safe_raw_sql(sql) as cur:
             yield from map(
-                expr.__pandas_result__, map(converter, cur.fetch_pandas_batches())
+                expr.__pandas_result__, map(convert, cur.fetch_pandas_batches())
             )
 
     def to_pyarrow_batches(

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -494,16 +494,16 @@ $$ {defn["source"]} $$"""
         sql = self.compile(expr, limit=limit, params=params)
         target_schema = expr.as_table().schema()
 
-        def convert(df: pd.DataFrame) -> pd.DataFrame:
+        def df_to_result(df: pd.DataFrame) -> pd.DataFrame | pd.Series | Any:
             # snowflake can rewrite the aliases we asked for, so align on
             # position rather than on name
             df.columns = list(target_schema.names)
-            return SnowflakePandasData.convert_table(df, target_schema)
+            return expr.__pandas_result__(
+                SnowflakePandasData.convert_table(df, target_schema)
+            )
 
         with self._safe_raw_sql(sql) as cur:
-            yield from map(
-                expr.__pandas_result__, map(convert, cur.fetch_pandas_batches())
-            )
+            yield from map(df_to_result, cur.fetch_pandas_batches())
 
     def to_pyarrow_batches(
         self,

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -468,9 +468,8 @@ $$ {defn["source"]} $$"""
         if res is None:
             res = ibis_schema.to_pyarrow().empty_table()
         else:
-            # snowflake can rewrite the aliases we asked for server-side, for
-            # example when QUOTED_IDENTIFIERS_IGNORE_CASE is enabled, so align
-            # the result on position rather than on name
+            # snowflake can rewrite the aliases we asked for, so align on
+            # position rather than on name
             res = res.rename_columns(list(ibis_schema.names))
 
         return expr.__pyarrow_result__(res, data_mapper=SnowflakePyArrowData)
@@ -496,8 +495,7 @@ $$ {defn["source"]} $$"""
         target_schema = expr.as_table().schema()
 
         def convert(df: pd.DataFrame) -> pd.DataFrame:
-            # snowflake can rewrite the aliases we asked for server-side, so
-            # align the result on position rather than on name
+            # see `to_pyarrow`; align on position rather than on name
             df.columns = list(target_schema.names)
             return SnowflakePandasData.convert_table(df, target_schema)
 

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -444,14 +444,8 @@ def test_insert_dict_variants(con):
 
 @pytest.fixture(scope="session")
 def ignore_case_con():
-    # a dedicated connection, because `_setup_session` mutates the session
-    #
-    # `create_object_udfs=False` matters here: the default re-issues
-    # `CREATE OR REPLACE FUNCTION ibis_udfs.public.*` while this session
-    # parameter is on, which folds the quoted lowercase argument names those
-    # javascript bodies reference to uppercase. `ibis_udfs` is shared across
-    # the account and the failure is swallowed into a warning, so it would
-    # break map and array tests elsewhere rather than this one.
+    # a dedicated connection, because `_setup_session` mutates the session;
+    # skip the UDFs, which would be rebuilt with their argument names folded
     return ibis.connect(
         _get_url(),
         create_object_udfs=False,
@@ -460,8 +454,7 @@ def ignore_case_con():
 
 
 def _drain_pyarrow_batches(con, t):
-    # `reader.schema` is computed client-side before the query is issued, so
-    # asserting on it would pass without ever contacting the server
+    # drain rather than check `reader.schema`, which is computed client-side
     with con.to_pyarrow_batches(t) as reader:
         return reader.read_all().to_pandas()
 
@@ -478,20 +471,14 @@ def _drain_pyarrow_batches(con, t):
     ],
 )
 def test_mixed_case_columns_ignore_case(ignore_case_con, export):
-    # under QUOTED_IDENTIFIERS_IGNORE_CASE snowflake folds the quoted aliases
-    # we emit to uppercase server-side, so results come back with names that
-    # don't match the ibis schema
-    #
-    # `to_pyarrow` and `to_pandas_batches` are the two that were broken;
-    # the other two are here as regression coverage, since they were already
-    # positional
+    # snowflake folds the quoted aliases we emit to uppercase server-side, so
+    # results come back with names the ibis schema doesn't have
     expected = pd.DataFrame({"errorCode": [1, 2, 3], "eventType": list("abc")})
     t = ibis.memtable(expected)
 
     result = export(ignore_case_con, t)
 
     assert list(result.columns) == list(expected.columns)
-    # an unordered scan over a temp table, so compare content, not row order
     tm.assert_frame_equal(result.sort_values("errorCode", ignore_index=True), expected)
 
 

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -456,10 +456,10 @@ def test_insert_dict_variants(con):
         ),
     ],
 )
-def test_mixed_case_columns_ignore_case(export):
-    # on a connection with QUOTED_IDENTIFIERS_IGNORE_CASE, columns asked for as
-    # errorCode, ErrorCode and ERRORCODE all come back as ERRORCODE, so they
-    # have to be put back to the case the ibis schema has
+def test_non_uppercase_columns_ignore_case(export):
+    # with QUOTED_IDENTIFIERS_IGNORE_CASE set, snowflake returns all columns
+    # uppercased regardless of their original case, so check they're renamed
+    # back to match
     con = ibis.connect(
         _get_url(),
         # a dedicated connection, because `_setup_session` mutates the session,

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -445,8 +445,17 @@ def test_insert_dict_variants(con):
 @pytest.fixture(scope="session")
 def ignore_case_con():
     # a dedicated connection, because `_setup_session` mutates the session
+    #
+    # `create_object_udfs=False` matters here: the default re-issues
+    # `CREATE OR REPLACE FUNCTION ibis_udfs.public.*` while this session
+    # parameter is on, which folds the quoted lowercase argument names those
+    # javascript bodies reference to uppercase. `ibis_udfs` is shared across
+    # the account and the failure is swallowed into a warning, so it would
+    # break map and array tests elsewhere rather than this one.
     return ibis.connect(
-        _get_url(), session_parameters={"QUOTED_IDENTIFIERS_IGNORE_CASE": True}
+        _get_url(),
+        create_object_udfs=False,
+        session_parameters={"QUOTED_IDENTIFIERS_IGNORE_CASE": True},
     )
 
 
@@ -459,21 +468,26 @@ def test_mixed_case_columns_ignore_case(ignore_case_con):
 
     names = list(expected.columns)
 
+    # the memtable is an unordered scan over a temp table, so compare on
+    # content rather than on row order
+    def normalize(df):
+        return df.sort_values(names[0], ignore_index=True)
+
     arrow = ignore_case_con.to_pyarrow(t)
     assert arrow.column_names == names
-    tm.assert_frame_equal(arrow.to_pandas(), expected)
+    tm.assert_frame_equal(normalize(arrow.to_pandas()), expected)
 
     # `reader.schema` is computed client-side, so drain the reader to
     # actually exercise the server round trip
     with ignore_case_con.to_pyarrow_batches(t) as reader:
         batched = reader.read_all()
     assert batched.column_names == names
-    tm.assert_frame_equal(batched.to_pandas(), expected)
+    tm.assert_frame_equal(normalize(batched.to_pandas()), expected)
 
-    tm.assert_frame_equal(ignore_case_con.to_pandas(t), expected)
+    tm.assert_frame_equal(normalize(ignore_case_con.to_pandas(t)), expected)
 
     batches = list(ignore_case_con.to_pandas_batches(t))
-    tm.assert_frame_equal(pd.concat(batches, ignore_index=True), expected)
+    tm.assert_frame_equal(normalize(pd.concat(batches)), expected)
 
 
 @h.given(

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -459,35 +459,40 @@ def ignore_case_con():
     )
 
 
-def test_mixed_case_columns_ignore_case(ignore_case_con):
+def _drain_pyarrow_batches(con, t):
+    # `reader.schema` is computed client-side before the query is issued, so
+    # asserting on it would pass without ever contacting the server
+    with con.to_pyarrow_batches(t) as reader:
+        return reader.read_all().to_pandas()
+
+
+@pytest.mark.parametrize(
+    "export",
+    [
+        param(lambda con, t: con.to_pyarrow(t).to_pandas(), id="to_pyarrow"),
+        param(_drain_pyarrow_batches, id="to_pyarrow_batches"),
+        param(lambda con, t: con.to_pandas(t), id="to_pandas"),
+        param(
+            lambda con, t: pd.concat(con.to_pandas_batches(t)), id="to_pandas_batches"
+        ),
+    ],
+)
+def test_mixed_case_columns_ignore_case(ignore_case_con, export):
     # under QUOTED_IDENTIFIERS_IGNORE_CASE snowflake folds the quoted aliases
     # we emit to uppercase server-side, so results come back with names that
     # don't match the ibis schema
+    #
+    # `to_pyarrow` and `to_pandas_batches` are the two that were broken;
+    # the other two are here as regression coverage, since they were already
+    # positional
     expected = pd.DataFrame({"errorCode": [1, 2, 3], "eventType": list("abc")})
     t = ibis.memtable(expected)
 
-    names = list(expected.columns)
+    result = export(ignore_case_con, t)
 
-    # the memtable is an unordered scan over a temp table, so compare on
-    # content rather than on row order
-    def normalize(df):
-        return df.sort_values(names[0], ignore_index=True)
-
-    arrow = ignore_case_con.to_pyarrow(t)
-    assert arrow.column_names == names
-    tm.assert_frame_equal(normalize(arrow.to_pandas()), expected)
-
-    # `reader.schema` is computed client-side, so drain the reader to
-    # actually exercise the server round trip
-    with ignore_case_con.to_pyarrow_batches(t) as reader:
-        batched = reader.read_all()
-    assert batched.column_names == names
-    tm.assert_frame_equal(normalize(batched.to_pandas()), expected)
-
-    tm.assert_frame_equal(normalize(ignore_case_con.to_pandas(t)), expected)
-
-    batches = list(ignore_case_con.to_pandas_batches(t))
-    tm.assert_frame_equal(normalize(pd.concat(batches)), expected)
+    assert list(result.columns) == list(expected.columns)
+    # an unordered scan over a temp table, so compare content, not row order
+    tm.assert_frame_equal(result.sort_values("errorCode", ignore_index=True), expected)
 
 
 @h.given(

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -469,13 +469,13 @@ def test_non_uppercase_columns_ignore_case(export):
         session_parameters={"QUOTED_IDENTIFIERS_IGNORE_CASE": True},
     )
 
-    expected = pd.DataFrame({"errorCode": [1, 2, 3], "eventType": list("abc")})
+    expected = pd.DataFrame({"digits": [1, 2, 3], "nonDigits": list("abc")})
     t = ibis.memtable(expected)
 
     result = export(con, t)
 
     assert list(result.columns) == list(expected.columns)
-    tm.assert_frame_equal(result.sort_values("errorCode", ignore_index=True), expected)
+    tm.assert_frame_equal(result.sort_values("digits", ignore_index=True), expected)
 
 
 @h.given(

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -442,42 +442,37 @@ def test_insert_dict_variants(con):
     assert len(t.execute()) == 4
 
 
-@pytest.fixture(scope="session")
-def ignore_case_con():
-    # a dedicated connection, because `_setup_session` mutates the session;
-    # skip the UDFs, which this parameter would replace in the account-shared
-    # `ibis_udfs` with their arguments uppercased, failing only at call time
-    return ibis.connect(
-        _get_url(),
-        create_object_udfs=False,
-        session_parameters={"QUOTED_IDENTIFIERS_IGNORE_CASE": True},
-    )
-
-
-def _drain_pyarrow_batches(con, t):
-    # drain rather than check `reader.schema`, which is computed client-side
-    with con.to_pyarrow_batches(t) as reader:
-        return reader.read_all().to_pandas()
-
-
 @pytest.mark.parametrize(
     "export",
     [
         param(lambda con, t: con.to_pyarrow(t).to_pandas(), id="to_pyarrow"),
-        param(_drain_pyarrow_batches, id="to_pyarrow_batches"),
+        param(
+            lambda con, t: con.to_pyarrow_batches(t).read_all().to_pandas(),
+            id="to_pyarrow_batches",
+        ),
         param(lambda con, t: con.to_pandas(t), id="to_pandas"),
         param(
             lambda con, t: pd.concat(con.to_pandas_batches(t)), id="to_pandas_batches"
         ),
     ],
 )
-def test_mixed_case_columns_ignore_case(ignore_case_con, export):
-    # snowflake folds the quoted aliases we emit to uppercase server-side, so
-    # results come back with names the ibis schema doesn't have
+def test_mixed_case_columns_ignore_case(export):
+    # on a connection with QUOTED_IDENTIFIERS_IGNORE_CASE, columns asked for as
+    # errorCode, ErrorCode and ERRORCODE all come back as ERRORCODE, so they
+    # have to be put back to the case the ibis schema has
+    con = ibis.connect(
+        _get_url(),
+        # a dedicated connection, because `_setup_session` mutates the session,
+        # and without this it would also replace the account-shared `ibis_udfs`
+        # functions with their arguments uppercased, failing only at call time
+        create_object_udfs=False,
+        session_parameters={"QUOTED_IDENTIFIERS_IGNORE_CASE": True},
+    )
+
     expected = pd.DataFrame({"errorCode": [1, 2, 3], "eventType": list("abc")})
     t = ibis.memtable(expected)
 
-    result = export(ignore_case_con, t)
+    result = export(con, t)
 
     assert list(result.columns) == list(expected.columns)
     tm.assert_frame_equal(result.sort_values("errorCode", ignore_index=True), expected)

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -442,6 +442,40 @@ def test_insert_dict_variants(con):
     assert len(t.execute()) == 4
 
 
+@pytest.fixture(scope="session")
+def ignore_case_con():
+    # a dedicated connection, because `_setup_session` mutates the session
+    return ibis.connect(
+        _get_url(), session_parameters={"QUOTED_IDENTIFIERS_IGNORE_CASE": True}
+    )
+
+
+def test_mixed_case_columns_ignore_case(ignore_case_con):
+    # under QUOTED_IDENTIFIERS_IGNORE_CASE snowflake folds the quoted aliases
+    # we emit to uppercase server-side, so results come back with names that
+    # don't match the ibis schema
+    expected = pd.DataFrame({"errorCode": [1, 2, 3], "eventType": list("abc")})
+    t = ibis.memtable(expected)
+
+    names = list(expected.columns)
+
+    arrow = ignore_case_con.to_pyarrow(t)
+    assert arrow.column_names == names
+    tm.assert_frame_equal(arrow.to_pandas(), expected)
+
+    # `reader.schema` is computed client-side, so drain the reader to
+    # actually exercise the server round trip
+    with ignore_case_con.to_pyarrow_batches(t) as reader:
+        batched = reader.read_all()
+    assert batched.column_names == names
+    tm.assert_frame_equal(batched.to_pandas(), expected)
+
+    tm.assert_frame_equal(ignore_case_con.to_pandas(t), expected)
+
+    batches = list(ignore_case_con.to_pandas_batches(t))
+    tm.assert_frame_equal(pd.concat(batches, ignore_index=True), expected)
+
+
 @h.given(
     column_name=st.text(
         st.characters(

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -445,7 +445,8 @@ def test_insert_dict_variants(con):
 @pytest.fixture(scope="session")
 def ignore_case_con():
     # a dedicated connection, because `_setup_session` mutates the session;
-    # skip the UDFs, which would be rebuilt with their argument names folded
+    # skip the UDFs, which this parameter would replace in the account-shared
+    # `ibis_udfs` with their arguments uppercased, failing only at call time
     return ibis.connect(
         _get_url(),
         create_object_udfs=False,


### PR DESCRIPTION
## Description of changes

Split out of #12060 for review.

`to_pyarrow` reconciled the Arrow result against the Ibis schema by name, and `to_pandas_batches` did no reconciliation at all before handing the frame to `SnowflakePandasData.convert_table`, which requires exact names. Both break whenever Snowflake returns column names that differ from the aliases we asked for. The usual trigger is `QUOTED_IDENTIFIERS_IGNORE_CASE`, where quoted aliases are folded to uppercase server-side:

```python
con = ibis.snowflake.connect(
    ..., session_parameters={"QUOTED_IDENTIFIERS_IGNORE_CASE": True}
)
t = con.table("MY_TABLE").rename({"errorCode": "ERRORCODE"})

t.head().to_pandas()           # works
t.head().to_pyarrow_batches()  # works
t.head().to_pyarrow()          # KeyError: 'Field "errorCode" does not exist in schema'
t.head().to_pandas_batches()   # ValueError: schema names don't match input data columns
```

Align both on position instead. That is what `_fetch_from_cursor` and `_make_batch_iter` already do in this backend, and what [Athena](https://github.com/ibis-project/ibis/blob/12.0.0/ibis/backends/athena/__init__.py#L546) and [BigQuery](https://github.com/ibis-project/ibis/blob/12.0.0/ibis/backends/bigquery/__init__.py#L989) (via [`_postprocess_arrow`](https://github.com/ibis-project/ibis/blob/12.0.0/ibis/backends/bigquery/__init__.py#L158-L164)) do in their own `to_pyarrow`.

The fixture passes `create_object_udfs=False` on purpose. The default replaces the account-shared `ibis_udfs` functions, and with this session parameter set they are created without error but fail when called, because their JavaScript bodies reference double-quoted lowercase argument names that no longer resolve. Confirmed against a live account with a temporary UDF shaped like `_make_udf`'s output: `{"a": 1}` with the parameter off, `100132 (P0000): JavaScript execution error: Uncaught ReferenceError: obj is not defined` with it on.

Snowflake CI is disabled (`disabled_manually`, last run 2026-01-24), so none of this runs in CI. Validated against a live account; see the validation comments on #12060.
