### PR TITLE
ci(release): pin compatible conventionalcommits v9

### DIFF
--- a/ci/release/dry_run.sh
+++ b/ci/release/dry_run.sh
@@ -42,7 +42,7 @@ nix develop '.#release' -c npx --yes \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
   -p "semantic-release-replace-plugin" \
-  -p "conventional-changelog-conventionalcommits" \
+  -p "conventional-changelog-conventionalcommits@9" \
   semantic-release \
   --ci \
   --dry-run \

--- a/ci/release/run.sh
+++ b/ci/release/run.sh
@@ -11,5 +11,5 @@ nix develop '.#release' -c npx --yes \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
   -p "semantic-release-replace-plugin" \
-  -p "conventional-changelog-conventionalcommits" \
+  -p "conventional-changelog-conventionalcommits@9" \
   semantic-release --ci


### PR DESCRIPTION
## Description of changes

Pin `conventional-changelog-conventionalcommits` to v9, in `ci/release/dry_run.sh` and `ci/release/run.sh`.

### The problem

`simulate_release` has failed on every branch since 2026-08-24. That failure blocks the merge of every open pull request.

```
Error: Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer (conventional-changelog@8 or newer).
Your changelog tooling loaded an older writer which cannot render this preset."
```

Nothing in this repo changed. Both release scripts call `npx --yes` without pinning a single package, so every run resolves the newest version of each one. The preset published v10.4.0 on 2026-08-18.

### The two newest versions cannot work together

| package | requires |
| --- | --- |
| `conventional-changelog-conventionalcommits@10.4.0` | `@conventional-changelog/template`, and so `conventional-changelog-writer` v9 |
| `@semantic-release/release-notes-generator@14.1.1` (newest) | `conventional-changelog-writer` v8 |

Preset v10 needs writer v9. The newest generator still needs writer v8. No combination of current releases works. Preset v10 raises the error above instead of failing obscurely, which is how we get a legible message. Pinning to v9 is the only fix until the generator supports writer v9.

### This is not only a CI failure

`ci/release/run.sh` drives the real release, and it carries the same unpinned command. The next release would fail identically. `simulate_release` is reporting a genuine pre-release failure here, not a flake.

### Verification

`simulate_release` passes on this PR, and renders `##### Bug Fixes` under `### Release Notes` rather than exiting early.

Reproduced standalone as well, outside this repo, using the real `presetConfig` from `.releaserc.js`:

| preset | result |
| --- | --- |
| unpinned (before) | semantic-release aborts with `Missing helper` |
| `@9` (after) | `The next release version is 1.0.1`, notes render |

### Optional follow-up

This pins one package. `semantic-release`, its five plugins, and `semantic-release-replace-plugin` stay unpinned in both scripts, and any of them can break the release the same way, with no warning until release day.

Renovate will not catch it either. `enabledManagers` lists `docker-compose`, `dockerfile`, `github-actions`, and `pep621`, none of which read shell scripts. Pinning the rest, or adding a `customManagers` regex rule, would stop this recurring.
