### PR TITLE
fix(mssql): map bare Stddev to stdev, not stdevp

### DIFF
--- a/ibis/backends/sql/dialects.py
+++ b/ibis/backends/sql/dialects.py
@@ -360,7 +360,7 @@ class MSSQL(TSQL):
     class Generator(TSQL.Generator):
         TRANSFORMS = TSQL.Generator.TRANSFORMS.copy() | {
             sge.ApproxDistinct: rename_func("approx_count_distinct"),
-            sge.Stddev: rename_func("stdevp"),
+            sge.Stddev: rename_func("stdev"),
             sge.StddevPop: rename_func("stdevp"),
             sge.StddevSamp: rename_func("stdev"),
             sge.Variance: rename_func("var"),

--- a/ibis/backends/sql/tests/test_compiler.py
+++ b/ibis/backends/sql/tests/test_compiler.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import pytest
 import sqlglot as sg
 
 import ibis
 from ibis import _
-from ibis.backends.sql.dialects import Trino
+from ibis.backends.sql.dialects import MSSQL, Trino
 
 
 def test_window_with_row_number_compiles():
@@ -26,3 +27,11 @@ def test_transpile_join():
         "SELECT * FROM t1 JOIN t2 ON x = y", read="duckdb", write=Trino
     )
     assert "CROSS JOIN" not in result
+
+
+@pytest.mark.parametrize("func", ["STDEV", "STDEVP", "VAR", "VARP"])
+def test_mssql_stat_funcs_roundtrip(func):
+    # GH #12057: bare Stddev was mapped to STDEVP, turning the sample deviation
+    # into the population one when raw T-SQL is round-tripped
+    sql = f"SELECT {func}([x]) AS [s] FROM [t]"
+    assert sg.transpile(sql, read=MSSQL, write=MSSQL)[0] == sql


### PR DESCRIPTION
Closes #12057.

`sqlglot.transpile("SELECT STDEV([x]) FROM [t]", read=MSSQL, write=MSSQL)` returns
`STDEVP` — sample in, population out. `sge.Variance` three lines below already maps
to `var`, the sample function, so this reads as a typo rather than a decision.

Our own compilation never emits a bare `Stddev` (it goes through `stddev_samp` /
`stddev_pop`), so only raw SQL through `Backend.sql()` was affected. Test round-trips
the four functions through the dialect, no backend needed.

Oracle's `Stddev` and MySQL's `Variance` look like the same mismatch. Left alone —
tell me if you want them in a follow-up.
