### PR TITLE
fix(snowflake): unblock nested types when batching

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -456,7 +456,10 @@ $$ {defn["source"]} $$"""
         limit: int | str | None = None,
         **kwargs: Any,
     ) -> pa.Table:
-        from ibis.backends.snowflake.converter import SnowflakePyArrowData
+        from ibis.backends.snowflake.converter import (
+            SnowflakePyArrowData,
+            source_schema,
+        )
 
         self._run_pre_execute_hooks(expr)
 
@@ -466,7 +469,11 @@ $$ {defn["source"]} $$"""
 
         ibis_schema = expr.as_table().schema()
         if res is None:
-            res = ibis_schema.to_pyarrow().empty_table()
+            # the connector returns None rather than an empty table for a
+            # zero-row result; stand in for it with the schema snowflake would
+            # have sent, since the natively-typed one can't be wrapped in the
+            # JSON extension type below
+            res = source_schema(ibis_schema).empty_table()
         else:
             # snowflake can rewrite the aliases we asked for server-side, for
             # example when QUOTED_IDENTIFIERS_IGNORE_CASE is enabled, so align
@@ -515,9 +522,14 @@ $$ {defn["source"]} $$"""
         chunk_size: int = 1_000_000,
         **kwargs: Any,
     ) -> pa.ipc.RecordBatchReader:
+        from ibis.backends.snowflake.converter import source_schema
+
         self._run_pre_execute_hooks(expr)
         sql = self.compile(expr, limit=limit, params=params, **kwargs)
-        target_schema = expr.as_table().schema().to_pyarrow()
+        # cast to what snowflake actually sends, not to the nested arrow types
+        # the ibis schema maps to: VARIANT, ARRAY and OBJECT arrive as JSON
+        # strings, and `string -> list/map/struct` is not an implemented cast
+        target_schema = source_schema(expr.as_table().schema())
 
         return pa.ipc.RecordBatchReader.from_batches(
             target_schema,
@@ -527,7 +539,7 @@ $$ {defn["source"]} $$"""
         )
 
     def _make_batch_iter(
-        self, sql: str, *, target_schema: sch.Schema, chunk_size: int
+        self, sql: str, *, target_schema: pa.Schema, chunk_size: int
     ) -> Iterator[pa.RecordBatch]:
         with self._safe_raw_sql(sql) as cur:
             yield from itertools.chain.from_iterable(

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import functools
 import glob
 import itertools
 import json
@@ -465,9 +464,14 @@ $$ {defn["source"]} $$"""
         with self._safe_raw_sql(sql) as cur:
             res = cur.fetch_arrow_all()
 
-        target_schema = expr.as_table().schema().to_pyarrow()
+        ibis_schema = expr.as_table().schema()
         if res is None:
-            res = target_schema.empty_table()
+            res = ibis_schema.to_pyarrow().empty_table()
+        else:
+            # snowflake can rewrite the aliases we asked for server-side, for
+            # example when QUOTED_IDENTIFIERS_IGNORE_CASE is enabled, so align
+            # the result on position rather than on name
+            res = res.rename_columns(list(ibis_schema.names))
 
         return expr.__pyarrow_result__(res, data_mapper=SnowflakePyArrowData)
 
@@ -490,13 +494,15 @@ $$ {defn["source"]} $$"""
         self._run_pre_execute_hooks(expr)
         sql = self.compile(expr, limit=limit, params=params)
         target_schema = expr.as_table().schema()
-        converter = functools.partial(
-            SnowflakePandasData.convert_table, schema=target_schema
-        )
+
+        def convert(df: pd.DataFrame) -> pd.DataFrame:
+            # see the comment in `to_pyarrow` about positional alignment
+            df.columns = list(target_schema.names)
+            return SnowflakePandasData.convert_table(df, target_schema)
 
         with self._safe_raw_sql(sql) as cur:
             yield from map(
-                expr.__pandas_result__, map(converter, cur.fetch_pandas_batches())
+                expr.__pandas_result__, map(convert, cur.fetch_pandas_batches())
             )
 
     def to_pyarrow_batches(

--- a/ibis/backends/snowflake/converter.py
+++ b/ibis/backends/snowflake/converter.py
@@ -87,10 +87,37 @@ else:
 
 
 try:
-    from ibis.formats.pyarrow import PyArrowData
+    from ibis.formats.pyarrow import PyArrowData, PyArrowType
 except ModuleNotFoundError:
     pass
 else:
+
+    def _is_json_encoded(dtype: dt.DataType) -> bool:
+        """Return whether snowflake hands back `dtype` as a JSON-encoded string."""
+        return (
+            dtype.is_json() or dtype.is_array() or dtype.is_map() or dtype.is_struct()
+        )
+
+    def source_schema(schema: Schema) -> pa.Schema:
+        """Return the pyarrow schema snowflake actually sends for `schema`.
+
+        Identical to `PyArrowSchema.from_ibis` except that JSON-encoded columns
+        arrive as strings: snowflake has no typed wire format for VARIANT,
+        ARRAY or OBJECT, so it serializes them and the nested arrow types the
+        ibis schema maps to never appear on the wire.
+        """
+        return pa.schema(
+            [
+                pa.field(
+                    name,
+                    pa.string()
+                    if _is_json_encoded(dtype)
+                    else PyArrowType.from_ibis(dtype),
+                    nullable=dtype.nullable,
+                )
+                for name, dtype in schema.items()
+            ]
+        )
 
     class SnowflakePyArrowData(PyArrowData):
         @classmethod
@@ -110,12 +137,7 @@ else:
 
         @classmethod
         def convert_column(cls, column: pa.Array, dtype: dt.DataType) -> pa.Array:
-            if (
-                dtype.is_json()
-                or dtype.is_array()
-                or dtype.is_map()
-                or dtype.is_struct()
-            ):
+            if _is_json_encoded(dtype):
                 if isinstance(column, pa.ChunkedArray):
                     column = column.combine_chunks()
 
@@ -124,11 +146,6 @@ else:
 
         @classmethod
         def convert_scalar(cls, scalar: pa.Scalar, dtype: dt.DataType) -> pa.Scalar:
-            if (
-                dtype.is_json()
-                or dtype.is_array()
-                or dtype.is_map()
-                or dtype.is_struct()
-            ):
+            if _is_json_encoded(dtype):
                 return pa.ExtensionScalar.from_storage(PYARROW_JSON_TYPE, scalar)
             return super().convert_scalar(scalar, dtype)

--- a/ibis/backends/snowflake/converter.py
+++ b/ibis/backends/snowflake/converter.py
@@ -99,12 +99,19 @@ else:
         )
 
     def source_schema(schema: Schema) -> pa.Schema:
-        """Return the pyarrow schema snowflake actually sends for `schema`.
+        """Return the pyarrow schema snowflake sends for the JSON-encoded part of `schema`.
 
         Identical to `PyArrowSchema.from_ibis` except that JSON-encoded columns
         arrive as strings: snowflake has no typed wire format for VARIANT,
         ARRAY or OBJECT, so it serializes them and the nested arrow types the
         ibis schema maps to never appear on the wire.
+
+        Geospatial columns are the one known gap. GEOGRAPHY and GEOMETRY also
+        arrive as text, but this returns the geoarrow extension type
+        `PyArrowType.from_ibis` maps them to, so casting to it fails the same
+        way the nested types did. That is unchanged from what the batches path
+        cast to before, and fixing it needs a live account to pin down which
+        of GeoJSON, WKT and WKB `GEOGRAPHY_OUTPUT_FORMAT` is producing.
         """
         return pa.schema(
             [

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -9,6 +9,7 @@ import hypothesis.strategies as st
 import pandas as pd
 import pandas.testing as tm
 import pyarrow as pa
+import pyarrow.csv as pcsv
 import pytest
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -16,6 +17,7 @@ from pytest import param
 
 import ibis
 import ibis.common.exceptions as com
+from ibis.backends.snowflake.converter import PYARROW_JSON_TYPE
 from ibis.backends.snowflake.tests.conftest import _get_url
 from ibis.util import gen_name
 
@@ -442,6 +444,46 @@ def test_insert_dict_variants(con):
     assert len(t.execute()) == 4
 
 
+def test_nested_types_empty_result(con):
+    # only `to_pyarrow` is affected: it builds a stand-in table when the
+    # connector returns None, while the batches path never gets a batch to cast
+    lit = ibis.struct({"a": [1, 2, 3]}).cast("struct<a: array<int>>")
+    t = con.tables.functional_alltypes.mutate(lit=lit).limit(0).select("id", "lit")
+
+    eager = con.to_pyarrow(t)
+    assert len(eager) == 0
+    assert eager.schema.field("lit").type == PYARROW_JSON_TYPE
+
+    with con.to_pyarrow_batches(t) as reader:
+        batched = reader.read_all()
+    assert len(batched) == 0
+    assert batched.schema.field("lit").type == pa.string()
+
+
+def test_nested_types_stream_as_json_text(con, tmp_path):
+    # snowflake sends nested values as JSON text and the batches path keeps it
+    raw = {"a": [1, 2, 3], "b": "456"}
+    lit = ibis.struct(raw).cast("struct<a: array<int>, b: json>")
+    t = (
+        con.tables.functional_alltypes.mutate(lit=lit)
+        .order_by("id")
+        .limit(1)
+        .select("id", "lit")
+    )
+
+    with con.to_pyarrow_batches(t) as reader:
+        batched = reader.read_all()
+    assert batched.schema.field("lit").type == pa.string()
+    assert json.loads(batched["lit"][0].as_py()) == raw
+
+    out = tmp_path / "nested.csv"
+    con.to_csv(t, out)
+    assert json.loads(pcsv.read_csv(out)["lit"][0].as_py()) == raw
+
+    # the eager path still wraps, which is what `repr` depends on
+    assert con.to_pyarrow(t)["lit"][0].as_py() == raw
+
+
 @pytest.fixture(scope="session")
 def ignore_case_con():
     # a dedicated connection, because `_setup_session` mutates the session
@@ -460,9 +502,8 @@ def ignore_case_con():
 
 
 def test_mixed_case_columns_ignore_case(ignore_case_con):
-    # under QUOTED_IDENTIFIERS_IGNORE_CASE snowflake folds the quoted aliases
-    # we emit to uppercase server-side, so results come back with names that
-    # don't match the ibis schema
+    # snowflake folds our quoted aliases to uppercase under this session
+    # parameter, so results come back with names the ibis schema doesn't have
     expected = pd.DataFrame({"errorCode": [1, 2, 3], "eventType": list("abc")})
     t = ibis.memtable(expected)
 

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -445,8 +445,17 @@ def test_insert_dict_variants(con):
 @pytest.fixture(scope="session")
 def ignore_case_con():
     # a dedicated connection, because `_setup_session` mutates the session
+    #
+    # `create_object_udfs=False` matters here: the default re-issues
+    # `CREATE OR REPLACE FUNCTION ibis_udfs.public.*` while this session
+    # parameter is on, which folds the quoted lowercase argument names those
+    # javascript bodies reference to uppercase. `ibis_udfs` is shared across
+    # the account and the failure is swallowed into a warning, so it would
+    # break map and array tests elsewhere rather than this one.
     return ibis.connect(
-        _get_url(), session_parameters={"QUOTED_IDENTIFIERS_IGNORE_CASE": True}
+        _get_url(),
+        create_object_udfs=False,
+        session_parameters={"QUOTED_IDENTIFIERS_IGNORE_CASE": True},
     )
 
 
@@ -459,21 +468,26 @@ def test_mixed_case_columns_ignore_case(ignore_case_con):
 
     names = list(expected.columns)
 
+    # the memtable is an unordered scan over a temp table, so compare on
+    # content rather than on row order
+    def normalize(df):
+        return df.sort_values(names[0], ignore_index=True)
+
     arrow = ignore_case_con.to_pyarrow(t)
     assert arrow.column_names == names
-    tm.assert_frame_equal(arrow.to_pandas(), expected)
+    tm.assert_frame_equal(normalize(arrow.to_pandas()), expected)
 
     # `reader.schema` is computed client-side, so drain the reader to
     # actually exercise the server round trip
     with ignore_case_con.to_pyarrow_batches(t) as reader:
         batched = reader.read_all()
     assert batched.column_names == names
-    tm.assert_frame_equal(batched.to_pandas(), expected)
+    tm.assert_frame_equal(normalize(batched.to_pandas()), expected)
 
-    tm.assert_frame_equal(ignore_case_con.to_pandas(t), expected)
+    tm.assert_frame_equal(normalize(ignore_case_con.to_pandas(t)), expected)
 
     batches = list(ignore_case_con.to_pandas_batches(t))
-    tm.assert_frame_equal(pd.concat(batches, ignore_index=True), expected)
+    tm.assert_frame_equal(normalize(pd.concat(batches)), expected)
 
 
 @h.given(

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -442,6 +442,40 @@ def test_insert_dict_variants(con):
     assert len(t.execute()) == 4
 
 
+@pytest.fixture(scope="session")
+def ignore_case_con():
+    # a dedicated connection, because `_setup_session` mutates the session
+    return ibis.connect(
+        _get_url(), session_parameters={"QUOTED_IDENTIFIERS_IGNORE_CASE": True}
+    )
+
+
+def test_mixed_case_columns_ignore_case(ignore_case_con):
+    # under QUOTED_IDENTIFIERS_IGNORE_CASE snowflake folds the quoted aliases
+    # we emit to uppercase server-side, so results come back with names that
+    # don't match the ibis schema
+    expected = pd.DataFrame({"errorCode": [1, 2, 3], "eventType": list("abc")})
+    t = ibis.memtable(expected)
+
+    names = list(expected.columns)
+
+    arrow = ignore_case_con.to_pyarrow(t)
+    assert arrow.column_names == names
+    tm.assert_frame_equal(arrow.to_pandas(), expected)
+
+    # `reader.schema` is computed client-side, so drain the reader to
+    # actually exercise the server round trip
+    with ignore_case_con.to_pyarrow_batches(t) as reader:
+        batched = reader.read_all()
+    assert batched.column_names == names
+    tm.assert_frame_equal(batched.to_pandas(), expected)
+
+    tm.assert_frame_equal(ignore_case_con.to_pandas(t), expected)
+
+    batches = list(ignore_case_con.to_pandas_batches(t))
+    tm.assert_frame_equal(pd.concat(batches, ignore_index=True), expected)
+
+
 @h.given(
     column_name=st.text(
         st.characters(

--- a/ibis/backends/snowflake/tests/test_converter.py
+++ b/ibis/backends/snowflake/tests/test_converter.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+import ibis
+from ibis.backends.snowflake.converter import (
+    PYARROW_JSON_TYPE,
+    SnowflakePyArrowData,
+    source_schema,
+)
+
+JSON_ENCODED = ["json", "array<int64>", "map<string, int64>", "struct<a: int64>"]
+
+
+@pytest.mark.parametrize("dtype", JSON_ENCODED)
+def test_source_schema_sends_json_encoded_types_as_strings(dtype):
+    # snowflake serializes VARIANT/ARRAY/OBJECT, so the nested arrow types the
+    # ibis schema maps to never appear on the wire
+    schema = ibis.schema({"x": dtype})
+    assert source_schema(schema).field("x").type == pa.string()
+
+
+def test_source_schema_accepts_what_the_connector_sends():
+    # the batches path casts to this schema, so the cast must be a no-op for
+    # the JSON-encoded columns and a widening for the narrow integer types
+    # snowflake returns
+    schema = ibis.schema({"i": "int64", "js": "json", "arr": "array<int64>"})
+    raw = pa.table(
+        {
+            "i": pa.array([1, 2], pa.int8()),
+            "js": pa.array(['{"a": 1}', "null"]),
+            "arr": pa.array(["[1]", "[2]"]),
+        }
+    )
+    cast = raw.cast(source_schema(schema))
+    assert cast.schema.equals(source_schema(schema))
+    assert cast["arr"].to_pylist() == ["[1]", "[2]"]
+
+
+def test_empty_table_survives_json_wrapping():
+    # the connector returns None for a zero-row result; the stand-in has to use
+    # the wire types, because the extension wrapping rejects native nested
+    # arrays as storage
+    schema = ibis.schema(
+        {"i": "int64", "arr": "array<int64>", "m": "map<string, int64>"}
+    )
+    empty = source_schema(schema).empty_table()
+    converted = SnowflakePyArrowData.convert_table(empty, schema)
+    assert len(converted) == 0
+    assert converted.schema.field("arr").type == PYARROW_JSON_TYPE
+
+
+def test_natively_typed_empty_table_would_not_survive():
+    # the natively-typed stand-in raises, which is why the fix uses wire types
+    schema = ibis.schema({"arr": "array<int64>"})
+    with pytest.raises(TypeError, match="Incompatible storage type"):
+        SnowflakePyArrowData.convert_table(schema.to_pyarrow().empty_table(), schema)
+
+
+@pytest.mark.parametrize("dtype", JSON_ENCODED)
+def test_eager_path_still_wraps_in_the_extension_type(dtype):
+    # the display path is unchanged: `repr` depends on `as_py` parsing the JSON
+    schema = ibis.schema({"x": dtype})
+    raw = pa.table({"x": pa.array(['{"a": 1}'])})
+    converted = SnowflakePyArrowData.convert_table(raw, schema)
+    assert converted.schema.field("x").type == PYARROW_JSON_TYPE
+    assert converted["x"][0].as_py() == {"a": 1}

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -10,6 +10,7 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 from ibis import util
+from ibis.backends.tests.conftest import NO_STRUCT_SUPPORT
 from ibis.backends.tests.errors import (
     DatabricksServerOperationError,
     DuckDBNotImplementedException,
@@ -189,6 +190,39 @@ def test_to_pyarrow_batches_borked_types(batting):
         assert isinstance(batch, pa.RecordBatch)
         assert len(batch) <= limit
         util.consume(batch_reader)
+
+
+@NO_STRUCT_SUPPORT
+@pytest.mark.notyet(
+    ["snowflake"],
+    raises=AssertionError,
+    reason="nested columns come back wrapped in the `ibis.json` extension type",
+)
+def test_to_pyarrow_nested_types(struct):
+    table = struct.select("abc").to_pyarrow()
+    assert pat.is_struct(table.schema.field("abc").type)
+
+
+@NO_STRUCT_SUPPORT
+@pytest.mark.notyet(
+    ["snowflake"],
+    raises=AssertionError,
+    reason="no typed wire format for VARIANT, ARRAY or OBJECT, so nested columns arrive as JSON text and stay that way",
+)
+def test_to_pyarrow_batches_nested_types(struct):
+    with struct.select("abc").to_pyarrow_batches() as reader:
+        table = reader.read_all()
+    assert pat.is_struct(table.schema.field("abc").type)
+
+
+@NO_STRUCT_SUPPORT
+def test_empty_nested_types_to_pyarrow(struct):
+    expr = struct.select("abc").limit(0)
+
+    assert len(expr.to_pyarrow()) == 0
+
+    with expr.to_pyarrow_batches() as reader:
+        assert len(reader.read_all()) == 0
 
 
 def test_to_pyarrow_memtable(con):


### PR DESCRIPTION
## Description of changes

Split out of #12060. Stacked on top of #12065 (positional alignment), which it touches the same methods as.

`_make_batch_iter` cast results to `schema().to_pyarrow()`, but Snowflake has no typed wire format for `VARIANT`, `ARRAY` or `OBJECT` — it serializes them, so those columns arrive as JSON strings. Casting `string` to `list<...>`/`map<...>`/`struct<...>` is unimplemented in PyArrow, so the batches path raised for any nested column, taking `to_parquet`, `to_parquet_dir`, `to_csv` and `to_delta` down with it.

Cast to what Snowflake actually sends instead. Nested columns come back as the JSON strings they were on the wire, which is what the formats built on this path can represent: `to_csv` writes them as RFC 4180 text and Parquet stores a plain string column that no reader needs Ibis to decode. `to_csv` on nested columns now works, which it doesn't on any other backend, since PyArrow's CSV writer can't represent native nested types either.

`to_pyarrow` had the mirror-image bug for a zero-row result: the connector returns `None` rather than an empty table, and the stand-in it substituted used the native nested types, so wrapping in the JSON extension type raised `TypeError: Incompatible storage type`. Build the stand-in from the wire types too.

## What this deliberately does not do

Route the batches path through `SnowflakePyArrowData`. That would tag these columns with the `ibis.json` extension type, which is a display-layer accommodation — it exists so `repr` of a nested column works (#7562) — and pushing it into a streaming API and into files on disk means the same Parquet file reads as `string` or as `extension<ibis.json>` depending on whether an unrelated import happened in the reading process.

That version was built, tested and measured against this one; see [the comparison on #12060](https://github.com/ibis-project/ibis/pull/12060#issuecomment-5136555049). The cost of the version proposed here is that eager and streaming still disagree for `json` columns, as they have since #7562.

## Testing

Snowflake CI is disabled, so the backend tests here do not run in CI; they were validated against a live account (see #12060).

`ibis/backends/tests/test_export.py` gains three tests that do run for every other backend, so the divergence is declared where the cross-backend contract lives rather than only in Snowflake's own suite:

* a struct column comes back as a struct from `to_pyarrow` — Snowflake `notyet`, it wraps in the `ibis.json` extension type;
* the same from `to_pyarrow_batches` — Snowflake `notyet`, it hands back the JSON text off the wire;
* a zero-row nested result is empty rather than raising, which Snowflake satisfies with this PR.
