### PR TITLE
docs(schema): document pandas.Series and pyarrow.Schema support in schema() docstring

### DIFF
--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -428,6 +428,7 @@ def schema(value: IntoSchema, /) -> Schema:
         - An existing `Schema` object
         - A mapping of column names to data types
         - An iterable of (column name, data type) pairs
+        - A `pandas.Series` or `pyarrow.Schema`
 
     Returns
     -------


### PR DESCRIPTION
## Description
Updates the `ibis.schema()` docstring parameters to include `pandas.Series` and `pyarrow.Schema`, which are supported by the singledispatch registration.