### PR TITLE
fix(deps): pin dep on sqlglot to <30.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ dependencies = [
   "atpublic>=2.3",
   "parsy>=2",
   "python-dateutil>=2.8.2",
-  "sqlglot>=23.4,!=26.32.0",
+  # temporarily pin to below 30.18 to avoid https://github.com/ibis-project/ibis/issues/12101
+  "sqlglot>=23.4,!=26.32.0,<30.18.0",
   "toolz>=0.11",
   "typing-extensions>=4.3.0",
   "tzdata>=2022.7",           # fallback time zone data on Windows

--- a/uv.lock
+++ b/uv.lock
@@ -2896,7 +2896,7 @@ requires-dist = [
     { name = "shapely", marker = "extra == 'geospatial'", specifier = ">=2" },
     { name = "singlestoredb", marker = "extra == 'singlestoredb'", specifier = ">=1.0" },
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.0.2,!=3.3.0b1" },
-    { name = "sqlglot", specifier = ">=23.4,!=26.32.0" },
+    { name = "sqlglot", specifier = ">=23.4,!=26.32.0,<30.18.0" },
     { name = "toolz", specifier = ">=0.11" },
     { name = "trino", marker = "extra == 'trino'", specifier = ">=0.321" },
     { name = "typing-extensions", specifier = ">=4.3.0" },


### PR DESCRIPTION
sqlglot renamed `Drop`'s `this` argument to `tables` in [tobymao/sqlglot#8229](https://github.com/tobymao/sqlglot/pull/8229) (merged 2026-08-20).

- **Impact**: The first release containing this breaking change is `30.18.0` (2026-09-03); `30.17.0` is unaffected.
- **Symptom**: In `30.18.0`, passing `this` to `sqlglot.expressions.Drop` is silently ignored rather than raising an argument error. As a result, SQL generation emits `DROP TABLE IF EXISTS` without a table name, leading to syntax errors at execution time.
- **Scope**: This affects `drop_table`, `drop_view` on the shared `SQLBackend`, and the memtable finalizer—impacting all SQL backends, not just DuckDB.
- **Verification**: Verified that `30.17.0` works cleanly and `30.18.0` consistently reproduces the syntax error on `DROP`.

This PR temporarily pins `sqlglot < 30.18.0` to unbreak existing releases and CI, mirroring the previous `<28` pin pattern from #11805. A proper refactor switching call sites to `tables` can follow in a separate PR.
