### PR TITLE
fix(trino): parse string-to-json casts with JSON_PARSE

### DIFF
--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -589,6 +589,11 @@ class TrinoCompiler(SQLGlotCompiler):
 
     def visit_Cast(self, op, *, arg, to):
         from_ = op.arg.dtype
+        if from_.is_string() and to.is_json():
+            # `CAST(varchar AS JSON)` wraps the string as a JSON string
+            # scalar rather than parsing its contents; JSON_PARSE does
+            # the parsing we actually want here.
+            return self.f.json_parse(arg)
         if from_.is_numeric() and to.is_timestamp():
             tz = to.timezone or "UTC"
             if from_.is_integer():

--- a/ibis/backends/sql/tests/test_compiler.py
+++ b/ibis/backends/sql/tests/test_compiler.py
@@ -26,3 +26,13 @@ def test_transpile_join():
         "SELECT * FROM t1 JOIN t2 ON x = y", read="duckdb", write=Trino
     )
     assert "CROSS JOIN" not in result
+
+
+def test_trino_string_to_json_cast_uses_json_parse():
+    # GH #12073: `CAST(varchar AS JSON)` in Trino wraps the string as a
+    # JSON string scalar instead of parsing it, so string->json casts
+    # must compile to JSON_PARSE instead of a plain CAST.
+    t = ibis.table({"raw": "string"}, name="t")
+    sql = ibis.to_sql(t.raw.cast("json"), dialect="trino")
+    assert "JSON_PARSE" in sql
+    assert "CAST(" not in sql

--- a/ibis/backends/tests/test_json.py
+++ b/ibis/backends/tests/test_json.py
@@ -82,6 +82,25 @@ def test_json_literal(con):
     assert result == {"scale": 100}
 
 
+@pytest.mark.notimpl(["polars"])
+@pytest.mark.notyet(
+    ["sqlite"],
+    reason="Syntax error near 'AS'",
+)
+@pytest.mark.notyet(
+    ["flink"],
+    reason="Calcite validation error casting a JSON array getitem result to another type",
+)
+def test_json_string_cast(con):
+    # GH #12073: casting a string containing JSON text to json must parse
+    # its contents rather than wrapping the string itself as a JSON scalar
+    # (this is easy to get wrong on backends, like Trino, that have a
+    # dedicated JSON-parsing function distinct from a generic CAST).
+    expr = ibis.literal('{"a": 1}').cast("json")["a"].cast("int")
+    result = con.execute(expr)
+    assert result == 1
+
+
 @pytest.mark.notimpl(["mysql", "risingwave"])
 @pytest.mark.notimpl(["mysql", "singlestoredb", "risingwave"])
 @pytest.mark.notyet(["bigquery", "sqlite"], reason="doesn't support maps")


### PR DESCRIPTION
## Description of changes

`CAST(varchar AS JSON)` in Trino wraps the string as a JSON string scalar rather than parsing its contents, so `.cast("json")` on a column of JSON text produced a JSON string, and every downstream field access silently returned NULL. `JSON_PARSE` parses the varchar as JSON.

String-to-JSON casts now compile to `JSON_PARSE`; other casts, including json-to-json, are unchanged. Athena inherits the fix since its compiler falls through to Trino's for casts.

Added a compiler-level regression test asserting the generated SQL, and an execution-level test in the shared cross-backend JSON suite (`ibis/backends/tests/test_json.py`) so it runs against every JSON-capable backend, not just Trino.

Verified locally against a real Trino container: the execution test fails on the pre-fix compiler with the same symptom as the issue (`None` instead of the parsed value), and passes after the fix. Also verified each backend-skip mark individually against real duckdb/sqlite/mysql/polars/flink execution rather than copying them from the unrelated JSON-literal test; mysql turned out to already work and its mark was dropped, and flink's mark's reason was corrected to the actual Calcite error observed. Athena and pyspark could not be exercised in this environment (no AWS credentials; local Java version too old for pyspark) and are left unmarked pending CI.

## Issues closed

* Resolves #12073