### PR TITLE
fix(docs): restore the docstring admonitions lost in the mkdocstrings swap

### DIFF
--- a/docs/_renderer.py
+++ b/docs/_renderer.py
@@ -1,17 +1,96 @@
 from __future__ import annotations
 
+import ast
 from textwrap import dedent
 
+import griffe
 import quartodoc as qd
 import toolz
 from plum import dispatch
+
+from ibis.util import (
+    BACKEND_SENSITIVE_MSG,
+    EXPERIMENTAL_MSG,
+    append_admonition,
+    deprecated_msg,
+)
+
+
+def _keyword_arguments(value: griffe.Expr) -> dict[str, str]:
+    """Statically evaluate the keyword arguments of a decorator call."""
+    if not isinstance(value, griffe.ExprCall):
+        return {}
+    return {
+        argument.name: ast.literal_eval(str(argument.value))
+        for argument in value.arguments
+        if isinstance(argument, griffe.ExprKeyword)
+    }
+
+
+def _admonition_arguments(decorator: griffe.Decorator, el) -> dict[str, str] | None:
+    """Return `append_admonition` arguments for `decorator`, if it adds one."""
+    kwargs = _keyword_arguments(decorator.value)
+    path = decorator.value.canonical_path
+
+    if path == "ibis.util.experimental":
+        return {"msg": EXPERIMENTAL_MSG}
+    elif path == "ibis.util.deprecated":
+        try:
+            qualname = el.path.removeprefix(f"{el.module.path}.")
+        except (AttributeError, ValueError):
+            qualname = el.name
+        return {"msg": f"DEPRECATED: {deprecated_msg(qualname, **kwargs)}"}
+    elif path == "ibis.util.backend_sensitive":
+        return {
+            "msg": kwargs.get("msg", BACKEND_SENSITIVE_MSG),
+            "body": kwargs.get("why", ""),
+            "kind": "note",
+        }
+    else:
+        return None
+
+
+def apply_admonitions(el) -> None:
+    """Rebuild the admonitions that ibis's decorators add to `__doc__`.
+
+    The `experimental`, `deprecated` and `backend_sensitive` decorators inject
+    their admonitions when the module is imported, but objects are collected by
+    parsing source, so none of that is visible to the docs build. The
+    decorators themselves *are* visible, so reproduce their output from them.
+    """
+    # decorators are applied bottom-up, and each admonition is inserted directly
+    # after the summary line, so replay them in the same order to match `help()`
+    for decorator in reversed(getattr(el, "decorators", ())):
+        if (kwargs := _admonition_arguments(decorator, el)) is None:
+            continue
+
+        docstring = el.docstring
+
+        # entries collected dynamically already have the decorator's admonition,
+        # because they read the docstring the decorator built at import time
+        if docstring is not None and f"## {kwargs['msg']}" in docstring.value:
+            continue
+
+        value = append_admonition(docstring.value if docstring else None, **kwargs)
+
+        if docstring is None:
+            el.docstring = griffe.Docstring(value, parent=el)
+        else:
+            docstring.value = value
+            # `parsed` is a cached property, so drop any parse of the old value
+            docstring.__dict__.pop("parsed", None)
 
 
 class Renderer(qd.MdRenderer):
     style = "ibis"
 
     @dispatch
-    def render(self, el: qd.ast.ExampleCode) -> str:
+    def render(self, el: griffe.Object | griffe.Alias):
+        apply_admonitions(el)
+        return super().render(el)
+
+    @dispatch
+    def render(self, el: qd.ast.ExampleCode) -> str:  # noqa: F811
         lines = el.value.splitlines()
 
         result = []

--- a/docs/backends/_utils.py
+++ b/docs/backends/_utils.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
 import json
+import sys
 from functools import cache, partial
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from quartodoc import MdRenderer, get_object
+
+# these pages are rendered with the docs directory as the working directory's
+# sibling, so make the shared renderer helpers importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from _renderer import apply_admonitions
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -66,7 +74,9 @@ def render_method(*, member, renderer: MdRenderer) -> Iterator[str]:
         yield f"`{name}({', '.join(params)})`"
     yield "\n"
 
-    yield get_renderer(header_level + 1).render(find_member_with_docstring(member))
+    documented = find_member_with_docstring(member)
+    apply_admonitions(documented)
+    yield get_renderer(header_level + 1).render(documented)
 
 
 def render_methods(obj, *methods: str, level: int) -> None:

--- a/docs/posts/ibis-version-8.0.0-release/index.qmd
+++ b/docs/posts/ibis-version-8.0.0-release/index.qmd
@@ -206,7 +206,7 @@ t.relocate("sex", "year")
 
 The `.sample()` method can be used to sample rows from a table:
 
-:::{.callout-info}
+:::{.callout-note}
 Number of rows returned may vary by invocation.
 :::
 

--- a/docs/posts/ibis-version-8.0.0-release/index.qmd
+++ b/docs/posts/ibis-version-8.0.0-release/index.qmd
@@ -206,7 +206,7 @@ t.relocate("sex", "year")
 
 The `.sample()` method can be used to sample rows from a table:
 
-:::{.callout-note}
+:::{.callout-info}
 Number of rows returned may vary by invocation.
 :::
 

--- a/docs/posts/run-on-snowflake/index.qmd
+++ b/docs/posts/run-on-snowflake/index.qmd
@@ -118,7 +118,7 @@ session.sproc.register(
 )
 ```
 
-::: {.callout-info}
+::: {.callout-note}
 ## More permanent solutions to packaging
 
 It's possible that a more permanent solution could be achieved with a `put` or

--- a/ibis/tests/test_util.py
+++ b/ibis/tests/test_util.py
@@ -2,9 +2,21 @@
 
 from __future__ import annotations
 
-import pytest
+import re
 
-from ibis.util import PseudoHashable, flatten_iterable, import_object, is_iterable
+import pytest
+from pytest import param
+
+from ibis.util import (
+    PseudoHashable,
+    append_admonition,
+    backend_sensitive,
+    deprecated,
+    experimental,
+    flatten_iterable,
+    import_object,
+    is_iterable,
+)
 
 
 @pytest.mark.parametrize(
@@ -159,3 +171,64 @@ def test_is_iterable(x, expected):
     else:
         assert actual is True
         assert list(x) == list(expected)
+
+
+VALID_QUARTO_CALLOUTS = frozenset(("note", "tip", "warning", "caution", "important"))
+
+
+@pytest.mark.parametrize("kind", sorted(VALID_QUARTO_CALLOUTS))
+def test_append_admonition_body_is_inside_the_callout(kind):
+    def f():
+        """Do a thing.
+
+        Parameters
+        ----------
+        x
+            A parameter.
+        """
+
+    docstr = append_admonition(
+        f.__doc__, msg="A title.", body="Some detail.", kind=kind
+    )
+    admonition = docstr[
+        docstr.index(":::") : docstr.index(":::", docstr.index(":::") + 1)
+    ]
+
+    assert f"::: {{.callout-{kind}}}" in docstr
+    assert "## A title." in admonition
+    # a body placed after the fence, or indented, renders as a code block
+    assert "Some detail." in admonition
+    assert "\n    Some detail." not in docstr
+
+
+def test_append_admonition_without_a_docstring():
+    def f(): ...
+
+    docstr = append_admonition(f.__doc__, msg="A title.", kind="note")
+    assert docstr == "::: {.callout-note}\n## A title.\n:::"
+
+
+def test_append_admonition_keeps_the_summary_first():
+    def f():
+        """Do a thing.
+
+        More detail.
+        """
+
+    docstr = append_admonition(f.__doc__, msg="A title.", kind="note")
+    summary, admonition, *_ = docstr.split("\n\n")
+    assert summary == "Do a thing."
+    assert admonition.strip().startswith("::: {.callout-note}")
+
+
+@pytest.mark.parametrize(
+    "decorated",
+    [
+        param(experimental(lambda: None), id="experimental"),
+        param(backend_sensitive()(lambda: None), id="backend_sensitive"),
+        param(deprecated(instead="use g")(lambda: None), id="deprecated"),
+    ],
+)
+def test_decorators_emit_a_valid_quarto_callout(decorated):
+    (kind,) = re.findall(r"::: \{\.callout-([a-z]+)\}", decorated.__doc__)
+    assert kind in VALID_QUARTO_CALLOUTS

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -324,10 +324,25 @@ def warn_deprecated(name, *, instead, as_of="", removed_in="", stacklevel=1):
 
 
 def append_admonition(
-    func: Callable, *, msg: str, body: str = "", kind: str = "warning"
+    docstr: str | None, *, msg: str, body: str = "", kind: str = "warning"
 ) -> str:
-    """Append a `kind` admonition with `msg` to `func`'s docstring."""
-    if docstr := func.__doc__:
+    """Append a `kind` admonition with `msg` to `docstr`.
+
+    Takes the docstring rather than the callable so that the documentation
+    build can reproduce the same admonition from a statically parsed
+    decorator, without importing the module that defines it.
+    """
+    lines = [f"::: {{.callout-{kind}}}", f"## {msg}"]
+
+    # the body is part of the callout, so it goes inside the fence; indenting it
+    # would turn it into a code block
+    if body:
+        lines += ["", body]
+
+    lines.append(":::")
+    admonition_doc = "\n".join(lines)
+
+    if docstr:
         preamble, *rest = docstr.split("\n\n", maxsplit=1)
 
         # count leading spaces and add them to the deprecation warning so the
@@ -336,18 +351,10 @@ def append_admonition(
             1 for _ in itertools.takewhile(str.isspace, rest[0] if rest else [])
         )
 
-        lines = [f"::: {{.callout-{kind}}}", f"## {msg}", ":::"]
-        admonition_doc = textwrap.indent("\n".join(lines), leading_spaces)
-
-        if body:
-            rest = [indent(body, spaces=len(leading_spaces) + 4), *rest]
-
-        docstr = "\n\n".join([preamble, admonition_doc, *rest])
+        docstr = "\n\n".join(
+            [preamble, textwrap.indent(admonition_doc, leading_spaces), *rest]
+        )
     else:
-        lines = [f"::: {{.callout-{kind}}}", f"## {msg}", ":::"]
-        admonition_doc = "\n".join(lines)
-        if body:
-            admonition_doc += f"\n\n{indent(body, spaces=4)}"
         docstr = admonition_doc
     return docstr
 
@@ -360,7 +367,7 @@ def deprecated(*, instead: str, as_of: str = "", removed_in: str = ""):
             func.__qualname__, instead=instead, as_of=as_of, removed_in=removed_in
         )
 
-        func.__doc__ = append_admonition(func, msg=f"DEPRECATED: {msg}")
+        func.__doc__ = append_admonition(func.__doc__, msg=f"DEPRECATED: {msg}")
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
@@ -378,15 +385,15 @@ def deprecated(*, instead: str, as_of: str = "", removed_in: str = ""):
     return decorator
 
 
-def backend_sensitive(
-    *,
-    msg: str = "This operation differs between backends.",
-    why: str = "",
-):
+BACKEND_SENSITIVE_MSG = "This operation differs between backends."
+EXPERIMENTAL_MSG = "This API is experimental and subject to change."
+
+
+def backend_sensitive(*, msg: str = BACKEND_SENSITIVE_MSG, why: str = ""):
     """Indicate that an API may be sensitive to a backend."""
 
     def wrapper(func):
-        func.__doc__ = append_admonition(func, msg=msg, body=why, kind="info")
+        func.__doc__ = append_admonition(func.__doc__, msg=msg, body=why, kind="note")
         return func
 
     return wrapper
@@ -395,9 +402,7 @@ def backend_sensitive(
 def experimental(func):
     """Decorate a callable to add warning about API instability in docstring."""
 
-    func.__doc__ = append_admonition(
-        func, msg="This API is experimental and subject to change."
-    )
+    func.__doc__ = append_admonition(func.__doc__, msg=EXPERIMENTAL_MSG)
     return func
 
 


### PR DESCRIPTION
## Description of changes

`ibis.util` has three decorators that document an API by appending a quarto
callout to it: `experimental`, `deprecated` and `backend_sensitive`. None of
them has rendered on the site since **2023-01-04**.

They work by assigning to `func.__doc__` at import time. That was fine while
the docs were collected by `pytkdocs`, which imports a module and reads
`__doc__`. `7baea1511` ("chore(dev-deps): bump mkdocstrings and add
mkdocstrings-python") replaced it:

```diff
-mkdocstrings = ">=0.17.0,<0.18.0"
-pytkdocs = { version = ">=0.15.0,<0.17.0", extras = ["numpy-style"] }
+mkdocstrings = ">=0.19.1,<1"
+mkdocstrings-python = ">=0.8.3,<1"
```

`mkdocstrings-python` is griffe-based and parses source, so a docstring built
at import time is invisible to it. Nothing about the decorators changed — the
ground moved under them. The quarto migration (`16e17b86d`) kept static
collection, and quartodoc is static by default, so the regression carried over.

Confirmed against the pinned `quartodoc==0.11.1` / `griffe==1.15.0`:

```
STATIC  has callout: False
DYNAMIC has callout: True
```

### What was hiding behind that

Porting the admonitions from mkdocs to quarto (`9a3ff39f6`) introduced two
bugs that never fired, because nothing was rendering:

1. **`callout-info` is not a quarto callout type.** Quarto has `note`, `tip`,
   `warning`, `caution` and `important`. `backend_sensitive` is the only caller
   passing `kind="info"`, so it would still not have rendered as a callout once
   visible. Every one of the other 216 `callout-*` uses in the repo is valid.
2. **The `why=` body was emitted outside the fence**, indented four spaces —
   a code block in quarto. Under mkdocs-material that indent is exactly how
   admonition content is attached, so the port was a faithful translation of
   syntax that no longer meant the same thing.

### The fix

- Rebuild the admonitions in `docs/_renderer.py` from the **decorators**, which
  griffe does record statically. Collection stays static: no imports of optional
  backend drivers, no dynamic-mode failure modes. The output is byte-identical
  to the runtime `__doc__`, so `help()` and the site can't drift.
- The same helper is applied to the backend API pages, which render through
  `docs/backends/_utils.py` rather than the quartodoc renderer.
- Injection is idempotent: the 52 `dynamic: true` entries in `_quarto.yml`
  already carry the decorator's admonition, and are skipped rather than
  doubled.
- `append_admonition` now takes the docstring instead of the callable, so the
  docs build can reuse it without importing anything, and the two syntax bugs
  above are fixed at the source.
- Two blog posts use the same invalid `callout-info`
  (`docs/posts/ibis-version-8.0.0-release`, `docs/posts/run-on-snowflake`);
  both are now `callout-note`.

### Considered and rejected

Setting `dynamic: true` globally is a one-line change that fixes strictly more
(it would also restore the `_regular_join_method` docstrings, see below), but
it needs the collector to import everything and it breaks on ibis code:
`Table.anti_join` has a `<locals>` qualname the resolver can't map back, and
`TimestampValue.day_of_week` trips griffe's cyclic-alias detection. Both would
mean contorting library code to satisfy the docs collector.

### Not fixed here

`_regular_join_method` (`ibis/expr/types/relations.py`) assigns
`f.__doc__ = _JOIN_DOCSTRING_TEMPLATES[how]` at runtime, so all eight
`*_join` methods on `Table` currently render with **no documentation at all**.
Same root cause, different mechanism — it isn't a decorator, so it can't be
recovered statically. Happy to open a separate issue.

## Testing

- `ibis/tests/test_util.py` gains coverage that the emitted `kind` is a real
  quarto callout type, that the body lands inside the fence, and that the
  summary line stays first.
- `pytest ibis/tests/` → 2965 passed, 119 skipped, 3 xfailed
- `pytest --doctest-modules ibis/util.py` → 6 passed
- `ruff check` / `ruff format --check` / `codespell` clean on all touched files

Evidence from the rendered docs to follow once the preview build finishes.
