### PR TITLE
fix(conda): install pyarrow-tests in the dev environment

### DIFF
--- a/conda/environment-arm64.yml
+++ b/conda/environment-arm64.yml
@@ -64,6 +64,7 @@ dependencies:
   - py-cpuinfo<10,>=9
   - pyarrow-hotfix>=0.4
   - pyarrow>=10.0.1
+  - pyarrow-tests
   - pydata-google-auth>=1.4.0
   - pydruid>=0.6.7
   - pyexasol>=0.25.2

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -64,6 +64,7 @@ dependencies:
   - py-cpuinfo<10,>=9
   - pyarrow-hotfix>=0.4
   - pyarrow>=10.0.1
+  - pyarrow-tests
   - pydata-google-auth>=1.4.0
   - pydruid>=0.6.7
   - pyexasol>=0.25.2


### PR DESCRIPTION
## Description of changes

`ibis/formats/tests/test_pyarrow.py` guards itself on `pyarrow.tests.strategies`. **conda-forge splits that into a separate `pyarrow-tests` package**, which neither conda environment file asks for — so the module-level `importorskip` fires and takes all 19 tests in the file with it, silently, since a skipped module reports nothing.

`docs/contribute/01_environment.qmd` points conda, mamba and pixi users at `conda/environment.yml` (pixi via `pixi init --import conda/environment.yml`), so every contributor who set up the documented way has been losing that coverage.

## History

Regression of #7383, which reported this in October 2023 — back when it was a hard collection error:

| PR | Effect |
|---|---|
| #7390 | Closed #7383 by adding `pyarrow-tests` to the conda **lock files** only. |
| #8242 | Removed the conda lock files entirely, taking the fix with them. |
| #8383 | Hand-added `pyarrow-tests` to the then hand-written `conda/environment-arm64.yml`. |
| #9552 | Rewrote the import as `pytest.importorskip("pyarrow.tests.strategies")`, converting the collection error into a silent skip. |
| #11878 | Converted both env files from hand-written YAML to `pyproject2conda` output plus manual fixups; `pyarrow-tests` did not make it onto the fixup list. (Mine.) |

`pyproject2conda` derives conda dependencies from `pyproject.toml`, and `pyarrow-tests` is conda-only — it has no PyPI existence — so the generator structurally cannot emit it. It survives only by being on the manual fixup list that these files carry on top of generated output, alongside `channels`, `just`, `gcsfs`, the `trino-python-client` and `PyAthena` conda-forge name mappings, and the `pip:` block for packages conda-forge doesn't have. That list is recorded nowhere but the files themselves, under a `# This file is manually edited.` header.

Two consequences. `conda/environment.yml` never carried the dependency at any point in its history, hand-written era included — only the arm64 file and the since-deleted lock files ever had it, so the documented x86 setup was never actually fixed. And since #9552 the failure has emitted no signal at all, which is why it survived two years after someone reported the loud version of it within days.

## Testing

Verified `pyarrow-tests` resolves alongside `pyarrow>=10.0.1` on conda-forge and provides the module:

```console
$ pixi exec --spec 'python=3.12' --spec 'pyarrow>=10.0.1' --spec pyarrow-tests --spec pytest --spec hypothesis \
    python -c "import pyarrow, pyarrow.tests.strategies as past; print(pyarrow.__version__, bool(past.schemas))"
25.0.0 True
```

Not an issue for PyPI wheels, which bundle `pyarrow/tests/`.

## Notes

- A more durable fix would add `-d pyarrow-tests` to the `pyproject2conda` invocation recorded in each file's header, so the dependency survives the next regeneration (verified: `-d` emits the entry and the generated header records the flag). Left out here because the same argument applies to every other entry on the fixup list, and making regeneration lossless is a much larger change than restoring one line.
- An earlier revision of this PR claimed PyArrow had stopped shipping `pyarrow/tests/` in its wheels as of 23.0.0, and worked around it in the test file. That was wrong — the wheel does ship it (89 `pyarrow/tests/*` entries, `strategies.py` included); the check had been contaminated by an ambient conda environment. The cause is narrower and this is the honest fix.
- This does **not** make those tests run in CI — the core CI job installs no pyarrow at all, so the module skips one line earlier. Separate bug, fixed in #12071.
- The `importorskip` masking is arguably worth addressing on its own; cf. #3480.
