### PR TITLE
revert(deps): restore tiangolo/issue-manager 0.6.0

### DIFF
--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.repository_owner == 'ibis-project'
     runs-on: ubuntu-latest
     steps:
-      - uses: tiangolo/issue-manager@0.8.1
+      - uses: tiangolo/issue-manager@0.6.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: >


### PR DESCRIPTION
Since upgrading to `tiangolo/issue-manager` 0.8.1, every Issue Manager run for the last two weeks dies as a `startup_failure` before any job starts.