### PR TITLE
fix(types): clamp Round scale at zero for negative digits

### DIFF
--- a/ibis/expr/operations/numeric.py
+++ b/ibis/expr/operations/numeric.py
@@ -159,9 +159,11 @@ class Round(Value):
 
         raw_digits = getattr(digits, "value", None)
 
-        # decimals with literal-typed digits return decimals
+        # decimals with literal-typed digits return decimals. Negative digits round
+        # to a power of ten, which is still an integral decimal, so the scale is
+        # clamped at zero rather than going negative.
         if arg_dtype.is_decimal() and raw_digits is not None:
-            return arg_dtype.copy(scale=raw_digits)
+            return arg_dtype.copy(scale=max(raw_digits, 0))
 
         nullable = arg_dtype.nullable
 

--- a/ibis/tests/expr/test_sql_builtins.py
+++ b/ibis/tests/expr/test_sql_builtins.py
@@ -165,6 +165,13 @@ def test_round(functional_alltypes, lineitem):
     result = dec.round(2)
     assert isinstance(result, ir.DecimalColumn)
 
+    # negative digits round to a power of ten, so the result is an integral
+    # decimal rather than one with a negative scale
+    result = dec.round(-1)
+    assert isinstance(result, ir.DecimalColumn)
+    assert result.type().scale == 0
+    assert result.type().precision == dec.type().precision
+
     result = ibis.literal(1.2345).round()
     assert isinstance(result, ir.IntegerScalar)
 


### PR DESCRIPTION
On a decimal column, round() keeps as many digits after the point as you ask
for, so ibis uses the number of digits you pass as the scale of the result
type. That is correct for positive digits.

For negative digits it breaks. round(1234.5678, -1) is 1230, which is a valid
result, but ibis tried to build a decimal type with a scale of -1, and there is
no such thing as -1 digits after the point. It raised
"ValueError: Decimal type scale cannot be negative" while building the
expression, before any SQL was generated. float and int columns were fine, only
decimal was affected.

1230 has no digits after the point, so the scale should be 0. This clamps it to
0 for negative digits and leaves positive digits unchanged.

DuckDB returns DECIMAL(10,0) for round(1234.5678::DECIMAL(10,4), -1), and ibis
now infers the same type.

I added assertions to the existing test_round for the decimal case. The full
test suite gives the same result before and after this change on my machine.