### PR TITLE
fix(polars): support pl.Object conversion to dt.Unknown in PolarsType.to_ibis

### DIFF
--- a/ibis/backends/polars/tests/test_client.py
+++ b/ibis/backends/polars/tests/test_client.py
@@ -86,12 +86,7 @@ def test_compile_with_memtable(con):
 
 
 def test_polars_object_dtype_memtable():
-    class CustomObj:
-        def __init__(self, x):
-            self.x = x
-
-    df = pl.DataFrame({"a": [1, 2], "b": [CustomObj(1), CustomObj(2)]})
     con = ibis.polars.connect()
-    t = con.create_table("custom_obj_table", df)
-    assert t.schema()["a"] == dt.int64
-    assert t.schema()["b"] == dt.Unknown(nullable=True)
+    df = pl.DataFrame({"a": [object(), object()]})
+    t = con.create_table("test_obj", df)
+    assert t.schema()["a"] == dt.Unknown(nullable=True)

--- a/ibis/backends/polars/tests/test_client.py
+++ b/ibis/backends/polars/tests/test_client.py
@@ -5,6 +5,7 @@ import polars.testing
 import pytest
 
 import ibis
+import ibis.expr.datatypes as dt
 from ibis.backends.tests.errors import PolarsSQLInterfaceError
 from ibis.util import gen_name
 
@@ -82,3 +83,15 @@ def test_compile_with_memtable(con):
     t = ibis.memtable({"a": [1, 2, 3], "b": [4, 5, 6]})
     result = con.compile(t)
     assert isinstance(result, pl.LazyFrame)
+
+
+def test_polars_object_dtype_memtable():
+    class CustomObj:
+        def __init__(self, x):
+            self.x = x
+
+    df = pl.DataFrame({"a": [1, 2], "b": [CustomObj(1), CustomObj(2)]})
+    con = ibis.polars.connect()
+    t = con.create_table("custom_obj_table", df)
+    assert t.schema()["a"] == dt.int64
+    assert t.schema()["b"] == dt.Unknown(nullable=True)

--- a/ibis/backends/polars/tests/test_client.py
+++ b/ibis/backends/polars/tests/test_client.py
@@ -87,6 +87,8 @@ def test_compile_with_memtable(con):
 
 def test_polars_object_dtype_memtable():
     con = ibis.polars.connect()
-    df = pl.DataFrame({"a": [object(), object()]})
+    df = pl.DataFrame({"a": [object(), object()]}, schema={"a": pl.Object})
     t = con.create_table("test_obj", df)
+
     assert t.schema()["a"] == dt.Unknown(nullable=True)
+    assert t.count().execute() == 2

--- a/ibis/formats/polars.py
+++ b/ibis/formats/polars.py
@@ -73,6 +73,8 @@ class PolarsType(TypeMapper):
                 [(field.name, cls.to_ibis(field.dtype)) for field in typ.fields],
                 nullable=nullable,
             )
+        elif base_type is pl.Object:
+            return dt.Unknown(nullable=nullable)
         else:
             return _from_polars_types[base_type](nullable=nullable)
 

--- a/ibis/formats/tests/test_polars.py
+++ b/ibis/formats/tests/test_polars.py
@@ -175,3 +175,7 @@ def test_convert_table():
 
 def test_array_type():
     assert PolarsType.to_ibis(pl.Array(pl.Int64, 2)) == dt.Array(dt.int64)
+
+
+def test_object_type_to_ibis():
+    assert PolarsType.to_ibis(pl.Object) == dt.Unknown()


### PR DESCRIPTION
## Description
When inferring or converting schemas from Polars tables containing Python object columns (`pl.Object`), `PolarsType.to_ibis` previously raised a `KeyError: Object` due to `pl.Object` missing from the inverse lookup registry.

This PR adds explicit handling for `pl.Object` to map cleanly to `dt.Unknown(nullable=nullable)`, matching expected schema behavior when encountering uncoerced Python object columns.

## Checklist
- [x] Added `pl.Object` handling in `ibis/formats/polars.py`
- [x] Added unit test `test_object_type_to_ibis` in `ibis/formats/tests/test_polars.py`
- [x] Ran `ruff check` and `ruff format`
- [x] Verified `pytest ibis/formats/tests/test_polars.py` (41/41 passing)