### PR TITLE
fix(pandas): respect the declared datetime resolution

### DIFF
--- a/ibis/formats/pandas.py
+++ b/ibis/formats/pandas.py
@@ -212,13 +212,34 @@ class PandasData(DataMapper):
             return s
 
     @classmethod
+    def _convert_datetime_resolution(cls, s, pandas_type):
+        """Align an already-datetime series with the declared resolution.
+
+        Backends hand back whatever resolution their source used -- pyarrow
+        preserves it rather than coercing to nanoseconds -- so a series can
+        disagree with `PandasType.from_ibis`. Values outside the declared
+        resolution's range are only representable at a coarser one, so leave
+        those alone rather than raising.
+        """
+        if s.dtype == pandas_type:
+            return s
+        try:
+            return s.astype(pandas_type)
+        except (pd.errors.OutOfBoundsDatetime, ValueError, TypeError):
+            return s
+
+    @classmethod
     def convert_Timestamp(cls, s, dtype, pandas_type):
         if isinstance(pandas_type, pd.DatetimeTZDtype) and isinstance(
             s.dtype, pd.DatetimeTZDtype
         ):
-            return s if s.dtype == pandas_type else s.dt.tz_convert(dtype.timezone)
+            if s.dtype != pandas_type:
+                s = s.dt.tz_convert(dtype.timezone)
+            return cls._convert_datetime_resolution(s, pandas_type)
         elif pdt.is_datetime64_dtype(s.dtype):
-            return s.dt.tz_localize(dtype.timezone)
+            return cls._convert_datetime_resolution(
+                s.dt.tz_localize(dtype.timezone), pandas_type
+            )
         else:
             try:
                 return s.astype(pandas_type)


### PR DESCRIPTION
`convert_Timestamp` ignored `pandas_type` on both of its already-datetime branches: `tz_convert` and `tz_localize` preserve whatever resolution the series arrived with, so a backend handing back microseconds kept them even though `PandasType.from_ibis` declares nanoseconds under pandas 2.

Nothing noticed while pyflink pinned pyarrow below 12, because that coerced every temporal column to nanoseconds on the way out. pyarrow 13 onward preserves the source resolution, so a non-empty result now carries microseconds while an empty one -- which pyflink builds with `DataFrame.from_records([])` and lands in the `astype` branch -- carries nanoseconds. Ten tests compare a filtered-empty frame against a non-empty fixture and fail on the dtype alone.

Coerce to the declared resolution once the timezone is settled. Values outside its range are only representable at a coarser resolution, so overflow leaves the series as it is rather than raising -- that is what keeps `test_big_timestamp` and `test_large_timestamp` working.

This is not flink-specific; flink is just the only backend whose pyarrow was old enough to hide it.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NFLdThxdduHqBiSqLbDSTf

<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

## Issues closed

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
