### PR TITLE
fix(trino): parse string-to-json casts with JSON_PARSE

### DIFF
--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -589,6 +589,11 @@ class TrinoCompiler(SQLGlotCompiler):
 
     def visit_Cast(self, op, *, arg, to):
         from_ = op.arg.dtype
+        if from_.is_string() and to.is_json():
+            # `CAST(varchar AS JSON)` wraps the string as a JSON string scalar
+            # instead of parsing its contents as JSON; `JSON_PARSE` is the
+            # function that parses the varchar as JSON text.
+            return self.f.json_parse(arg)
         if from_.is_numeric() and to.is_timestamp():
             tz = to.timezone or "UTC"
             if from_.is_integer():

--- a/ibis/backends/sql/tests/test_compiler.py
+++ b/ibis/backends/sql/tests/test_compiler.py
@@ -21,6 +21,15 @@ def test_window_with_row_number_compiles():
     assert ibis.to_sql(expr)
 
 
+def test_trino_string_to_json_cast_uses_json_parse():
+    # GH #12073: `CAST(varchar AS JSON)` wraps the string as a JSON string
+    # scalar rather than parsing its contents, so field access returns NULL
+    t = ibis.table({"raw": "string"}, name="events")
+    sql = ibis.to_sql(t.select(a=t.raw.cast("json")), dialect="trino")
+    assert "JSON_PARSE" in sql
+    assert "CAST" not in sql
+
+
 def test_transpile_join():
     (result,) = sg.transpile(
         "SELECT * FROM t1 JOIN t2 ON x = y", read="duckdb", write=Trino


### PR DESCRIPTION
## Description of changes

In Trino, `CAST(varchar AS JSON)` wraps the string as a JSON *string* scalar instead of parsing its contents as JSON syntax, so `.cast("json")` on a column of JSON text produced a JSON string and every downstream field access returned `NULL`. `JSON_PARSE` is the function that parses a varchar as JSON, so string-to-JSON casts now compile to it. Other casts, including json-to-json, are unchanged.

Regression test added in `ibis/backends/sql/tests/test_compiler.py`; it fails on `main` (`CAST("t0"."raw" AS JSON)`) and passes with the fix.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.

## Issues closed

* Resolves #12073
