### PR TITLE
fix(expr): handle compound interval window bounds

### DIFF
--- a/ibis/backends/duckdb/tests/test_window.py
+++ b/ibis/backends/duckdb/tests/test_window.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import ibis
+
+
+def test_compound_preceding_interval():
+    table = ibis.memtable(
+        {
+            "id": [1, 1, 1],
+            "date": [
+                datetime(2024, 1, 1),
+                datetime(2024, 1, 2),
+                datetime(2024, 2, 1),
+            ],
+            "value": [10.0, 20.0, 30.0],
+        }
+    )
+    window = ibis.window(
+        group_by="id",
+        order_by="date",
+        between=(ibis.interval(months=-1, days=1), 0),
+    )
+    expression = table.mutate(rolling_sum=table.value.sum().over(window)).order_by(
+        "date"
+    )
+
+    result = ibis.duckdb.connect().execute(expression)
+
+    assert result.rolling_sum.tolist() == [10.0, 30.0, 50.0]

--- a/ibis/expr/operations/window.py
+++ b/ibis/expr/operations/window.py
@@ -12,6 +12,7 @@ import ibis.common.exceptions as com
 import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
+from ibis import util
 from ibis.common.patterns import CoercionError
 from ibis.common.typing import VarTuple  # noqa: TC001
 from ibis.expr.operations.analytic import Analytic  # noqa: TC001
@@ -20,9 +21,59 @@ from ibis.expr.operations.generic import Literal
 from ibis.expr.operations.numeric import Negate
 from ibis.expr.operations.reductions import Reduction  # noqa: TC001
 from ibis.expr.operations.sortkeys import SortKey  # noqa: TC001
+from ibis.expr.operations.temporal import IntervalAdd, IntervalSubtract
 
 T = TypeVar("T", bound=dt.Numeric | dt.Interval, covariant=True)
 S = TypeVar("S", bound=ds.DataShape, default=ds.Any, covariant=True)
+
+_NS_PER_DAY = 24 * 60 * 60 * 1_000_000_000
+_MONTH_UNITS = frozenset({"Y", "Q", "M"})
+
+
+def _interval_components(value):
+    """Return exact month and nanosecond components for a literal interval tree."""
+    if isinstance(value, Literal) and value.dtype.is_interval():
+        if value.value is None:
+            return None
+        unit = value.dtype.unit.short
+        if unit in _MONTH_UNITS:
+            return util.convert_unit(value.value, unit, "M"), 0
+        return 0, util.convert_unit(value.value, unit, "ns")
+    elif isinstance(value, IntervalAdd):
+        left = _interval_components(value.left)
+        right = _interval_components(value.right)
+        if left is not None and right is not None:
+            return left[0] + right[0], left[1] + right[1]
+    elif isinstance(value, IntervalSubtract):
+        left = _interval_components(value.left)
+        right = _interval_components(value.right)
+        if left is not None and right is not None:
+            return left[0] - right[0], left[1] - right[1]
+    elif isinstance(value, Negate):
+        if (components := _interval_components(value.arg)) is not None:
+            return -components[0], -components[1]
+
+    return None
+
+
+def _rewrite_interval(value, sign=1):
+    """Distribute negation to interval literals for portable SQL generation."""
+    if isinstance(value, Literal):
+        return value.copy(value=sign * value.value)
+    elif isinstance(value, IntervalAdd):
+        return IntervalAdd(
+            _rewrite_interval(value.left, sign),
+            _rewrite_interval(value.right, sign),
+        )
+    elif isinstance(value, IntervalSubtract):
+        return IntervalSubtract(
+            _rewrite_interval(value.left, sign),
+            _rewrite_interval(value.right, sign),
+        )
+    elif isinstance(value, Negate):
+        return _rewrite_interval(value.arg, -sign)
+    else:
+        raise AssertionError(f"Unsupported literal interval operation: {type(value)}")
 
 
 @public
@@ -52,11 +103,21 @@ class WindowBoundary(Value[T, S]):
 
         if isinstance(arg, cls):
             return arg
-        elif isinstance(arg, Negate):
-            return cls(arg.arg, preceding=True)
         elif isinstance(arg, Literal):
             new = arg.copy(value=abs(arg.value))
             return cls(new, preceding=arg.value < 0)
+        elif (components := _interval_components(arg)) is not None:
+            months, nanoseconds = components
+            month_bounds = sorted(
+                (months * 28 * _NS_PER_DAY, months * 31 * _NS_PER_DAY)
+            )
+            lower = month_bounds[0] + nanoseconds
+            upper = month_bounds[1] + nanoseconds
+            if lower < 0 and upper <= 0:
+                return cls(_rewrite_interval(arg, sign=-1), preceding=True)
+            return cls(_rewrite_interval(arg), preceding=False)
+        elif isinstance(arg, Negate):
+            return cls(arg.arg, preceding=True)
         elif isinstance(arg, Value):
             return cls(arg, preceding=False)
         else:

--- a/ibis/tests/expr/test_window_frames.py
+++ b/ibis/tests/expr/test_window_frames.py
@@ -218,6 +218,92 @@ def test_window_builder_between():
     assert w9.how == "range"
 
 
+@pytest.mark.parametrize(
+    ("value", "magnitude"),
+    [
+        (
+            ibis.interval(months=-1, days=1),
+            ibis.interval(months=1, days=-1),
+        ),
+        (
+            ibis.interval(months=-1, days=-1),
+            ibis.interval(months=1, days=1),
+        ),
+        (
+            ibis.interval(months=-1, days=28),
+            ibis.interval(months=1, days=-28),
+        ),
+        (
+            ibis.interval(days=1) - ibis.interval(months=1),
+            ibis.interval(days=-1) - ibis.interval(months=-1),
+        ),
+        (
+            ibis.interval(years=-1, months=12, days=-1),
+            ibis.interval(years=1, months=-12, days=1),
+        ),
+    ],
+)
+def test_window_builder_between_negative_compound_interval(value, magnitude):
+    window = bl.WindowBuilder().between(value, 0)
+
+    zero = ibis.literal(0).cast(value.type())
+    assert window.start == ops.WindowBoundary(magnitude, preceding=True)
+    assert window.end == ops.WindowBoundary(zero, preceding=False)
+    assert window.how == "range"
+
+
+def test_window_builder_between_positive_compound_interval():
+    value = ibis.interval(months=1, days=1)
+    window = bl.WindowBuilder().between(0, value)
+
+    zero = ibis.literal(0).cast(value.type())
+    assert window.start == ops.WindowBoundary(zero, preceding=False)
+    assert window.end == ops.WindowBoundary(value, preceding=False)
+    assert window.how == "range"
+
+
+def test_window_builder_between_negated_negative_compound_interval():
+    value = -ibis.interval(months=-1, days=1)
+    magnitude = ibis.interval(months=1, days=-1)
+    window = bl.WindowBuilder().between(0, value)
+
+    zero = ibis.literal(0).cast(value.type())
+    assert window.start == ops.WindowBoundary(zero, preceding=False)
+    assert window.end == ops.WindowBoundary(magnitude, preceding=False)
+    assert window.how == "range"
+
+
+def test_window_builder_between_ambiguous_compound_interval():
+    value = ibis.interval(years=-1, days=361)
+    window = bl.WindowBuilder().between(0, value)
+
+    zero = ibis.literal(0).cast(value.type())
+    assert window.start == ops.WindowBoundary(zero, preceding=False)
+    assert window.end == ops.WindowBoundary(value, preceding=False)
+    assert window.how == "range"
+
+
+@pytest.mark.parametrize(
+    ("dialect", "magnitude"),
+    [
+        ("bigquery", "INTERVAL '-1' DAY + INTERVAL '1' MONTH"),
+        ("duckdb", "INTERVAL '-1' DAY + INTERVAL '1' MONTH"),
+        ("postgres", "INTERVAL '-1 DAY' + INTERVAL '1 MONTH'"),
+    ],
+)
+def test_compound_interval_window_sql(dialect, magnitude):
+    table = ibis.table({"date": "timestamp", "value": "float64"}, name="t")
+    window = ibis.window(
+        order_by="date",
+        between=(ibis.interval(months=-1, days=1), 0),
+    )
+    expression = table.mutate(total=table.value.sum().over(window))
+
+    sql = " ".join(ibis.to_sql(expression, dialect=dialect).split())
+
+    assert f"RANGE BETWEEN {magnitude} preceding" in sql
+
+
 def test_window_api_supports_value_expressions(t):
     w = ibis.window(between=(t.d, t.d + 1), group_by=t.b, order_by=t.c)
     func = t.a.sum().over(w).op()


### PR DESCRIPTION
## Description of changes

### Problem

A signed compound interval such as `ibis.interval(months=-1, days=1)` is represented by an `IntervalAdd`, so `WindowBoundary.__coerce__` treated it as `FOLLOWING` instead of recognizing that it is negative. DuckDB consequently received an invalid frame such as `1 DAY + -1 MONTH FOLLOWING`.

### Why it matters

This prevents valid rolling windows with compound calendar intervals from compiling or executing. The same structural shortcut can also choose the wrong side for negated or calendar-cancelling interval expressions.

### Fix (symptom → root cause → change)

`WindowBoundary` now folds literal `IntervalAdd`, `IntervalSubtract`, and `Negate` trees into exact `(months, nanoseconds)` components before deciding the frame direction. Year/quarter/month cancellation is exact; only the final month total uses conservative 28–31 day bounds to prove that an interval is nonpositive.

For a proven-negative bound, the sign is distributed to the interval literals to produce a positive `PRECEDING` magnitude without relying on a compound-interval unary negation. Positive intervals remain `FOLLOWING`, and nonliteral interval expressions retain the existing behavior.

### Tests

- Added expression tests for negative and positive compound bounds, root negation, year/month cancellation, and a PostgreSQL-sensitive mixed calendar case.
- Added DuckDB, PostgreSQL, and BigQuery SQL assertions for the generated positive `PRECEDING` magnitude.
- Added a boundary-sensitive DuckDB execution regression that distinguishes `1 month - 1 day` from nearby incorrect magnitudes.
- Ran `pytest ibis/tests/expr -q`: 2,749 passed, 43 skipped, 3 xfailed.
- Ran the new DuckDB execution test: 1 passed.
- Ran Ruff check/format and `git diff --check`: passed.

### Manual verification

Compiled the issue case for DuckDB, PostgreSQL, and BigQuery and confirmed each emits a binary compound interval (`-1 day + 1 month`) followed by `PRECEDING`, with no top-level unary interval negation. Executed the boundary-sensitive case on DuckDB 1.5.0 and obtained the expected rolling sums `[10.0, 30.0, 50.0]`.

## Issues closed

* Resolves #11933
