### PR TITLE
fix(pyarrow): don't raise on unrecognized arrow extension types

### DIFF
--- a/ibis/formats/pyarrow.py
+++ b/ibis/formats/pyarrow.py
@@ -108,6 +108,16 @@ class PyArrowType(TypeMapper):
             return dt.Map(key_dtype, value_dtype, nullable=nullable)
         elif pa.types.is_dictionary(typ):
             return cls.to_ibis(typ.value_type)
+        elif isinstance(typ, pa.ExtensionType) and typ.extension_name == "ibis.json":
+            # the snowflake backend wraps JSON-encoded columns in a registered
+            # extension type whose storage is JSON text; `json` rather than the
+            # `string` storage keeps the fact that the text is parseable, which
+            # is what the extension scalar's `as_py` relies on
+            #
+            # the element types don't survive: array, map and struct are all
+            # wrapped in the same extension type, so they all come back as
+            # `json` rather than as themselves
+            return dt.JSON(nullable=nullable)
         elif (
             isinstance(typ, pa.ExtensionType)
             and type(typ).__module__ == "geoarrow.types.type_pyarrow"
@@ -156,6 +166,12 @@ class PyArrowType(TypeMapper):
                 geotype = "geometry"
 
             return dt.GeoSpatial(geotype, srid, nullable)
+        elif isinstance(typ, pa.ExtensionType):
+            # an extension type we don't recognize is still readable as
+            # whatever it's stored as, which is what every consumer that hasn't
+            # registered it sees anyway; falling through would reach the lookup
+            # below and raise `TypeError: unhashable type`
+            return cls.to_ibis(typ.storage_type, nullable=nullable)
         else:
             return _from_pyarrow_types[typ](nullable=nullable)
 

--- a/ibis/formats/pyarrow.py
+++ b/ibis/formats/pyarrow.py
@@ -117,9 +117,12 @@ class PyArrowType(TypeMapper):
             # snowflake backend wraps JSON-encoded columns in `ibis.json`,
             # whose storage is likewise JSON text
             #
-            # `json` rather than the `string` storage keeps the fact that the
-            # text is parseable, which is what the ibis extension scalar's
-            # `as_py` relies on
+            # both map to `json` rather than to their `string` storage for
+            # plain fidelity: the column is JSON and ibis has a type for that.
+            # the cost is that backends without `json` support are worse off
+            # than they would be with `string` -- polars, for one, raises
+            # `Converting json to polars is not supported yet` -- but that is
+            # how every other `json` column already behaves there
             #
             # for `ibis.json` the element types don't survive: array, map and
             # struct are all wrapped in the same extension type, so they all
@@ -181,6 +184,10 @@ class PyArrowType(TypeMapper):
 
             return dt.GeoSpatial(geotype, srid, nullable)
         elif isinstance(typ, pa.BaseExtensionType):
+            # keep this last: every extension branch above is more specific,
+            # and hoisting this one would quietly turn geometry columns into
+            # `binary` and JSON columns into `string`
+            #
             # an extension type we don't recognize is still readable as
             # whatever it's stored as, which is what every consumer that hasn't
             # registered it sees anyway; falling through would reach the lookup

--- a/ibis/formats/pyarrow.py
+++ b/ibis/formats/pyarrow.py
@@ -108,16 +108,30 @@ class PyArrowType(TypeMapper):
             return dt.Map(key_dtype, value_dtype, nullable=nullable)
         elif pa.types.is_dictionary(typ):
             return cls.to_ibis(typ.value_type)
-        elif isinstance(typ, pa.ExtensionType) and typ.extension_name == "ibis.json":
-            # the snowflake backend wraps JSON-encoded columns in a registered
-            # extension type whose storage is JSON text; `json` rather than the
-            # `string` storage keeps the fact that the text is parseable, which
-            # is what the extension scalar's `as_py` relies on
+        elif isinstance(typ, pa.BaseExtensionType) and typ.extension_name in (
+            "arrow.json",
+            "ibis.json",
+        ):
+            # `arrow.json` is pyarrow's own canonical type, and is what parquet
+            # files written with the JSON logical type read back as. the
+            # snowflake backend wraps JSON-encoded columns in `ibis.json`,
+            # whose storage is likewise JSON text
             #
-            # the element types don't survive: array, map and struct are all
-            # wrapped in the same extension type, so they all come back as
-            # `json` rather than as themselves
+            # `json` rather than the `string` storage keeps the fact that the
+            # text is parseable, which is what the ibis extension scalar's
+            # `as_py` relies on
+            #
+            # for `ibis.json` the element types don't survive: array, map and
+            # struct are all wrapped in the same extension type, so they all
+            # come back as `json` rather than as themselves
             return dt.JSON(nullable=nullable)
+        elif (
+            isinstance(typ, pa.BaseExtensionType)
+            and typ.extension_name == "arrow.uuid"
+        ):
+            # storage is `fixed_size_binary(16)`, which has no ibis equivalent,
+            # so the fallback below would raise rather than degrade
+            return dt.UUID(nullable=nullable)
         elif (
             isinstance(typ, pa.ExtensionType)
             and type(typ).__module__ == "geoarrow.types.type_pyarrow"
@@ -166,11 +180,16 @@ class PyArrowType(TypeMapper):
                 geotype = "geometry"
 
             return dt.GeoSpatial(geotype, srid, nullable)
-        elif isinstance(typ, pa.ExtensionType):
+        elif isinstance(typ, pa.BaseExtensionType):
             # an extension type we don't recognize is still readable as
             # whatever it's stored as, which is what every consumer that hasn't
             # registered it sees anyway; falling through would reach the lookup
             # below and raise `TypeError: unhashable type`
+            #
+            # `BaseExtensionType` rather than `ExtensionType`: the latter only
+            # covers types defined in python, so the ones pyarrow implements in
+            # c++ -- `arrow.json`, `arrow.uuid`, `arrow.bool8`, `arrow.opaque`,
+            # `arrow.fixed_shape_tensor` -- would miss it
             return cls.to_ibis(typ.storage_type, nullable=nullable)
         else:
             return _from_pyarrow_types[typ](nullable=nullable)

--- a/ibis/formats/tests/test_pyarrow.py
+++ b/ibis/formats/tests/test_pyarrow.py
@@ -197,6 +197,82 @@ def test_geo_gets_converted_to_geoarrow(ibis_type):
     )
 
 
+class UnknownExtensionType(pa.ExtensionType):
+    def __init__(self, storage_type):
+        super().__init__(storage_type, "test.unknown")
+
+    def __arrow_ext_serialize__(self):
+        return b""
+
+    @classmethod
+    def __arrow_ext_deserialize__(cls, storage_type, serialized):
+        return cls(storage_type)
+
+
+@pytest.mark.parametrize(
+    ("storage", "expected"),
+    [
+        (pa.int64(), dt.int64),
+        (pa.string(), dt.string),
+        (pa.list_(pa.int64()), dt.Array(dt.int64)),
+    ],
+    ids=["int64", "string", "list"],
+)
+def test_unknown_extension_type_falls_back_to_storage(storage, expected):
+    # every extension type `to_ibis` doesn't recognize used to reach the dict
+    # lookup at the end of the chain and raise `TypeError: unhashable type`,
+    # which broke `memtable` on any arrow input carrying one
+    typ = UnknownExtensionType(storage)
+
+    assert PyArrowType.to_ibis(typ) == expected
+
+    table = pa.table({"x": pa.ExtensionArray.from_storage(typ, pa.array([], storage))})
+    assert ibis.memtable(table).schema() == ibis.schema({"x": expected})
+
+
+def test_ibis_json_extension_gets_converted_to_json():
+    # the snowflake backend returns JSON-encoded columns wrapped in a
+    # registered `ibis.json` extension type; without a case here, feeding that
+    # output back to `memtable` raises `TypeError: unhashable type: 'JSONType'`
+    converter = pytest.importorskip("ibis.backends.snowflake.converter")
+
+    assert PyArrowType.to_ibis(converter.PYARROW_JSON_TYPE) == dt.json
+    assert PyArrowType.to_ibis(converter.PYARROW_JSON_TYPE, nullable=False) == dt.JSON(
+        nullable=False
+    )
+
+
+def test_ibis_json_extension_roundtrips_through_memtable():
+    converter = pytest.importorskip("ibis.backends.snowflake.converter")
+
+    table = pa.table(
+        {
+            "i": pa.array([1]),
+            "js": pa.ExtensionArray.from_storage(
+                converter.PYARROW_JSON_TYPE, pa.array(['{"a": 1}'])
+            ),
+        }
+    )
+    assert ibis.memtable(table).schema() == ibis.schema({"i": "int64", "js": "json"})
+
+
+@pytest.mark.parametrize(
+    "dtype", ["json", "array<int64>", "map<string, int64>", "struct<a: int64>"]
+)
+def test_ibis_json_extension_roundtrips_lossily(dtype):
+    # the snowflake converter wraps every JSON-encoded dtype in the same
+    # extension type, which keeps no record of what it wrapped, so array, map
+    # and struct all come back as `json` rather than as themselves
+    converter = pytest.importorskip("ibis.backends.snowflake.converter")
+
+    schema = ibis.schema({"x": dtype})
+    wrapped = converter.SnowflakePyArrowData.convert_table(
+        pa.table({"x": pa.array(['{"a": 1}'])}), schema
+    )
+    assert wrapped.schema.field("x").type == converter.PYARROW_JSON_TYPE
+    assert PyArrowSchema.to_ibis(wrapped.schema) == ibis.schema({"x": "json"})
+
+
 def test_geoarrow_gets_converted_to_geo():
     gat = pytest.importorskip("geoarrow.types")
 

--- a/ibis/formats/tests/test_pyarrow.py
+++ b/ibis/formats/tests/test_pyarrow.py
@@ -230,6 +230,39 @@ def test_unknown_extension_type_falls_back_to_storage(storage, expected):
     assert ibis.memtable(table).schema() == ibis.schema({"x": expected})
 
 
+@pytest.mark.parametrize(
+    ("factory", "expected"),
+    [
+        pytest.param(lambda: pa.json_(pa.string()), dt.json, id="json"),
+        pytest.param(pa.uuid, dt.uuid, id="uuid"),
+        pytest.param(pa.bool8, dt.int8, id="bool8"),
+    ],
+)
+def test_pyarrow_native_extension_types(factory, expected):
+    # the types pyarrow implements in c++ subclass `BaseExtensionType` but not
+    # `ExtensionType`, so a guard on the latter misses them entirely
+    typ = pytest.importorskip("pyarrow") and factory()
+    assert not isinstance(typ, pa.ExtensionType)
+    assert isinstance(typ, pa.BaseExtensionType)
+
+    assert PyArrowType.to_ibis(typ) == expected
+
+
+def test_parquet_json_logical_type_roundtrips_to_memtable(tmp_path):
+    # the most likely way a user meets an extension type they never created:
+    # parquet's JSON logical type reads back as `arrow.json`
+    pq = pytest.importorskip("pyarrow.parquet")
+
+    path = tmp_path / "json.parquet"
+    pq.write_table(
+        pa.table({"x": pa.array(['{"a": 1}'], pa.json_(pa.string()))}), path
+    )
+
+    table = pq.read_table(path)
+    assert table.schema.field("x").type.extension_name == "arrow.json"
+    assert ibis.memtable(table).schema() == ibis.schema({"x": "json"})
+
+
 def test_ibis_json_extension_gets_converted_to_json():
     # the snowflake backend returns JSON-encoded columns wrapped in a
     # registered `ibis.json` extension type; without a case here, feeding that

--- a/ibis/formats/tests/test_pyarrow.py
+++ b/ibis/formats/tests/test_pyarrow.py
@@ -263,47 +263,46 @@ def test_parquet_json_logical_type_roundtrips_to_memtable(tmp_path):
     assert ibis.memtable(table).schema() == ibis.schema({"x": "json"})
 
 
-def test_ibis_json_extension_gets_converted_to_json():
-    # the snowflake backend returns JSON-encoded columns wrapped in a
-    # registered `ibis.json` extension type; without a case here, feeding that
-    # output back to `memtable` raises `TypeError: unhashable type: 'JSONType'`
-    converter = pytest.importorskip("ibis.backends.snowflake.converter")
+class IbisJSONType(pa.ExtensionType):
+    """Stand-in for the type the snowflake backend wraps JSON columns in.
 
-    assert PyArrowType.to_ibis(converter.PYARROW_JSON_TYPE) == dt.json
-    assert PyArrowType.to_ibis(converter.PYARROW_JSON_TYPE, nullable=False) == dt.JSON(
-        nullable=False
-    )
+    Defined here rather than imported so that these tests exercise the
+    contract core actually implements -- an extension named `ibis.json` maps
+    to `json` -- without importing a backend for its global registration side
+    effect. Left unregistered: registration only matters for deserializing
+    IPC and parquet, and registering a second `ibis.json` would collide with
+    the backend's if it were imported in the same session.
+    """
+
+    def __init__(self):
+        super().__init__(pa.string(), "ibis.json")
+
+    def __arrow_ext_serialize__(self):
+        return b""
+
+    @classmethod
+    def __arrow_ext_deserialize__(cls, storage_type, serialized):
+        return cls()
+
+
+def test_ibis_json_extension_gets_converted_to_json():
+    # without a case for it, feeding a wrapped column back to `memtable`
+    # raised `TypeError: unhashable type: 'JSONType'`
+    typ = IbisJSONType()
+
+    assert PyArrowType.to_ibis(typ) == dt.json
+    assert PyArrowType.to_ibis(typ, nullable=False) == dt.JSON(nullable=False)
 
 
 def test_ibis_json_extension_roundtrips_through_memtable():
-    converter = pytest.importorskip("ibis.backends.snowflake.converter")
-
+    typ = IbisJSONType()
     table = pa.table(
         {
             "i": pa.array([1]),
-            "js": pa.ExtensionArray.from_storage(
-                converter.PYARROW_JSON_TYPE, pa.array(['{"a": 1}'])
-            ),
+            "js": pa.ExtensionArray.from_storage(typ, pa.array(['{"a": 1}'])),
         }
     )
     assert ibis.memtable(table).schema() == ibis.schema({"i": "int64", "js": "json"})
-
-
-@pytest.mark.parametrize(
-    "dtype", ["json", "array<int64>", "map<string, int64>", "struct<a: int64>"]
-)
-def test_ibis_json_extension_roundtrips_lossily(dtype):
-    # the snowflake converter wraps every JSON-encoded dtype in the same
-    # extension type, which keeps no record of what it wrapped, so array, map
-    # and struct all come back as `json` rather than as themselves
-    converter = pytest.importorskip("ibis.backends.snowflake.converter")
-
-    schema = ibis.schema({"x": dtype})
-    wrapped = converter.SnowflakePyArrowData.convert_table(
-        pa.table({"x": pa.array(['{"a": 1}'])}), schema
-    )
-    assert wrapped.schema.field("x").type == converter.PYARROW_JSON_TYPE
-    assert PyArrowSchema.to_ibis(wrapped.schema) == ibis.schema({"x": "json"})
 
 
 def test_geoarrow_gets_converted_to_geo():


### PR DESCRIPTION
## Description of changes

Split out of #12060, and generalized in the process. Independent of the Snowflake PRs in that stack.

`PyArrowType.to_ibis` handled exactly two extension types by name — geoarrow's, and nothing else — so every other one fell through the `elif` chain to the `_from_pyarrow_types` lookup and raised `TypeError: unhashable type`. Any Arrow input carrying an extension type Ibis didn't hardcode was unusable:

```python
class MyType(pa.ExtensionType):
    def __init__(self):
        super().__init__(pa.int64(), "acme.counter")
    ...

table = pa.table({"x": pa.ExtensionArray.from_storage(MyType(), pa.array([1, 2, 3]))})
ibis.memtable(table)  # TypeError: unhashable type: 'MyType'
```

Fall back to the storage type, which is what a consumer that hasn't registered the extension sees anyway — PyArrow, DuckDB, Polars and pandas all present such a column as its storage.

The Snowflake backend hit this via its own output. It wraps JSON-encoded columns in an `ibis.json` extension type (#7562), so `ibis.memtable(con.to_pyarrow(t))` raised on any nested column and Ibis could not re-ingest what it had just produced. That type gets a case ahead of the fallback, mapping to `json` rather than to its `string` storage: the storage is JSON text, and `json` records that the text is parseable, which is what the extension scalar's `as_py` relies on. The element types don't survive — array, map and struct are wrapped in the same extension type — so they all come back as `json`.

## Testing

`ibis/formats/tests/test_pyarrow.py` gains a locally defined `test.unknown` extension type parametrized over int64, string and list storage, so the general case is covered without reference to any backend, plus coverage of the `ibis.json` case and its lossiness.

⚠️ These tests do not currently execute — the whole module has been silently skipping since PyArrow 23.0.0 dropped `pyarrow/tests/` from its wheels. #12066 fixes that and should land first.
