### PR TITLE
feat(bigquery): use native UNPIVOT for pivot_longer

### DIFF
--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_pivot_longer_casts_mismatched_types/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_pivot_longer_casts_mismatched_types/out.sql
@@ -1,0 +1,13 @@
+SELECT
+  `artist`,
+  `week`,
+  `rank`
+FROM (
+  SELECT
+    `t0`.*
+    EXCEPT (`wk1`, `wk2`),
+    CAST(`t0`.`wk1` AS FLOAT64) AS `wk1`,
+    CAST(`t0`.`wk2` AS FLOAT64) AS `wk2`
+  FROM `t` AS `t0`
+)
+UNPIVOT INCLUDE NULLS (`rank` FOR `week` IN (`wk1` AS 'wk1', `wk2` AS 'wk2'))

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_pivot_longer_multi_names_to_falls_back/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_pivot_longer_multi_names_to_falls_back/out.sql
@@ -1,0 +1,46 @@
+SELECT
+  `t1`.`id`,
+  `t1`.`__pivoted__`.`metric` AS `metric`,
+  `t1`.`__pivoted__`.`grp` AS `grp`,
+  `t1`.`__pivoted__`.`val` AS `val`
+FROM (
+  SELECT
+    `t0`.`id`,
+    IF(pos = pos_2, `__pivoted__`, NULL) AS `__pivoted__`
+  FROM `t` AS `t0`
+  CROSS JOIN UNNEST(GENERATE_ARRAY(
+    0,
+    GREATEST(
+      ARRAY_LENGTH(
+        [
+          STRUCT('x' AS `metric`, 'a' AS `grp`, `t0`.`x_a` AS `val`),
+          STRUCT('x' AS `metric`, 'b' AS `grp`, `t0`.`x_b` AS `val`)
+        ]
+      )
+    ) - 1
+  )) AS pos
+  CROSS JOIN UNNEST([
+    STRUCT('x' AS `metric`, 'a' AS `grp`, `t0`.`x_a` AS `val`),
+    STRUCT('x' AS `metric`, 'b' AS `grp`, `t0`.`x_b` AS `val`)
+  ]) AS `__pivoted__` WITH OFFSET AS pos_2
+  WHERE
+    pos = pos_2
+    OR (
+      pos > (
+        ARRAY_LENGTH(
+          [
+            STRUCT('x' AS `metric`, 'a' AS `grp`, `t0`.`x_a` AS `val`),
+            STRUCT('x' AS `metric`, 'b' AS `grp`, `t0`.`x_b` AS `val`)
+          ]
+        ) - 1
+      )
+      AND pos_2 = (
+        ARRAY_LENGTH(
+          [
+            STRUCT('x' AS `metric`, 'a' AS `grp`, `t0`.`x_a` AS `val`),
+            STRUCT('x' AS `metric`, 'b' AS `grp`, `t0`.`x_b` AS `val`)
+          ]
+        ) - 1
+      )
+    )
+) AS `t1`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_pivot_longer_uses_native_unpivot/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_pivot_longer_uses_native_unpivot/out.sql
@@ -1,0 +1,13 @@
+SELECT
+  `artist`,
+  `week`,
+  `rank`
+FROM (
+  SELECT
+    `t0`.*
+    EXCEPT (`wk1`, `wk2`),
+    CAST(`t0`.`wk1` AS INT64) AS `wk1`,
+    CAST(`t0`.`wk2` AS INT64) AS `wk2`
+  FROM `t` AS `t0`
+)
+UNPIVOT INCLUDE NULLS (`rank` FOR `week` IN (`wk1` AS 'wk1', `wk2` AS 'wk2'))

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_pivot_longer_values_drop_na_uses_exclude_nulls/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_pivot_longer_values_drop_na_uses_exclude_nulls/out.sql
@@ -1,0 +1,13 @@
+SELECT
+  `artist`,
+  `week`,
+  `rank`
+FROM (
+  SELECT
+    `t0`.*
+    EXCEPT (`wk1`, `wk2`),
+    CAST(`t0`.`wk1` AS INT64) AS `wk1`,
+    CAST(`t0`.`wk2` AS INT64) AS `wk2`
+  FROM `t` AS `t0`
+)
+UNPIVOT EXCLUDE NULLS (`rank` FOR `week` IN (`wk1` AS 'wk1', `wk2` AS 'wk2'))

--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -711,3 +711,38 @@ def test_unreasonably_long_name():
         match="BigQuery does not allow column names longer than 300 characters",
     ):
         ibis.to_sql(expr, dialect="bigquery")
+
+
+def test_pivot_longer_uses_native_unpivot(snapshot):
+    t = ibis.table(dict(artist="string", wk1="int64", wk2="int64"), name="t")
+    expr = t.pivot_longer(["wk1", "wk2"], names_to="week", values_to="rank")
+    result = to_sql(expr)
+    assert "UNPIVOT" in result
+    snapshot.assert_match(result, "out.sql")
+
+
+def test_pivot_longer_multi_names_to_falls_back(snapshot):
+    # UNPIVOT only ever produces a single name column, so a call needing
+    # more than one `names_to` column can't be expressed natively.
+    t = ibis.table(dict(id="int64", x_a="int64", x_b="int64"), name="t")
+    expr = t.pivot_longer(
+        ["x_a", "x_b"],
+        names_to=["metric", "grp"],
+        names_pattern=r"(x)_(a|b)",
+        values_to="val",
+    )
+    result = to_sql(expr)
+    assert "UNPIVOT" not in result
+    snapshot.assert_match(result, "out.sql")
+
+
+def test_pivot_longer_casts_mismatched_types(snapshot):
+    # BigQuery's UNPIVOT IN-list requires every column to share the exact
+    # same type; ibis's schema unifies int64/float64 columns to float64, so
+    # each column must be cast before entering the IN-list to match.
+    t = ibis.table(dict(artist="string", wk1="int64", wk2="float64"), name="t")
+    expr = t.pivot_longer(["wk1", "wk2"], names_to="week", values_to="rank")
+    result = to_sql(expr)
+    assert result.count("CAST(") == 2
+    assert "AS FLOAT64" in result
+    snapshot.assert_match(result, "out.sql")

--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -718,6 +718,11 @@ def test_pivot_longer_uses_native_unpivot(snapshot):
     expr = t.pivot_longer(["wk1", "wk2"], names_to="week", values_to="rank")
     result = to_sql(expr)
     assert "UNPIVOT" in result
+    # default (values_drop_na=False) keeps NULLs, matching pivot_longer's
+    # behavior on every other backend, unlike UNPIVOT's own EXCLUDE NULLS
+    # default -- must be stated explicitly, not left to BigQuery's default.
+    assert "INCLUDE NULLS" in result
+    assert "EXCLUDE NULLS" not in result
     snapshot.assert_match(result, "out.sql")
 
 

--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -721,6 +721,17 @@ def test_pivot_longer_uses_native_unpivot(snapshot):
     snapshot.assert_match(result, "out.sql")
 
 
+def test_pivot_longer_values_drop_na_uses_exclude_nulls(snapshot):
+    t = ibis.table(dict(artist="string", wk1="int64", wk2="int64"), name="t")
+    expr = t.pivot_longer(
+        ["wk1", "wk2"], names_to="week", values_to="rank", values_drop_na=True
+    )
+    result = to_sql(expr)
+    assert "EXCLUDE NULLS" in result
+    assert "INCLUDE NULLS" not in result
+    snapshot.assert_match(result, "out.sql")
+
+
 def test_pivot_longer_multi_names_to_falls_back(snapshot):
     # UNPIVOT only ever produces a single name column, so a call needing
     # more than one `names_to` column can't be expressed natively.

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -285,6 +285,14 @@ def aggregation(op, **kw):
     return func()
 
 
+@translate.register(ops.PivotLonger)
+def pivot_longer(op, **kw):
+    # Polars has no native unpivot construct wired into `translate`, unlike
+    # SQLGlotCompiler backends (which lower via `LOWERED_OPS`); fall back to
+    # the backend-agnostic struct/array/unnest expansion.
+    return translate(op.to_generic().op(), **kw)
+
+
 @translate.register(PandasRename)
 def rename(op, **kw):
     parent = translate(op.parent, **kw)

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -287,9 +287,6 @@ def aggregation(op, **kw):
 
 @translate.register(ops.PivotLonger)
 def pivot_longer(op, **kw):
-    # Polars has no native unpivot construct wired into `translate`, unlike
-    # SQLGlotCompiler backends (which lower via `LOWERED_OPS`); fall back to
-    # the backend-agnostic struct/array/unnest expansion.
     return translate(op.to_generic().op(), **kw)
 
 

--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -26,6 +26,7 @@ from ibis.backends.sql.rewrites import (
     empty_in_values_right_side,
     lower_bucket,
     lower_capitalize,
+    lower_pivot_longer,
     lower_sample,
     one_to_zero_index,
     sqlize,
@@ -306,6 +307,7 @@ class SQLGlotCompiler(abc.ABC):
     LOWERED_OPS: dict[type[ops.Node], pats.Replace | None] = {
         ops.Bucket: lower_bucket,
         ops.Capitalize: lower_capitalize,
+        ops.PivotLonger: lower_pivot_longer,
         ops.Sample: lower_sample(supported_methods=()),
         ops.StringSlice: lower_stringslice,
     }

--- a/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -28,7 +28,9 @@ from ibis.backends.sql.rewrites import (
     lower_sample,
     split_select_distinct_with_order_by,
 )
+from ibis.common.patterns import replace
 from ibis.common.temporal import DateUnit, IntervalUnit, TimestampUnit, TimeUnit
+from ibis.expr.rewrites import p
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -104,6 +106,20 @@ def _force_quote_table(table: sge.Table) -> sge.Table:
     return table
 
 
+@replace(p.PivotLonger)
+def lower_pivot_longer_bigquery(_, **kwargs):
+    """Use BigQuery's native `UNPIVOT` when there's a single `names_to` column.
+
+    `UNPIVOT` only ever produces a single name column, so a `PivotLonger`
+    call that needs more than one `names_to` column (e.g., from a
+    multi-group `names_pattern`) can't be expressed natively and falls back
+    to the generic struct-packing/unnesting implementation.
+    """
+    if len(_.names_to) != 1:
+        return _.to_generic().op()
+    return _
+
+
 class BigQueryCompiler(SQLGlotCompiler):
     dialect = BigQuery
     type_mapper = BigQueryType
@@ -122,6 +138,7 @@ class BigQueryCompiler(SQLGlotCompiler):
     supports_qualify = True
 
     LOWERED_OPS = {
+        ops.PivotLonger: lower_pivot_longer_bigquery,
         ops.Sample: lower_sample(
             supported_methods=("block",),
             supports_seed=False,
@@ -1077,6 +1094,61 @@ class BigQueryCompiler(SQLGlotCompiler):
             .from_(parent)
             .join(unnest, join_type="CROSS" if not keep_empty else "LEFT")
         )
+
+    def visit_PivotLonger(
+        self, op, *, parent, pivot_columns, names_to, values_to, names, pivot_values
+    ):
+        quoted = self.quoted
+        (name_column,) = names_to
+
+        table = sg.to_identifier(parent.alias_or_name, quoted=quoted)
+        excludes = [sg.column(c, quoted=quoted) for c in pivot_columns]
+        star = sge.Column(this=sge.Star(**{EXCEPT_ARG: excludes}), table=table)
+
+        # apply `values_transform` (already compiled into `pivot_values`) in
+        # place of each pivoted column, so UNPIVOT only has to melt them.
+        #
+        # unlike ibis's own struct/array unification, BigQuery's UNPIVOT
+        # requires every column in the IN-list to share the *exact* same
+        # type (e.g. INT64 and FLOAT64 side by side is a hard error), so
+        # cast each one to the value column's resolved output type first
+        value_type = self.type_mapper.from_ibis(op.schema[values_to])
+        renamed = [
+            sge.Cast(this=pivot_values[c], to=value_type).as_(c, quoted=quoted)
+            for c in pivot_columns
+        ]
+        inner = sg.select(star, *renamed).from_(parent).subquery()
+
+        in_exprs = [
+            sge.PivotAlias(
+                this=sg.column(c, quoted=quoted), alias=sge.convert(names[c][0])
+            )
+            for c in pivot_columns
+        ]
+        pivot = sge.Pivot(
+            expressions=[sg.column(values_to, quoted=quoted)],
+            fields=[
+                sge.In(this=sg.column(name_column, quoted=quoted), expressions=in_exprs)
+            ],
+            unpivot=True,
+            # ibis's generic `PivotLonger` lowering keeps rows with NULL
+            # values (unlike BigQuery's default EXCLUDE NULLS), so match
+            # that here to stay a drop-in replacement
+            include_nulls=True,
+        )
+        inner.set("pivots", [pivot])
+
+        # BigQuery's UNPIVOT always places the melted columns as
+        # `..., value_col, name_col` (matching the `value FOR name` clause
+        # order), but ibis's `PivotLonger.schema` declares `..., name_col,
+        # value_col` (`to_generic()`'s struct field order). Result columns
+        # are matched to the schema positionally, so `SELECT *` here would
+        # mislabel the two columns; select them explicitly in schema order.
+        keep = [c for c in op.schema.names if c not in (name_column, values_to)]
+        cols = [sg.column(c, quoted=quoted) for c in keep]
+        cols.append(sg.column(name_column, quoted=quoted))
+        cols.append(sg.column(values_to, quoted=quoted))
+        return sg.select(*cols).from_(inner)
 
     def visit_TimestampBucket(self, op, *, arg, interval, offset):
         arg_dtype = op.arg.dtype

--- a/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -110,14 +110,9 @@ def _force_quote_table(table: sge.Table) -> sge.Table:
 def lower_pivot_longer_bigquery(_, **kwargs):
     """Use BigQuery's native `UNPIVOT` when there's a single `names_to` column.
 
-    Both forms of `UNPIVOT` (single- and multi-column) produce exactly one
-    name column; BigQuery's "multi-column" form instead melts several
-    *value* columns at once (e.g. unpivoting `(lo, hi)` pairs into a single
-    `(lo, hi)` per row), which isn't something `PivotLonger` can ask for in
-    the first place (`values_to` is always a single column). So a
-    `PivotLonger` call that needs more than one `names_to` column (e.g.,
-    from a multi-group `names_pattern`) can't be expressed by either form
-    and falls back to the generic struct-packing/unnesting implementation.
+    Both forms of `UNPIVOT` only ever produce one name column, so a
+    `PivotLonger` with more than one (e.g. from a multi-group
+    `names_pattern`) falls back to the generic implementation.
     """
     if len(_.names_to) != 1:
         return _.to_generic().op()
@@ -1118,13 +1113,8 @@ class BigQueryCompiler(SQLGlotCompiler):
         excludes = [sg.column(c, quoted=quoted) for c in pivot_columns]
         star = sge.Column(this=sge.Star(**{EXCEPT_ARG: excludes}), table=table)
 
-        # apply `values_transform` (already compiled into `pivot_values`) in
-        # place of each pivoted column, so UNPIVOT only has to melt them.
-        #
-        # unlike ibis's own struct/array unification, BigQuery's UNPIVOT
-        # requires every column in the IN-list to share the *exact* same
-        # type (e.g. INT64 and FLOAT64 side by side is a hard error), so
-        # cast each one to the value column's resolved output type first
+        # UNPIVOT's IN-list requires every column to share the exact same
+        # type, so cast each pivoted column to the value column's type first
         value_type = self.type_mapper.from_ibis(op.schema[values_to])
         renamed = [
             sge.Cast(this=pivot_values[c], to=value_type).as_(c, quoted=quoted)
@@ -1144,19 +1134,14 @@ class BigQueryCompiler(SQLGlotCompiler):
                 sge.In(this=sg.column(name_column, quoted=quoted), expressions=in_exprs)
             ],
             unpivot=True,
-            # `values_drop_na=False` (ibis's default) keeps rows with NULL
-            # values, unlike BigQuery's own default of EXCLUDE NULLS, so
-            # match that here to stay a drop-in replacement
+            # ibis defaults to keeping NULLs, opposite of UNPIVOT's own default
             include_nulls=not values_drop_na,
         )
         inner.set("pivots", [pivot])
 
-        # BigQuery's UNPIVOT always places the melted columns as
-        # `..., value_col, name_col` (matching the `value FOR name` clause
-        # order), but ibis's `PivotLonger.schema` declares `..., name_col,
-        # value_col` (`to_generic()`'s struct field order). Result columns
-        # are matched to the schema positionally, so `SELECT *` here would
-        # mislabel the two columns; select them explicitly in schema order.
+        # UNPIVOT's output order is [value_col, name_col], but the schema
+        # expects [name_col, value_col]; select explicitly to avoid a
+        # positional mismatch from `SELECT *`.
         keep = [c for c in op.schema.names if c not in (name_column, values_to)]
         cols = [sg.column(c, quoted=quoted) for c in keep]
         cols.append(sg.column(name_column, quoted=quoted))

--- a/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -110,10 +110,14 @@ def _force_quote_table(table: sge.Table) -> sge.Table:
 def lower_pivot_longer_bigquery(_, **kwargs):
     """Use BigQuery's native `UNPIVOT` when there's a single `names_to` column.
 
-    `UNPIVOT` only ever produces a single name column, so a `PivotLonger`
-    call that needs more than one `names_to` column (e.g., from a
-    multi-group `names_pattern`) can't be expressed natively and falls back
-    to the generic struct-packing/unnesting implementation.
+    Both forms of `UNPIVOT` (single- and multi-column) produce exactly one
+    name column; BigQuery's "multi-column" form instead melts several
+    *value* columns at once (e.g. unpivoting `(lo, hi)` pairs into a single
+    `(lo, hi)` per row), which isn't something `PivotLonger` can ask for in
+    the first place (`values_to` is always a single column). So a
+    `PivotLonger` call that needs more than one `names_to` column (e.g.,
+    from a multi-group `names_pattern`) can't be expressed by either form
+    and falls back to the generic struct-packing/unnesting implementation.
     """
     if len(_.names_to) != 1:
         return _.to_generic().op()
@@ -1096,7 +1100,16 @@ class BigQueryCompiler(SQLGlotCompiler):
         )
 
     def visit_PivotLonger(
-        self, op, *, parent, pivot_columns, names_to, values_to, names, pivot_values
+        self,
+        op,
+        *,
+        parent,
+        pivot_columns,
+        names_to,
+        values_to,
+        names,
+        pivot_values,
+        values_drop_na,
     ):
         quoted = self.quoted
         (name_column,) = names_to
@@ -1131,10 +1144,10 @@ class BigQueryCompiler(SQLGlotCompiler):
                 sge.In(this=sg.column(name_column, quoted=quoted), expressions=in_exprs)
             ],
             unpivot=True,
-            # ibis's generic `PivotLonger` lowering keeps rows with NULL
-            # values (unlike BigQuery's default EXCLUDE NULLS), so match
-            # that here to stay a drop-in replacement
-            include_nulls=True,
+            # `values_drop_na=False` (ibis's default) keeps rows with NULL
+            # values, unlike BigQuery's own default of EXCLUDE NULLS, so
+            # match that here to stay a drop-in replacement
+            include_nulls=not values_drop_na,
         )
         inner.set("pivots", [pivot])
 

--- a/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -107,7 +107,7 @@ def _force_quote_table(table: sge.Table) -> sge.Table:
 
 
 @replace(p.PivotLonger)
-def lower_pivot_longer_bigquery(_, **kwargs):
+def pivot_longer_to_unpivot(_, **kwargs):
     """Use BigQuery's native `UNPIVOT` when there's a single `names_to` column.
 
     Both forms of `UNPIVOT` only ever produce one name column, so a
@@ -137,7 +137,7 @@ class BigQueryCompiler(SQLGlotCompiler):
     supports_qualify = True
 
     LOWERED_OPS = {
-        ops.PivotLonger: lower_pivot_longer_bigquery,
+        ops.PivotLonger: pivot_longer_to_unpivot,
         ops.Sample: lower_sample(
             supported_methods=("block",),
             supports_seed=False,

--- a/ibis/backends/sql/rewrites.py
+++ b/ibis/backends/sql/rewrites.py
@@ -615,6 +615,16 @@ def lower_capitalize(_, **kwargs):
     return ops.StringConcat((first, rest))
 
 
+@replace(p.PivotLonger)
+def lower_pivot_longer(_, **kwargs):
+    """Rewrite `PivotLonger` in terms of struct-packing and unnesting.
+
+    This is the default lowering for backends without a native unpivot
+    construct.
+    """
+    return _.to_generic().op()
+
+
 def lower_sample(
     supported_methods=("row", "block"),
     supports_seed=True,

--- a/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/bigquery/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/bigquery/out.sql
@@ -1,143 +1,84 @@
-WITH `t5` AS (
+WITH `t4` AS (
   SELECT
-    `t4`.`field_of_study`,
-    ANY_VALUE(`t4`.`diff`) AS `diff`
+    `t3`.`field_of_study`,
+    ANY_VALUE(`t3`.`diff`) AS `diff`
   FROM (
     SELECT
-      `t3`.`field_of_study`,
-      `t3`.`years`,
-      `t3`.`degrees`,
-      `t3`.`earliest_degrees`,
-      `t3`.`latest_degrees`,
-      `t3`.`latest_degrees` - `t3`.`earliest_degrees` AS `diff`
+      `t2`.`field_of_study`,
+      `t2`.`years`,
+      `t2`.`degrees`,
+      `t2`.`earliest_degrees`,
+      `t2`.`latest_degrees`,
+      `t2`.`latest_degrees` - `t2`.`earliest_degrees` AS `diff`
     FROM (
       SELECT
-        `t2`.`field_of_study`,
-        `t2`.`years`,
-        `t2`.`degrees`,
-        FIRST_VALUE(`t2`.`degrees`) OVER (
-          PARTITION BY `t2`.`field_of_study`
-          ORDER BY `t2`.`years` ASC
+        `t1`.`field_of_study`,
+        `t1`.`years`,
+        `t1`.`degrees`,
+        FIRST_VALUE(`t1`.`degrees`) OVER (
+          PARTITION BY `t1`.`field_of_study`
+          ORDER BY `t1`.`years` ASC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS `earliest_degrees`,
-        LAST_VALUE(`t2`.`degrees`) OVER (
-          PARTITION BY `t2`.`field_of_study`
-          ORDER BY `t2`.`years` ASC
+        LAST_VALUE(`t1`.`degrees`) OVER (
+          PARTITION BY `t1`.`field_of_study`
+          ORDER BY `t1`.`years` ASC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS `latest_degrees`
       FROM (
         SELECT
-          `t1`.`field_of_study`,
-          `t1`.`__pivoted__`.`years` AS `years`,
-          `t1`.`__pivoted__`.`degrees` AS `degrees`
+          `field_of_study`,
+          `years`,
+          `degrees`
         FROM (
           SELECT
-            `t0`.`field_of_study`,
-            IF(pos = pos_2, `__pivoted__`, NULL) AS `__pivoted__`
+            `t0`.*
+            EXCEPT (`1970-71`, `1975-76`, `1980-81`, `1985-86`, `1990-91`, `1995-96`, `2000-01`, `2005-06`, `2010-11`, `2011-12`, `2012-13`, `2013-14`, `2014-15`, `2015-16`, `2016-17`, `2017-18`, `2018-19`, `2019-20`),
+            CAST(`t0`.`1970-71` AS INT64) AS `1970-71`,
+            CAST(`t0`.`1975-76` AS INT64) AS `1975-76`,
+            CAST(`t0`.`1980-81` AS INT64) AS `1980-81`,
+            CAST(`t0`.`1985-86` AS INT64) AS `1985-86`,
+            CAST(`t0`.`1990-91` AS INT64) AS `1990-91`,
+            CAST(`t0`.`1995-96` AS INT64) AS `1995-96`,
+            CAST(`t0`.`2000-01` AS INT64) AS `2000-01`,
+            CAST(`t0`.`2005-06` AS INT64) AS `2005-06`,
+            CAST(`t0`.`2010-11` AS INT64) AS `2010-11`,
+            CAST(`t0`.`2011-12` AS INT64) AS `2011-12`,
+            CAST(`t0`.`2012-13` AS INT64) AS `2012-13`,
+            CAST(`t0`.`2013-14` AS INT64) AS `2013-14`,
+            CAST(`t0`.`2014-15` AS INT64) AS `2014-15`,
+            CAST(`t0`.`2015-16` AS INT64) AS `2015-16`,
+            CAST(`t0`.`2016-17` AS INT64) AS `2016-17`,
+            CAST(`t0`.`2017-18` AS INT64) AS `2017-18`,
+            CAST(`t0`.`2018-19` AS INT64) AS `2018-19`,
+            CAST(`t0`.`2019-20` AS INT64) AS `2019-20`
           FROM `humanities` AS `t0`
-          CROSS JOIN UNNEST(GENERATE_ARRAY(
-            0,
-            GREATEST(
-              ARRAY_LENGTH(
-                [
-                  STRUCT('1970-71' AS `years`, `t0`.`1970-71` AS `degrees`),
-                  STRUCT('1975-76' AS `years`, `t0`.`1975-76` AS `degrees`),
-                  STRUCT('1980-81' AS `years`, `t0`.`1980-81` AS `degrees`),
-                  STRUCT('1985-86' AS `years`, `t0`.`1985-86` AS `degrees`),
-                  STRUCT('1990-91' AS `years`, `t0`.`1990-91` AS `degrees`),
-                  STRUCT('1995-96' AS `years`, `t0`.`1995-96` AS `degrees`),
-                  STRUCT('2000-01' AS `years`, `t0`.`2000-01` AS `degrees`),
-                  STRUCT('2005-06' AS `years`, `t0`.`2005-06` AS `degrees`),
-                  STRUCT('2010-11' AS `years`, `t0`.`2010-11` AS `degrees`),
-                  STRUCT('2011-12' AS `years`, `t0`.`2011-12` AS `degrees`),
-                  STRUCT('2012-13' AS `years`, `t0`.`2012-13` AS `degrees`),
-                  STRUCT('2013-14' AS `years`, `t0`.`2013-14` AS `degrees`),
-                  STRUCT('2014-15' AS `years`, `t0`.`2014-15` AS `degrees`),
-                  STRUCT('2015-16' AS `years`, `t0`.`2015-16` AS `degrees`),
-                  STRUCT('2016-17' AS `years`, `t0`.`2016-17` AS `degrees`),
-                  STRUCT('2017-18' AS `years`, `t0`.`2017-18` AS `degrees`),
-                  STRUCT('2018-19' AS `years`, `t0`.`2018-19` AS `degrees`),
-                  STRUCT('2019-20' AS `years`, `t0`.`2019-20` AS `degrees`)
-                ]
-              )
-            ) - 1
-          )) AS pos
-          CROSS JOIN UNNEST([
-            STRUCT('1970-71' AS `years`, `t0`.`1970-71` AS `degrees`),
-            STRUCT('1975-76' AS `years`, `t0`.`1975-76` AS `degrees`),
-            STRUCT('1980-81' AS `years`, `t0`.`1980-81` AS `degrees`),
-            STRUCT('1985-86' AS `years`, `t0`.`1985-86` AS `degrees`),
-            STRUCT('1990-91' AS `years`, `t0`.`1990-91` AS `degrees`),
-            STRUCT('1995-96' AS `years`, `t0`.`1995-96` AS `degrees`),
-            STRUCT('2000-01' AS `years`, `t0`.`2000-01` AS `degrees`),
-            STRUCT('2005-06' AS `years`, `t0`.`2005-06` AS `degrees`),
-            STRUCT('2010-11' AS `years`, `t0`.`2010-11` AS `degrees`),
-            STRUCT('2011-12' AS `years`, `t0`.`2011-12` AS `degrees`),
-            STRUCT('2012-13' AS `years`, `t0`.`2012-13` AS `degrees`),
-            STRUCT('2013-14' AS `years`, `t0`.`2013-14` AS `degrees`),
-            STRUCT('2014-15' AS `years`, `t0`.`2014-15` AS `degrees`),
-            STRUCT('2015-16' AS `years`, `t0`.`2015-16` AS `degrees`),
-            STRUCT('2016-17' AS `years`, `t0`.`2016-17` AS `degrees`),
-            STRUCT('2017-18' AS `years`, `t0`.`2017-18` AS `degrees`),
-            STRUCT('2018-19' AS `years`, `t0`.`2018-19` AS `degrees`),
-            STRUCT('2019-20' AS `years`, `t0`.`2019-20` AS `degrees`)
-          ]) AS `__pivoted__` WITH OFFSET AS pos_2
-          WHERE
-            pos = pos_2
-            OR (
-              pos > (
-                ARRAY_LENGTH(
-                  [
-                    STRUCT('1970-71' AS `years`, `t0`.`1970-71` AS `degrees`),
-                    STRUCT('1975-76' AS `years`, `t0`.`1975-76` AS `degrees`),
-                    STRUCT('1980-81' AS `years`, `t0`.`1980-81` AS `degrees`),
-                    STRUCT('1985-86' AS `years`, `t0`.`1985-86` AS `degrees`),
-                    STRUCT('1990-91' AS `years`, `t0`.`1990-91` AS `degrees`),
-                    STRUCT('1995-96' AS `years`, `t0`.`1995-96` AS `degrees`),
-                    STRUCT('2000-01' AS `years`, `t0`.`2000-01` AS `degrees`),
-                    STRUCT('2005-06' AS `years`, `t0`.`2005-06` AS `degrees`),
-                    STRUCT('2010-11' AS `years`, `t0`.`2010-11` AS `degrees`),
-                    STRUCT('2011-12' AS `years`, `t0`.`2011-12` AS `degrees`),
-                    STRUCT('2012-13' AS `years`, `t0`.`2012-13` AS `degrees`),
-                    STRUCT('2013-14' AS `years`, `t0`.`2013-14` AS `degrees`),
-                    STRUCT('2014-15' AS `years`, `t0`.`2014-15` AS `degrees`),
-                    STRUCT('2015-16' AS `years`, `t0`.`2015-16` AS `degrees`),
-                    STRUCT('2016-17' AS `years`, `t0`.`2016-17` AS `degrees`),
-                    STRUCT('2017-18' AS `years`, `t0`.`2017-18` AS `degrees`),
-                    STRUCT('2018-19' AS `years`, `t0`.`2018-19` AS `degrees`),
-                    STRUCT('2019-20' AS `years`, `t0`.`2019-20` AS `degrees`)
-                  ]
-                ) - 1
-              )
-              AND pos_2 = (
-                ARRAY_LENGTH(
-                  [
-                    STRUCT('1970-71' AS `years`, `t0`.`1970-71` AS `degrees`),
-                    STRUCT('1975-76' AS `years`, `t0`.`1975-76` AS `degrees`),
-                    STRUCT('1980-81' AS `years`, `t0`.`1980-81` AS `degrees`),
-                    STRUCT('1985-86' AS `years`, `t0`.`1985-86` AS `degrees`),
-                    STRUCT('1990-91' AS `years`, `t0`.`1990-91` AS `degrees`),
-                    STRUCT('1995-96' AS `years`, `t0`.`1995-96` AS `degrees`),
-                    STRUCT('2000-01' AS `years`, `t0`.`2000-01` AS `degrees`),
-                    STRUCT('2005-06' AS `years`, `t0`.`2005-06` AS `degrees`),
-                    STRUCT('2010-11' AS `years`, `t0`.`2010-11` AS `degrees`),
-                    STRUCT('2011-12' AS `years`, `t0`.`2011-12` AS `degrees`),
-                    STRUCT('2012-13' AS `years`, `t0`.`2012-13` AS `degrees`),
-                    STRUCT('2013-14' AS `years`, `t0`.`2013-14` AS `degrees`),
-                    STRUCT('2014-15' AS `years`, `t0`.`2014-15` AS `degrees`),
-                    STRUCT('2015-16' AS `years`, `t0`.`2015-16` AS `degrees`),
-                    STRUCT('2016-17' AS `years`, `t0`.`2016-17` AS `degrees`),
-                    STRUCT('2017-18' AS `years`, `t0`.`2017-18` AS `degrees`),
-                    STRUCT('2018-19' AS `years`, `t0`.`2018-19` AS `degrees`),
-                    STRUCT('2019-20' AS `years`, `t0`.`2019-20` AS `degrees`)
-                  ]
-                ) - 1
-              )
-            )
-        ) AS `t1`
-      ) AS `t2`
-    ) AS `t3`
-  ) AS `t4`
+        )
+        UNPIVOT INCLUDE NULLS (`degrees` FOR 
+          `years` IN (
+            `1970-71` AS '1970-71',
+            `1975-76` AS '1975-76',
+            `1980-81` AS '1980-81',
+            `1985-86` AS '1985-86',
+            `1990-91` AS '1990-91',
+            `1995-96` AS '1995-96',
+            `2000-01` AS '2000-01',
+            `2005-06` AS '2005-06',
+            `2010-11` AS '2010-11',
+            `2011-12` AS '2011-12',
+            `2012-13` AS '2012-13',
+            `2013-14` AS '2013-14',
+            `2014-15` AS '2014-15',
+            `2015-16` AS '2015-16',
+            `2016-17` AS '2016-17',
+            `2017-18` AS '2017-18',
+            `2018-19` AS '2018-19',
+            `2019-20` AS '2019-20'
+          )
+        )
+      ) AS `t1`
+    ) AS `t2`
+  ) AS `t3`
   GROUP BY
     1
 )
@@ -146,21 +87,21 @@ SELECT
 FROM (
   SELECT
     *
-  FROM `t5` AS `t6`
+  FROM `t4` AS `t5`
   ORDER BY
-    `t6`.`diff` DESC
+    `t5`.`diff` DESC
   LIMIT 10
-) AS `t9`
+) AS `t8`
 UNION ALL
 SELECT
   *
 FROM (
   SELECT
     *
-  FROM `t5` AS `t6`
+  FROM `t4` AS `t5`
   WHERE
-    `t6`.`diff` < 0
+    `t5`.`diff` < 0
   ORDER BY
-    `t6`.`diff` ASC NULLS LAST
+    `t5`.`diff` ASC NULLS LAST
   LIMIT 10
-) AS `t10`
+) AS `t9`

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -520,4 +520,49 @@ class TableUnnest(Relation):
         return Schema(base)
 
 
+@public
+class PivotLonger(Relation):
+    """Pivot a table from wide to long."""
+
+    parent: Relation
+    pivot_columns: VarTuple[str]
+    names_to: VarTuple[str]
+    values_to: str
+    names: FrozenOrderedDict[str, VarTuple[Any]]
+    pivot_values: FrozenOrderedDict[str, Value]
+
+    @attribute
+    def values(self):
+        return self.parent.fields
+
+    def to_generic(self):
+        """Expand into the struct-packing/unnesting implementation.
+
+        This is the backend-agnostic definition of `PivotLonger`: build one
+        struct per pivoted column, collect them into an array, and unnest.
+        Used both as the default lowering for backends without a native
+        unpivot construct, and as the fallback for `PivotLonger` shapes a
+        backend's native unpivot can't express (e.g., more than one
+        `names_to` column).
+        """
+        import ibis
+
+        parent = self.parent.to_expr()
+
+        pieces = []
+        for col in self.pivot_columns:
+            row = dict(zip(self.names_to, self.names[col]))
+            row[self.values_to] = self.pivot_values[col].to_expr()
+            pieces.append(ibis.struct(row))
+
+        keep = [name for name in parent.columns if name not in self.pivot_columns]
+        return parent.select(*keep, __pivoted__=ibis.array(pieces).unnest()).unpack(
+            "__pivoted__"
+        )
+
+    @attribute
+    def schema(self):
+        return self.to_generic().schema()
+
+
 # TODO(kszucs): support t.select(*t) syntax by implementing Table.__iter__()

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -538,7 +538,7 @@ class PivotLonger(Relation):
 
     def to_generic(self):
         """Expand into the backend-agnostic struct/array/unnest implementation."""
-        import ibis
+        from ibis.expr.types import array, struct
 
         parent = self.parent.to_expr()
 
@@ -546,10 +546,10 @@ class PivotLonger(Relation):
         for col in self.pivot_columns:
             row = dict(zip(self.names_to, self.names[col]))
             row[self.values_to] = self.pivot_values[col].to_expr()
-            pieces.append(ibis.struct(row))
+            pieces.append(struct(row))
 
         keep = [name for name in parent.columns if name not in self.pivot_columns]
-        result = parent.select(*keep, __pivoted__=ibis.array(pieces).unnest()).unpack(
+        result = parent.select(*keep, __pivoted__=array(pieces).unnest()).unpack(
             "__pivoted__"
         )
         if self.values_drop_na:

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -530,6 +530,7 @@ class PivotLonger(Relation):
     values_to: str
     names: FrozenOrderedDict[str, VarTuple[Any]]
     pivot_values: FrozenOrderedDict[str, Value]
+    values_drop_na: bool = False
 
     @attribute
     def values(self):
@@ -556,9 +557,12 @@ class PivotLonger(Relation):
             pieces.append(ibis.struct(row))
 
         keep = [name for name in parent.columns if name not in self.pivot_columns]
-        return parent.select(*keep, __pivoted__=ibis.array(pieces).unnest()).unpack(
+        result = parent.select(*keep, __pivoted__=ibis.array(pieces).unnest()).unpack(
             "__pivoted__"
         )
+        if self.values_drop_na:
+            result = result.drop_null(self.values_to)
+        return result
 
     @attribute
     def schema(self):

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -537,15 +537,7 @@ class PivotLonger(Relation):
         return self.parent.fields
 
     def to_generic(self):
-        """Expand into the struct-packing/unnesting implementation.
-
-        This is the backend-agnostic definition of `PivotLonger`: build one
-        struct per pivoted column, collect them into an array, and unnest.
-        Used both as the default lowering for backends without a native
-        unpivot construct, and as the fallback for `PivotLonger` shapes a
-        backend's native unpivot can't express (e.g., more than one
-        `names_to` column).
-        """
+        """Expand into the backend-agnostic struct/array/unnest implementation."""
         import ibis
 
         parent = self.parent.to_expr()

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -4242,12 +4242,29 @@ class Table(Expr, FixedTextJupyterMixin):
             deferred expression.
         values_drop_na
             If `True`, drop rows where the resulting `values_to` column is
-            `NULL`.
+            `NULL`. Rows are kept by default, unlike BigQuery's own `UNPIVOT`
+            (see Notes).
 
         Returns
         -------
         Table
             Pivoted table
+
+        Notes
+        -----
+        On BigQuery, a call with a single `names_to` column compiles to a
+        native `UNPIVOT` instead of the generic unnest-based implementation
+        used on other backends. This is a compilation detail only: output is
+        identical either way. One default differs from BigQuery's own SQL:
+        BigQuery's `UNPIVOT` excludes `NULL` values by default, but
+        `pivot_longer` keeps them by default (`values_drop_na=False`), to
+        stay consistent across backends. Set `values_drop_na=True` to get
+        BigQuery's `EXCLUDE NULLS` behavior (this also drops nulls on other
+        backends, so results stay consistent).
+
+        A `names_to` with more than one column (e.g. from a multi-group
+        `names_pattern`) always uses the generic implementation on BigQuery
+        too, since `UNPIVOT` only ever produces a single name column.
 
         Examples
         --------

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -4252,19 +4252,12 @@ class Table(Expr, FixedTextJupyterMixin):
 
         Notes
         -----
-        On BigQuery, a call with a single `names_to` column compiles to a
-        native `UNPIVOT` instead of the generic unnest-based implementation
-        used on other backends. This is a compilation detail only: output is
-        identical either way. One default differs from BigQuery's own SQL:
-        BigQuery's `UNPIVOT` excludes `NULL` values by default, but
-        `pivot_longer` keeps them by default (`values_drop_na=False`), to
-        stay consistent across backends. Set `values_drop_na=True` to get
-        BigQuery's `EXCLUDE NULLS` behavior (this also drops nulls on other
-        backends, so results stay consistent).
-
-        A `names_to` with more than one column (e.g. from a multi-group
-        `names_pattern`) always uses the generic implementation on BigQuery
-        too, since `UNPIVOT` only ever produces a single name column.
+        On BigQuery, a single-column `names_to` compiles to a native
+        `UNPIVOT` instead of the generic unnest-based implementation used on
+        other backends; output is identical either way. BigQuery's own
+        `UNPIVOT` excludes `NULL` values by default, but `pivot_longer` keeps
+        them by default (`values_drop_na=False`) to stay consistent across
+        backends. Set `values_drop_na=True` for `EXCLUDE NULLS` behavior.
 
         Examples
         --------

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -4517,24 +4517,28 @@ class Table(Expr, FixedTextJupyterMixin):
         elif isinstance(values_transform, Deferred):
             values_transform = values_transform.resolve
 
-        pieces = []
+        pivot_columns = []
+        names = {}
+        pivot_values = {}
 
         for pivot_col in pivot_cols:
             col_name = pivot_col.get_name()
             match_result = names_pattern.match(col_name)
-            row = {
-                name: names_transform[name](value)
+            pivot_columns.append(col_name)
+            names[col_name] = tuple(
+                names_transform[name](value)
                 for name, value in zip(names_to, match_result.groups())
-            }
-            row[values_to] = values_transform(pivot_col)
-            pieces.append(ibis.struct(row))
+            )
+            pivot_values[col_name] = values_transform(pivot_col)
 
-        # nest into an array of structs to zip unnests together
-        pieces = ibis.array(pieces)
-
-        return self.select(~pivot_sel, __pivoted__=pieces.unnest()).unpack(
-            "__pivoted__"
-        )
+        return ops.PivotLonger(
+            parent=self,
+            pivot_columns=pivot_columns,
+            names_to=names_to,
+            values_to=values_to,
+            names=names,
+            pivot_values=pivot_values,
+        ).to_expr()
 
     @util.experimental
     def pivot_wider(

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -4218,6 +4218,7 @@ class Table(Expr, FixedTextJupyterMixin):
         ) = None,
         values_to: str = "value",
         values_transform: Callable[[ir.Value], ir.Value] | Deferred | None = None,
+        values_drop_na: bool = False,
     ) -> Table:
         r"""Transform a table from wider to longer.
 
@@ -4239,6 +4240,9 @@ class Table(Expr, FixedTextJupyterMixin):
         values_transform
             Apply a function to the value column. This can be a lambda or
             deferred expression.
+        values_drop_na
+            If `True`, drop rows where the resulting `values_to` column is
+            `NULL`.
 
         Returns
         -------
@@ -4538,6 +4542,7 @@ class Table(Expr, FixedTextJupyterMixin):
             values_to=values_to,
             names=names,
             pivot_values=pivot_values,
+            values_drop_na=values_drop_na,
         ).to_expr()
 
     @util.experimental


### PR DESCRIPTION
## Description of changes

`Table.pivot_longer` currently compiles to a generic struct-pack / array / unnest expression on every backend, including BigQuery, even though BigQuery has a native `UNPIVOT` operator for exactly this shape of query. This PR adds a BigQuery-specific compilation path that uses `UNPIVOT` when possible, matching the existing pattern of backend-specific rewrites via `LOWERED_OPS`.

- `ops.PivotLonger` is now a real relational op (instead of being eagerly expanded into struct/array/unnest at expression-build time), so a backend can special-case it during compilation. `to_generic()` on the op still produces the original struct/array/unnest tree and remains the implementation for every other backend.
- On BigQuery, a `pivot_longer` call with a single `names_to` column compiles to a native `UNPIVOT`. A call with more than one `names_to` column (e.g. from a multi-group `names_pattern`) still falls back to the generic implementation, since `UNPIVOT` (in both its single-column and multi-column forms) only ever produces a single name column — it can't express multiple `names_to` columns.
- Two BigQuery-specific correctness issues had to be handled to make this a safe drop-in replacement:
  - `UNPIVOT`'s `IN (...)` list requires every column to share the exact same type (no implicit widening), so pivot columns of different-but-unifiable types (e.g. `int64` + `float64`) are now explicitly cast to the pivoted column's unified type before entering the `IN` list.
  - `UNPIVOT`'s physical output column order is always `[...passthrough, value_col, name_col]`, which does not match `PivotLonger`'s declared schema order of `[...passthrough, name_col, value_col]`. Since results are mapped to schema positionally, this silently swapped the name/value columns' data. The generated SQL now selects columns explicitly in schema order rather than relying on `SELECT *`.
- Added `values_drop_na: bool = False` to `pivot_longer`. When `True`, rows where the resulting `values_to` column is `NULL` are dropped (`result.drop_null(values_to)` in the generic implementation). This is implemented once in `to_generic()`, so every backend gets it for free. On BigQuery it maps to `UNPIVOT`'s native `EXCLUDE NULLS` modifier instead. `pivot_longer` keeps `NULL`s by default (`values_drop_na=False`) on every backend, which is the opposite of `UNPIVOT`'s own default (`EXCLUDE NULLS`) — the generated BigQuery SQL always states `INCLUDE NULLS` or `EXCLUDE NULLS` explicitly, so it never silently relies on BigQuery's default.

All of the above (native `UNPIVOT` compilation, the type-cast fix, the column-order fix, and `values_drop_na`) were also verified against a live BigQuery project, comparing results row-for-row against `pandas.melt()`, in addition to the unit tests included here.

This is a drop-in replacement: output is identical to the previous struct/array/unnest implementation for BigQuery users, and there is no behavior change for any other backend.

---

This addresses an active query performance issue I'm hitting in production use of Ibis against BigQuery. AI (Claude) was used to aid in scoping and implementing these changes, including the live BigQuery testing referenced above.
