### PR TITLE
fix(pyarrow): relax non-nullable struct children when converting data

### DIFF
--- a/ibis/formats/pyarrow.py
+++ b/ibis/formats/pyarrow.py
@@ -266,6 +266,38 @@ class PyArrowSchema(SchemaMapper):
         return Schema.from_tuples(fields)
 
 
+def _castable_type(typ: pa.DataType) -> pa.DataType:
+    """Relax non-nullable struct children that no data can satisfy.
+
+    Arrow materializes the children of a NULL struct as NULL, so casting to a
+    struct type that declares a non-nullable child fails with `ArrowInvalid`
+    as soon as the struct itself holds a NULL.  Such a type is still legal in
+    Arrow, so `PyArrowType.from_ibis` keeps producing it faithfully; only data
+    being cast *into* it needs the child fields relaxed.
+
+    Nested types are rewritten so that structs buried inside lists and maps are
+    relaxed too.  A NULL list or map does not materialize its children, so
+    their own field nullability is left untouched.
+    """
+    if pa.types.is_struct(typ):
+        return pa.struct(
+            [
+                field.with_nullable(True).with_type(_castable_type(field.type))
+                for field in typ
+            ]
+        )
+    elif pa.types.is_fixed_size_list(typ):
+        value_field = typ.value_field.with_type(_castable_type(typ.value_type))
+        return pa.list_(value_field, typ.list_size)
+    elif pa.types.is_list(typ):
+        return pa.list_(typ.value_field.with_type(_castable_type(typ.value_type)))
+    elif pa.types.is_map(typ):
+        item_field = typ.item_field.with_type(_castable_type(typ.item_type))
+        return pa.map_(typ.key_field, item_field, keys_sorted=typ.keys_sorted)
+    else:
+        return typ
+
+
 class PyArrowData(DataMapper):
     @classmethod
     def infer_scalar(cls, scalar: Any) -> dt.DataType:
@@ -306,7 +338,7 @@ class PyArrowData(DataMapper):
 
     @classmethod
     def convert_scalar(cls, scalar: pa.Scalar, dtype: dt.DataType) -> pa.Scalar:
-        desired_type = PyArrowType.from_ibis(dtype)
+        desired_type = _castable_type(PyArrowType.from_ibis(dtype))
         scalar_type = scalar.type
         if scalar_type != desired_type:
             try:
@@ -320,7 +352,7 @@ class PyArrowData(DataMapper):
 
     @classmethod
     def convert_column(cls, column: pa.Array, dtype: dt.DataType) -> pa.Array:
-        desired_type = PyArrowType.from_ibis(dtype)
+        desired_type = _castable_type(PyArrowType.from_ibis(dtype))
         if column.type != desired_type:
             return column.cast(desired_type)
         else:
@@ -328,7 +360,12 @@ class PyArrowData(DataMapper):
 
     @classmethod
     def convert_table(cls, table: pa.Table, schema: Schema) -> pa.Table:
-        desired_schema = PyArrowSchema.from_ibis(schema)
+        desired_schema = pa.schema(
+            [
+                field.with_type(_castable_type(field.type))
+                for field in PyArrowSchema.from_ibis(schema)
+            ]
+        )
         if table.schema == desired_schema:
             return table
         arrays = [

--- a/ibis/formats/tests/test_pyarrow.py
+++ b/ibis/formats/tests/test_pyarrow.py
@@ -128,6 +128,97 @@ def test_dtype_from_nullable_list_type(value_nullable, list_nullable):
     assert restored_type.value_field.nullable is value_nullable
 
 
+@pytest.mark.parametrize("field_nullable", [True, False])
+@pytest.mark.parametrize("struct_nullable", [True, False])
+def test_dtype_from_nullable_struct_type(struct_nullable, field_nullable):
+    # the pyarrow type itself is preserved faithfully in both directions
+    ibis_type = dt.Struct(
+        {"a": dt.Int64(nullable=field_nullable)}, nullable=struct_nullable
+    )
+    restored_type = PyArrowType.from_ibis(ibis_type)
+
+    assert restored_type.field("a").type == pa.int64()
+    assert restored_type.field("a").nullable is field_nullable
+
+
+def test_to_pyarrow_nullable_struct_with_non_nullable_fields():
+    # a nullable struct column holding NULLs must be convertible even when its
+    # child fields are declared non-nullable: a NULL struct materializes its
+    # children as NULL, so the strict child type is uninhabitable
+    schema = ibis.schema(
+        {"id": "int64", "address": dt.Struct({"street": "!string", "number": "!int64"})}
+    )
+    t = ibis.memtable(
+        [
+            {"id": 1, "address": {"street": "Main St", "number": 10}},
+            {"id": 2, "address": None},
+        ],
+        schema=schema,
+    )
+
+    result = t.to_pyarrow()
+
+    assert result["address"].to_pylist() == [
+        {"street": "Main St", "number": 10},
+        None,
+    ]
+    address = result.schema.field("address")
+    assert address.nullable is True
+    assert [field.nullable for field in address.type] == [True, True]
+
+
+@pytest.mark.parametrize(
+    "arrow_type",
+    [
+        pytest.param(
+            pa.struct([pa.field("a", pa.int64(), nullable=False)]), id="struct"
+        ),
+        pytest.param(
+            pa.list_(pa.struct([pa.field("a", pa.int64(), nullable=False)])), id="list"
+        ),
+        pytest.param(
+            pa.list_(pa.struct([pa.field("a", pa.int64(), nullable=False)]), 2),
+            id="fixed_size_list",
+        ),
+        pytest.param(
+            pa.map_(
+                pa.string(), pa.struct([pa.field("a", pa.int64(), nullable=False)])
+            ),
+            id="map",
+        ),
+    ],
+)
+def test_castable_type_relaxes_nested_struct_fields(arrow_type):
+    relaxed = ipa._castable_type(arrow_type)
+
+    # every struct child, however deeply nested, is nullable ...
+    assert all(field.nullable for field in _iter_struct_fields(relaxed))
+    # ... and nothing else about the type changed
+    assert relaxed.id == arrow_type.id
+
+
+def _iter_struct_fields(typ):
+    if pa.types.is_struct(typ):
+        for field in typ:
+            yield field
+            yield from _iter_struct_fields(field.type)
+    elif pa.types.is_map(typ):
+        yield from _iter_struct_fields(typ.item_type)
+    elif pa.types.is_list(typ) or pa.types.is_fixed_size_list(typ):
+        yield from _iter_struct_fields(typ.value_type)
+
+
+def test_convert_scalar_nullable_struct_with_non_nullable_fields():
+    # same bug shape at the scalar call site
+    arrow_type = pa.struct(
+        [pa.field("street", pa.string()), pa.field("number", pa.int64())]
+    )
+    scalar = pa.scalar(None, type=arrow_type)
+    dtype = dt.Struct({"street": "!string", "number": "!int64"})
+
+    assert ipa.PyArrowData.convert_scalar(scalar, dtype).as_py() is None
+
+
 @pytest.mark.parametrize("value_type", [pa.string(), pa.date32()])
 def test_dtype_from_dictionary_type(value_type):
     dict_type = pa.dictionary(pa.int32(), value_type)


### PR DESCRIPTION
## Description of changes

Fixes #11939.

### Problem

A nullable struct column whose child fields are declared non-nullable — e.g.
`struct<street: !string, number: !int64>` — cannot be exported at all:

```python
schema = ibis.schema({"id": "int", "address": dt.Struct({"street": "!string", "number": "!int"})})
t = ibis.memtable(
    [
        {"id": 1, "address": {"street": "Main St", "number": 10}},
        {"id": 2, "address": None},
        {"id": 3, "address": {"street": "High St", "number": 42}},
    ],
    schema=schema,
)
t.select("address").to_pyarrow()
# ArrowInvalid: field 'street' of type string has nulls.
#               Can't cast to non-nullable field 'street' of type string
```

Reproduced on current `main` (`8e5c...`/`f7e2ca345`) with the duckdb backend; the
reporter hit it on polars/BigQuery. It is backend-independent — the failure is in
`ibis/formats/pyarrow.py`, at `PyArrowData.convert_column`'s `column.cast(...)`.

Root cause: Arrow materializes the children of a NULL struct as NULL. So as soon
as the struct column holds a NULL, *no* Arrow data can satisfy a non-nullable
child field, and the cast into the declared type necessarily raises.

### Approach

The offending type is perfectly legal in Arrow, and `PyArrowType.from_ibis`
must keep producing it faithfully — `test_roundtripable_types` /
`test_schema_roundtrip` are hypothesis properties that assert exactly that. So
the fix deliberately does **not** touch the type mapping.

Instead a small `_castable_type()` helper relaxes non-nullable struct children of
the type that *data* is cast into, and the three `PyArrowData` conversion
entry points use it:

- `convert_column` (the reported failure)
- `convert_table` (so the assembled table's schema matches the relaxed arrays)
- `convert_scalar` — the same bug shape, verified before fixing:
  ```
  >>> PyArrowData.convert_scalar(pa.scalar(None, type=<nullable-children struct>), dt.Struct({"street": "!string", ...}))
  ArrowInvalid: field 'street' of type string has nulls. Can't cast to non-nullable field 'street' of type string
  ```

The relaxation recurses so that structs buried inside lists/fixed-size-lists/maps
are covered too. List and map field nullability is left alone on purpose: a NULL
list or map does not materialize its children, so it does not force nulls into
them.

### How this was tested

`uv run pytest ibis/formats ibis/backends/tests/test_struct.py
ibis/backends/tests/test_array.py ibis/backends/tests/test_map.py
ibis/backends/tests/test_export.py -m "duckdb or core"` →
**521 passed, 18 skipped, 6 xfailed**, plus `ruff format` / `ruff check` clean on
the two changed files.

Four new tests in `ibis/formats/tests/test_pyarrow.py`. Sabotage run — with the
`ibis/formats/pyarrow.py` change stashed and only the tests kept, all of them
fail, the end-to-end one with the exact error from the issue:

```
E   pyarrow.lib.ArrowInvalid: field 'street' of type string has nulls.
    Can't cast to non-nullable field 'street' of type string
FAILED test_to_pyarrow_nullable_struct_with_non_nullable_fields
FAILED test_castable_type_relaxes_nested_struct_fields[struct|list|fixed_size_list|map]
```

`test_dtype_from_nullable_struct_type` pins the type mapping itself as unchanged,
so a future fix cannot regress the round-trip property.

### Deliberately left out

- **No change to `PyArrowType.from_ibis`.** Relaxing children there also fixes
  the bug but breaks `test_roundtripable_types` and `test_schema_roundtrip`
  (`struct<: bool not null>` no longer round-trips), and would silently weaken
  the non-nullable embedded struct fields that #10189 added for BigQuery.
- **No change to the ibis type system.** `!string` inside a nullable struct
  stays expressible; only the Arrow data handed back is relaxed.
- The produced Arrow schema for such a column now always has nullable children,
  rather than depending on whether the batch happens to contain a NULL. That
  seems preferable to a data-dependent output type, but happy to make it
  conditional if you'd rather keep the strict type when no NULLs are present.
