### PR TITLE
docs: document that Expr output method kwargs are backend-specific

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -690,8 +690,6 @@ class Expr(Immutable, Coercible):
         This method is eager and will execute the associated expression
         immediately.
 
-        See https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html for details.
-
         Parameters
         ----------
         path
@@ -699,7 +697,15 @@ class Expr(Immutable, Coercible):
         params
             Mapping of scalar parameter expressions to value.
         **kwargs
-            Additional keyword arguments passed to pyarrow.parquet.ParquetWriter
+            Additional, backend-specific keyword arguments.
+
+        Notes
+        -----
+        Which `kwargs` are accepted depends on the backend. Backends with a
+        native Parquet writer take that writer's options, while backends using
+        the default PyArrow-based implementation forward `kwargs` to
+        [`pyarrow.parquet.ParquetWriter`](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html).
+        See the `to_parquet` method of the backend you are using for details.
 
         Examples
         --------
@@ -792,8 +798,6 @@ class Expr(Immutable, Coercible):
         This method is eager and will execute the associated expression
         immediately.
 
-        See https://arrow.apache.org/docs/python/generated/pyarrow.dataset.write_dataset.html for details.
-
         Parameters
         ----------
         directory
@@ -801,7 +805,15 @@ class Expr(Immutable, Coercible):
         params
             Mapping of scalar parameter expressions to value.
         **kwargs
-            Additional keyword arguments passed to pyarrow.dataset.write_dataset
+            Additional, backend-specific keyword arguments.
+
+        Notes
+        -----
+        Which `kwargs` are accepted depends on the backend. Backends with a
+        native Parquet writer take that writer's options, while backends using
+        the default PyArrow-based implementation forward `kwargs` to
+        [`pyarrow.dataset.write_dataset`](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.write_dataset.html).
+        See the `to_parquet_dir` method of the backend you are using for details.
         """
         self._find_backend(use_default=True).to_parquet_dir(
             self, directory, params=params, **kwargs
@@ -821,8 +833,6 @@ class Expr(Immutable, Coercible):
         This method is eager and will execute the associated expression
         immediately.
 
-        See https://arrow.apache.org/docs/python/generated/pyarrow.csv.CSVWriter.html for details.
-
         Parameters
         ----------
         path
@@ -830,7 +840,15 @@ class Expr(Immutable, Coercible):
         params
             Mapping of scalar parameter expressions to value.
         **kwargs
-            Additional keyword arguments passed to pyarrow.csv.CSVWriter
+            Additional, backend-specific keyword arguments.
+
+        Notes
+        -----
+        Which `kwargs` are accepted depends on the backend. Backends with a
+        native CSV writer take that writer's options, while backends using the
+        default PyArrow-based implementation forward `kwargs` to
+        [`pyarrow.csv.CSVWriter`](https://arrow.apache.org/docs/python/generated/pyarrow.csv.CSVWriter.html).
+        See the `to_csv` method of the backend you are using for details.
         """
         self._find_backend(use_default=True).to_csv(self, path, params=params, **kwargs)
 
@@ -855,7 +873,15 @@ class Expr(Immutable, Coercible):
         params
             Mapping of scalar parameter expressions to value.
         **kwargs
-            Additional keyword arguments passed to deltalake.writer.write_deltalake method
+            Additional, backend-specific keyword arguments.
+
+        Notes
+        -----
+        Which `kwargs` are accepted depends on the backend. Backends with a
+        native Delta Lake writer take that writer's options, while backends
+        using the default implementation forward `kwargs` to
+        [`deltalake.write_deltalake`](https://delta-io.github.io/delta-rs/api/delta_writer/).
+        See the `to_delta` method of the backend you are using for details.
         """
         self._find_backend(use_default=True).to_delta(
             self, path, params=params, **kwargs


### PR DESCRIPTION
## Description of changes

`Table.to_csv` documents its `**kwargs` as "Additional keyword arguments passed to pyarrow.csv.CSVWriter", but the expression-level method just dispatches to the backend:

```python
self._find_backend(use_default=True).to_csv(self, path, params=params, **kwargs)
```

Only the default `BaseBackend` implementation goes through PyArrow. `BackendDuckDB.to_csv` overrides it and documents its own `kwargs` as "DuckDB CSV writer arguments" — and DuckDB is the default backend, so the documented PyArrow contract is wrong on the most common path.

The same shape applies to the sibling output methods, so this PR fixes the whole class rather than just the reported method:

| `Expr` method | overridden by |
|---|---|
| `to_csv` | DuckDB |
| `to_parquet` | DuckDB, PySpark |
| `to_parquet_dir` | PySpark |
| `to_delta` | PySpark |

For each of the four, `**kwargs` is now described as "Additional, backend-specific keyword arguments." — the wording `to_json` already uses, and which #11769 asks for. The PyArrow / `deltalake` references are not dropped: they move into a `Notes` section as the *default* implementation's behaviour, with a pointer to the backend's own method. This follows the precedent of #8623 (`to_delta` kwargs docs).

`to_json` and `to_xlsx` already described their kwargs correctly and are left alone.

## Testing

Documentation-only change — no executable behaviour is modified, so there is no regression test to add. Verified:

- `ruff check --force-exclude ibis/expr/types/core.py` → passes
- `ruff format --force-exclude --check ibis/expr/types/core.py` → already formatted
- `codespell ibis/expr/types/core.py` → clean
- docstrings re-parsed via `ast.get_docstring` to confirm the numpydoc sections are well-formed; `Notes` is placed before `Examples`, matching `to_xlsx` in the same file
- the one new URL (`https://delta-io.github.io/delta-rs/api/delta_writer/`) returns HTTP 200, for the lychee link check

## Deliberately left out

- No change to the backend implementations or to any signature.
- No change to `to_json` / `to_xlsx`, whose wording is already correct.
- The per-backend writer options are not enumerated in the base docstrings; they belong with each backend's own method and would drift.

## Issues closed

* Resolves #11769