### PR TITLE
docs(sql): drop three parameters translate does not take

### DIFF
--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -613,12 +613,6 @@ class SQLGlotCompiler(abc.ABC):
             An ibis operation
         params
             A mapping of expressions to concrete values
-        compiler
-            An instance of SQLGlotCompiler
-        translate_rel
-            Relation node translator
-        translate_val
-            Value node translator
 
         Returns
         -------


### PR DESCRIPTION
## Description of changes

`SQLGlotCompiler.translate` documents five parameters and takes two:

```python
def translate(self, op, *, params: Mapping[ir.Value, Any]) -> sge.Expression:
    """Translate an ibis operation to a sqlglot expression.

    Parameters
    ----------
    op
        An ibis operation
    params
        A mapping of expressions to concrete values
    compiler
        An instance of SQLGlotCompiler
    translate_rel
        Relation node translator
    translate_val
        Value node translator
    """
```

`compiler`, `translate_rel` and `translate_val` were added in ca9520405 when the module-level `translate` became a method; the method never accepted them. Dropping them, `op` and `params` stay as they are.

Documentation only.
