### PR TITLE
fix(cache): preserve expression type detail the backend cannot store

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -19,6 +19,7 @@ import ibis
 import ibis.common.exceptions as exc
 import ibis.config
 import ibis.expr.operations as ops
+import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis import util
 
@@ -31,6 +32,8 @@ if TYPE_CHECKING:
     import pyarrow as pa
     import sqlglot as sg
     import torch
+
+    import ibis.expr.datatypes as dt
 
 
 __all__ = ("BaseBackend", "connect")
@@ -899,6 +902,41 @@ class CacheEntry(NamedTuple):
     finalizer: weakref.finalize
 
 
+def _is_more_specific(want: dt.DataType, got: dt.DataType) -> bool:
+    """Return whether `want` is a strictly more specific version of `got`.
+
+    A backend can only report the types it is able to store, which is sometimes
+    coarser than the type Ibis inferred for an expression. DuckDB, for example,
+    has a single `GEOMETRY` type, so a `point:geometry` column comes back as
+    `geospatial:geometry`. `want` is considered more specific when it is a
+    subclass instance of `got` agreeing with it on every parameter `got`
+    carries.
+    """
+    return (
+        type(want) is not type(got)
+        and isinstance(want, type(got))
+        and all(
+            getattr(want, name, None) == getattr(got, name) for name in got.__argnames__
+        )
+    )
+
+
+def _preserve_expr_schema(want: sch.Schema, got: sch.Schema) -> sch.Schema:
+    """Restore type detail that a round trip through the backend erased.
+
+    Columns whose reported type genuinely differs from the expression's type are
+    left alone: only Ibis-level refinements of the same type are restored.
+    """
+    if want == got or tuple(want.names) != tuple(got.names):
+        return got
+    return sch.Schema(
+        {
+            name: want[name] if _is_more_specific(want[name], got_type) else got_type
+            for name, got_type in got.items()
+        }
+    )
+
+
 class CacheHandler:
     """A mixin for handling `.cache()`/`CachedTable` operations."""
 
@@ -922,6 +960,13 @@ class CacheHandler:
         entry = self._cache_op_to_entry.get(table.op())
         if entry is None or (cached_op := entry.cached_op_ref()) is None:
             cached_op = self._create_cached_table(util.gen_name("cached"), table).op()
+            # `.cache()` must not alter the schema of the expression: the round
+            # trip through the backend's storage can lose type detail that the
+            # backend has no way to express (a `point:geometry` column, say,
+            # comes back from DuckDB as a bare `geospatial:geometry`)
+            schema = _preserve_expr_schema(table.schema(), cached_op.schema)
+            if schema != cached_op.schema:
+                cached_op = cached_op.copy(schema=schema)
             entry = CacheEntry(
                 table.op(),
                 weakref.ref(cached_op),

--- a/ibis/backends/duckdb/tests/test_geospatial.py
+++ b/ibis/backends/duckdb/tests/test_geospatial.py
@@ -10,6 +10,7 @@ from packaging.version import parse as vparse
 from pytest import param
 
 import ibis
+import ibis.expr.datatypes as dt
 from ibis.conftest import LINUX, MACOS, SANDBOXED, WINDOWS
 
 duckdb = pytest.importorskip("duckdb")
@@ -554,3 +555,23 @@ def test_cache_geometry(con, monkeypatch):
     data = data.select(geom=data.x.point(data.y)).cache()
     result = data.execute()
     assert result.at[0, "geom"] == shapely.Point(1, 2)
+
+
+def test_cache_preserves_geospatial_subtype(con, monkeypatch):
+    """`.cache()` must not coarsen `point:geometry` into `geospatial:geometry`.
+
+    DuckDB has a single `GEOMETRY` type, so the geometry subtype Ibis inferred
+    for the expression cannot survive a round trip through storage and has to
+    be carried over from the expression being cached.
+
+    ibis issue #11973
+    """
+    monkeypatch.setattr(ibis.options, "default_backend", con)
+    data = ibis.memtable({"x": [1.0], "y": [2.0]})
+    expr = data.select(geom=data.x.point(data.y))
+
+    assert expr.schema()["geom"] == dt.Point(geotype="geometry")
+
+    with expr.cache() as cached:
+        assert cached.schema() == expr.schema()
+        assert cached.schema().equals(expr.schema())


### PR DESCRIPTION
## Description of changes

`.cache()` materializes the expression into a temporary table and then reads
that table's schema back from the backend, so any type detail that only exists
at the Ibis level is silently dropped. DuckDB has a single `GEOMETRY` type, so a
`point:geometry` column (e.g. the output of `ST_Centroid`/`.point()`) comes back
as `geospatial:geometry` and the documented no-op becomes schema-changing:

```python
con = ibis.duckdb.connect(); con.load_extension("spatial")
t = con.sql("SELECT 1::INTEGER AS id, ST_Point(1.0, 2.0) AS geom")
t2 = t.mutate(c=t.geom.centroid())
t2.schema()["c"]            # point:geometry
t2.cache().schema()["c"]    # geospatial:geometry   <- before this PR
t2.schema().equals(t2.cache().schema())   # False
```

Approach: in `CacheHandler._cached_table`, keep the cached expression's dtype for
a column when it is a *strictly more specific* version of what the backend
reports — same class hierarchy (`dt.Point` is a `dt.GeoSpatial`) and identical
values for every parameter the backend's type carries (`geotype`, `srid`,
`nullable`). Any column whose type genuinely differs still uses the type the
backend reported, so this cannot paper over a real storage-level type change.

This is conversion-neutral: `PyArrowType.from_ibis` and
`PandasData.convert_GeoSpatial` both ignore the geometry subtype (all geospatial
dtypes go through `gat.wkb(...)` / `GeoSeries.from_wkb`), so preserving
`point:geometry` changes the reported schema only, not the data path.

## Tests

* New `test_cache_preserves_geospatial_subtype` in
  `ibis/backends/duckdb/tests/test_geospatial.py`.
* Sabotage run: with the `ibis/backends/__init__.py` change stashed the new test
  fails with
  `assert ibis.Schema {... geospatial:geometry} == ibis.Schema {... point:geometry}`;
  with the change it passes.
* `pytest ibis/backends/duckdb/tests/test_geospatial.py ibis/backends/tests/test_expr_caching.py ibis/backends/duckdb/tests/test_client.py -m duckdb`
  → 121 passed, 1 skipped, 14 xfailed.
* `pytest ibis/tests --ignore=ibis/tests/benchmarks` → 2869 passed, 3 xfailed.
* `ruff check` / `ruff format` on the two changed files (the two remaining
  `ruff check` findings, `RUF036` at `ibis/backends/__init__.py:1340` and
  `PLR0917` at `test_geospatial.py:492`, are pre-existing and untouched).

Local environment: duckdb 1.5.x with the spatial extension, branch based on
`upstream/main` at 05d2b2933.

## Deliberately left out

* No attempt to recover the subtype from DuckDB itself — `GEOMETRY` carries no
  subtype, so the only place the information still exists is the expression.
* No change to `create_table`/`table()` schema reporting: a table read straight
  out of the database has no expression to carry detail over from, and should
  keep reporting exactly what the backend stores.

## Issues closed

* Resolves #11973
