### PR TITLE
fix(sql): adapt Drop expression for sqlglot 30.18 compatibility

### DIFF
--- a/ibis/backends/athena/__init__.py
+++ b/ibis/backends/athena/__init__.py
@@ -26,6 +26,7 @@ import ibis.expr.types as ir
 from ibis import util
 from ibis.backends import CanCreateDatabase, NoExampleLoader, UrlFromPath
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.base import AlterTable, RenameTable
 
 if TYPE_CHECKING:
@@ -448,7 +449,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
 
     def _make_memtable_finalizer(self, name: str) -> Callable[..., None]:
         this = sg.table(name, quoted=self.compiler.quoted)
-        drop_stmt = sge.Drop(kind="TABLE", this=this, exists=True)
+        drop_stmt = Drop(kind="TABLE", this=this, exists=True)
         drop_sql = drop_stmt.sql(self.dialect)
         path = f"{self._memtable_volume_path}/{name}"
 
@@ -487,7 +488,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
         self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         name = sg.table(name, catalog=catalog, quoted=self.compiler.quoted)
-        sql = sge.Drop(this=name, kind="SCHEMA", exists=force)
+        sql = Drop(this=name, kind="SCHEMA", exists=force)
         with self._safe_raw_sql(sql, unload=False):
             pass
 
@@ -577,7 +578,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
             kind="VIEW",
             expression=sg.parse_one(query, dialect=dialect),
         )
-        drop_view = sge.Drop(
+        drop_view = Drop(
             kind="VIEW", this=sg.to_identifier(view_name, quoted=quoted)
         ).sql(dialect)
 

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -41,6 +41,7 @@ from ibis.backends.bigquery.client import (
 )
 from ibis.backends.bigquery.datatypes import BigQuerySchema
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -696,7 +697,7 @@ class Backend(
         cascade: bool = False,
     ) -> None:
         """Drop a BigQuery dataset."""
-        stmt = sge.Drop(
+        stmt = Drop(
             kind="SCHEMA",
             this=sg.table(name, db=catalog),
             exists=force,
@@ -1289,7 +1290,7 @@ class Backend(
     ) -> None:
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
-        stmt = sge.Drop(
+        stmt = Drop(
             kind="TABLE",
             this=sg.table(
                 name,
@@ -1332,7 +1333,7 @@ class Backend(
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
 
-        stmt = sge.Drop(
+        stmt = Drop(
             kind="VIEW",
             this=sg.table(
                 name,

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_cast_float_to_int/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_cast_float_to_int/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  CAST(trunc(`t0`.`double_col`) AS INT64) AS `Cast_double_col_int64`
+  CAST(TRUNC(`t0`.`double_col`) AS INT64) AS `Cast_double_col_int64`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -34,6 +34,7 @@ from ibis.backends import (
 )
 from ibis.backends.clickhouse.converter import ClickHousePandasData
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.base import C
 
 if TYPE_CHECKING:
@@ -543,9 +544,7 @@ class Backend(SupportsTempTables, SQLBackend, CanCreateDatabase, DirectExampleLo
     def drop_database(
         self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
-        src = sge.Drop(
-            this=sg.table(name, catalog=catalog), kind="DATABASE", exists=force
-        )
+        src = Drop(this=sg.table(name, catalog=catalog), kind="DATABASE", exists=force)
         with self._safe_raw_sql(src):
             pass
 

--- a/ibis/backends/databricks/__init__.py
+++ b/ibis/backends/databricks/__init__.py
@@ -27,6 +27,7 @@ import ibis.expr.types as ir
 from ibis import util
 from ibis.backends import CanCreateDatabase, PyArrowExampleLoader, UrlFromPath
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.base import STAR, AlterTable, RenameTable
 from ibis.backends.sql.datatypes import DatabricksType
 
@@ -234,7 +235,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
 
             if overwrite:
                 cur.execute(
-                    sge.Drop(kind="TABLE", this=final_table, exists=True).sql(dialect)
+                    Drop(kind="TABLE", this=final_table, exists=True).sql(dialect)
                 )
                 if temp:
                     cur.execute(
@@ -246,9 +247,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
                         ).sql(dialect)
                     )
                     cur.execute(
-                        sge.Drop(kind="TABLE", this=initial_table, exists=True).sql(
-                            dialect
-                        )
+                        Drop(kind="TABLE", this=initial_table, exists=True).sql(dialect)
                     )
                 else:
                     cur.execute(
@@ -338,7 +337,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
             # clean up the temporary view
             with self.con.cursor() as cur:
                 cur.execute(
-                    sge.Drop(this=view_name, kind="VIEW", exists=True).sql(self.dialect)
+                    Drop(this=view_name, kind="VIEW", exists=True).sql(self.dialect)
                 )
 
         js = json.loads(out)
@@ -446,7 +445,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
         self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         name = sg.table(name, catalog=catalog, quoted=self.compiler.quoted)
-        with self._safe_raw_sql(sge.Drop(this=name, kind="SCHEMA", replace=force)):
+        with self._safe_raw_sql(Drop(this=name, kind="SCHEMA", replace=force)):
             pass
 
     def list_tables(

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -32,6 +32,7 @@ from ibis.backends import (
     SupportsTempTables,
 )
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.base import C
 from ibis.common.dispatch import lazy_singledispatch
 from ibis.expr.operations.udf import InputType
@@ -385,7 +386,7 @@ class Backend(
         self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         db_name = sg.table(name, db=catalog)
-        with self._safe_raw_sql(sge.Drop(kind="SCHEMA", this=db_name, exists=force)):
+        with self._safe_raw_sql(Drop(kind="SCHEMA", this=db_name, exists=force)):
             pass
 
     def list_tables(

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -32,6 +32,7 @@ from ibis.backends import (
     UrlFromPath,
 )
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.base import STAR, AlterTable, C, RenameTable
 from ibis.expr.operations.udf import InputType
 
@@ -236,14 +237,14 @@ class Backend(
 
                 if in_memory:
                     cur.execute(
-                        sge.Drop(kind="VIEW", this=table.get_name(), exists=True).sql(
+                        Drop(kind="VIEW", this=table.get_name(), exists=True).sql(
                             dialect
                         )
                     )
 
             if overwrite:
                 cur.execute(
-                    sge.Drop(kind="TABLE", this=final_table, exists=True).sql(dialect)
+                    Drop(kind="TABLE", this=final_table, exists=True).sql(dialect)
                 )
                 # TODO: This branching should be removed once DuckDB >=0.9.3 is
                 # our lower bound (there's an upstream bug in 0.9.2 that
@@ -260,9 +261,7 @@ class Backend(
                         ).sql(dialect)
                     )
                     cur.execute(
-                        sge.Drop(kind="TABLE", this=initial_table, exists=True).sql(
-                            dialect
-                        )
+                        Drop(kind="TABLE", this=initial_table, exists=True).sql(dialect)
                     )
                 else:
                     cur.execute(
@@ -537,7 +536,7 @@ class Backend(
             )
 
         name = sg.table(name, catalog=catalog, quoted=self.compiler.quoted)
-        with self._safe_raw_sql(sge.Drop(this=name, kind="SCHEMA", replace=force)):
+        with self._safe_raw_sql(Drop(this=name, kind="SCHEMA", replace=force)):
             pass
 
     @util.experimental

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -21,6 +21,7 @@ import ibis.expr.types as ir
 from ibis import util
 from ibis.backends import CanCreateDatabase, NoExampleLoader
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.base import STAR, C
 
 if TYPE_CHECKING:
@@ -260,7 +261,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
             this=table,
             expression=sg.parse_one(query, dialect=dialect),
         )
-        drop_view = sg.exp.Drop(kind="VIEW", this=table).sql(dialect)
+        drop_view = Drop(kind="VIEW", this=table).sql(dialect)
         describe = sg.exp.Describe(this=table).sql(dialect)
         type_mapper = self.compiler.type_mapper
         con = self.con
@@ -316,13 +317,13 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
 
     def _clean_up_tmp_table(self, name: str) -> None:
         ident = sg.to_identifier(name, quoted=self.compiler.quoted)
-        drop_sql = sge.Drop(kind="TABLE", this=ident, exists=True, cascade=True)
+        drop_sql = Drop(kind="TABLE", this=ident, exists=True, cascade=True)
         with self._safe_raw_sql(drop_sql):
             pass
 
     def _make_memtable_finalizer(self, name: str) -> Callable[..., None]:
         ident = sg.to_identifier(name, quoted=self.compiler.quoted)
-        drop_sql = sge.Drop(kind="TABLE", this=ident, exists=True, cascade=True).sql(
+        drop_sql = Drop(kind="TABLE", this=ident, exists=True, cascade=True).sql(
             self.dialect
         )
 
@@ -424,7 +425,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
 
             if overwrite:
                 self.con.execute(
-                    sge.Drop(kind="TABLE", this=this, exists=True).sql(self.name)
+                    Drop(kind="TABLE", this=this, exists=True).sql(self.name)
                 )
                 self.con.execute(
                     f"RENAME TABLE {table_expr.sql(self.name)} TO {this.sql(self.name)}"
@@ -451,7 +452,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
             raise NotImplementedError(
                 "`catalog` argument is not supported for the Exasol backend"
             )
-        drop_schema = sg.exp.Drop(
+        drop_schema = Drop(
             kind="SCHEMA",
             this=sg.to_identifier(name, quoted=self.compiler.quoted),
             exists=force,

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -29,6 +29,7 @@ from ibis.backends.impala.udf import (
     wrap_udf,
 )
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -380,7 +381,7 @@ class Backend(SQLBackend, HasCurrentDatabase, NoExampleLoader):
         create_sql = sge.Create(
             kind="VIEW", this=ident, exists=True, expression=query, dialect=self.dialect
         )
-        drop_sql = sge.Drop(kind="VIEW", this=ident, exists=True)
+        drop_sql = Drop(kind="VIEW", this=ident, exists=True)
 
         with self._safe_raw_sql(create_sql):
             pass

--- a/ibis/backends/materialize/__init__.py
+++ b/ibis/backends/materialize/__init__.py
@@ -12,6 +12,7 @@ import ibis
 import ibis.expr.operations as ops
 from ibis.backends.materialize.api import mz_now, mz_top_k
 from ibis.backends.postgres import Backend as PostgresBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.materialize import MaterializeCompiler
 
 __all__ = ("Backend", "mz_now", "mz_top_k")
@@ -528,7 +529,7 @@ ORDER BY a.attnum ASC"""  # noqa: S608
 
         # Handle overwrite with RENAME (separate transaction)
         if overwrite:
-            drop_stmt = sge.Drop(kind="TABLE", this=this, exists=True).sql(dialect)
+            drop_stmt = Drop(kind="TABLE", this=this, exists=True).sql(dialect)
             rename_stmt = f"ALTER TABLE IF EXISTS {table_expr.sql(dialect)} RENAME TO {this_no_catalog.sql(dialect)}"
 
             with con.cursor() as cursor:
@@ -647,7 +648,7 @@ ORDER BY a.attnum ASC"""  # noqa: S608
         """
         # Note: sqlglot's 'catalog' parameter maps to Materialize's database
         # and sqlglot's 'db' parameter maps to Materialize's schema
-        drop_stmt = sge.Drop(
+        drop_stmt = Drop(
             this=sg.table(
                 name, catalog=database, db=schema, quoted=self.compiler.quoted
             ),
@@ -1421,7 +1422,7 @@ ORDER BY a.attnum ASC"""  # noqa: S608
         # and sqlglot's 'db' parameter maps to Materialize's schema
         sink_table = sg.table(name, catalog=database, db=schema, quoted=quoted)
 
-        drop_stmt = sge.Drop(
+        drop_stmt = Drop(
             this=sink_table,
             kind="SINK",
             exists=force,
@@ -1618,7 +1619,7 @@ ORDER BY a.attnum ASC"""  # noqa: S608
         # and sqlglot's 'db' parameter maps to Materialize's schema
         conn_table = sg.table(name, catalog=database, db=schema, quoted=quoted)
 
-        drop_stmt = sge.Drop(
+        drop_stmt = Drop(
             this=conn_table,
             kind="CONNECTION",
             exists=force,
@@ -1812,7 +1813,7 @@ ORDER BY a.attnum ASC"""  # noqa: S608
         # and sqlglot's 'db' parameter maps to Materialize's schema
         secret_table = sg.table(name, catalog=database, db=schema, quoted=quoted)
 
-        drop_stmt = sge.Drop(
+        drop_stmt = Drop(
             this=secret_table,
             kind="SECRET",
             exists=force,
@@ -2010,7 +2011,7 @@ ORDER BY a.attnum ASC"""  # noqa: S608
         quoted = self.compiler.quoted
         cluster_id = sg.to_identifier(name, quoted=quoted)
 
-        drop_stmt = sge.Drop(
+        drop_stmt = Drop(
             this=cluster_id,
             kind="CLUSTER",
             exists=force,
@@ -2293,7 +2294,7 @@ ORDER BY a.attnum ASC"""  # noqa: S608
         quoted = self.compiler.quoted
         idx_name = sg.table(name, quoted=quoted)
 
-        drop_cmd = sge.Drop(
+        drop_cmd = Drop(
             this=idx_name,
             kind="INDEX",
             exists=force,

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -30,6 +30,7 @@ from ibis.backends import (
     PyArrowExampleLoader,
 )
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.base import STAR, C
 
 if TYPE_CHECKING:
@@ -477,7 +478,7 @@ GO"""
 
     def drop_catalog(self, name: str, /, *, force: bool = False) -> None:
         with self._safe_ddl(
-            sge.Drop(
+            Drop(
                 kind="DATABASE",
                 this=sg.to_identifier(name, quoted=self.compiler.quoted),
                 exists=force,
@@ -546,7 +547,7 @@ GO"""
                 )
 
             cur.execute(
-                sge.Drop(
+                Drop(
                     kind="SCHEMA",
                     exists=force,
                     this=sg.to_identifier(name, quoted=quoted),
@@ -723,7 +724,7 @@ GO"""
 
             if overwrite:
                 cur.execute(
-                    sge.Drop(kind="TABLE", this=this, exists=True).sql(self.dialect)
+                    Drop(kind="TABLE", this=this, exists=True).sql(self.dialect)
                 )
                 old = raw_table.sql(self.dialect)
                 new = raw_this.sql(self.dialect)

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -666,7 +666,10 @@ GO"""
         properties = []
 
         if temp:
-            properties.append(sge.TemporaryProperty())
+            # tsql spells temporary-ness with a `##` name prefix rather than a
+            # property; older sqlglot prepended the second `#` for a
+            # TemporaryProperty, newer sqlglot emits the name verbatim, so name
+            # the table explicitly and leave the property off
             catalog, db = None, None
 
         if obj is not None:
@@ -693,7 +696,7 @@ GO"""
         raw_table = sg.table(temp_name, catalog=catalog, db=db, quoted=False)
         target = sge.Schema(
             this=sg.table(
-                "#" * bool(temp) + temp_name, catalog=catalog, db=db, quoted=quoted
+                "##" * bool(temp) + temp_name, catalog=catalog, db=db, quoted=quoted
             ),
             expressions=schema.to_sqlglot_column_defs(self.dialect),
         )

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -30,6 +30,7 @@ from ibis.backends import (
     SupportsTempTables,
 )
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.base import STAR, TRUE, C, RenameTable
 
 if TYPE_CHECKING:
@@ -241,7 +242,7 @@ class Backend(
     def drop_database(
         self, name: str, *, catalog: str | None = None, force: bool = False
     ) -> None:
-        sql = sge.Drop(
+        sql = Drop(
             kind="DATABASE", exists=force, this=sg.table(name, catalog=catalog)
         ).sql(self.name)
         with self.begin() as cur:
@@ -434,7 +435,7 @@ class Backend(
                 cur.execute(sge.Insert(this=table_expr, expression=query).sql(dialect))
 
             if overwrite:
-                cur.execute(sge.Drop(kind="TABLE", this=this, exists=True).sql(dialect))
+                cur.execute(Drop(kind="TABLE", this=this, exists=True).sql(dialect))
                 cur.execute(
                     sge.Alter(
                         kind="TABLE",

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -29,6 +29,7 @@ from ibis.backends import (
     PyArrowExampleLoader,
 )
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.base import STAR, C
 
 if TYPE_CHECKING:
@@ -559,7 +560,7 @@ class Backend(
         create_view = sg.exp.Create(kind="VIEW", this=this, expression=sg_expr).sql(
             dialect
         )
-        drop_view = sg.exp.Drop(kind="VIEW", this=this).sql(dialect)
+        drop_view = Drop(kind="VIEW", this=this).sql(dialect)
 
         metadata_query = (
             sg.select(
@@ -615,7 +616,7 @@ class Backend(
         ident = sg.to_identifier(name, quoted=self.compiler.quoted)
 
         truncate = sge.TruncateTable(expressions=[ident]).sql(dialect)
-        drop = sge.Drop(kind="TABLE", this=ident).sql(dialect)
+        drop = Drop(kind="TABLE", this=ident).sql(dialect)
 
         with self.begin() as bind:
             # global temporary tables cannot be dropped without first truncating them
@@ -637,7 +638,7 @@ class Backend(
         ident = sg.to_identifier(name, quoted=self.compiler.quoted)
 
         truncate = sge.TruncateTable(expressions=[ident]).sql(dialect)
-        drop = sge.Drop(kind="TABLE", this=ident).sql(dialect)
+        drop = Drop(kind="TABLE", this=ident).sql(dialect)
 
         def finalizer(con=self.con, name: str = name) -> None:
             cursor = con.cursor()

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -30,6 +30,7 @@ from ibis.backends import (
     SupportsTempTables,
 )
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.base import TRUE, C, ColGen
 
 if TYPE_CHECKING:
@@ -510,7 +511,7 @@ ORDER BY a.attnum ASC"""
             properties=sge.Properties(expressions=[sge.TemporaryProperty()]),
         ).sql(self.dialect)
 
-        drop_stmt = sge.Drop(kind="VIEW", this=sg.table(name), exists=True).sql(
+        drop_stmt = Drop(kind="VIEW", this=sg.table(name), exists=True).sql(
             self.dialect
         )
 
@@ -552,7 +553,7 @@ ORDER BY a.attnum ASC"""
                 f"{self.name} does not support dropping a database in a different catalog"
             )
 
-        sql = sge.Drop(
+        sql = Drop(
             kind="SCHEMA",
             this=sg.table(name),
             exists=force,
@@ -654,7 +655,7 @@ ORDER BY a.attnum ASC"""
             stmts.append(sge.Insert(this=table_expr, expression=query).sql(dialect))
 
         if overwrite:
-            stmts.append(sge.Drop(kind="TABLE", this=this, exists=True).sql(dialect))
+            stmts.append(Drop(kind="TABLE", this=this, exists=True).sql(dialect))
             stmts.append(
                 f"ALTER TABLE IF EXISTS {table_expr.sql(dialect)} RENAME TO {this_no_catalog.sql(dialect)}"
             )
@@ -679,7 +680,7 @@ ORDER BY a.attnum ASC"""
         database: str | None = None,
         force: bool = False,
     ) -> None:
-        drop_stmt = sg.exp.Drop(
+        drop_stmt = Drop(
             kind="TABLE",
             this=sg.table(name, db=database, quoted=self.compiler.quoted),
             exists=force,

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -34,6 +34,7 @@ from ibis.backends import (
 from ibis.backends.pyspark.converter import PySparkPandasData
 from ibis.backends.pyspark.datatypes import PySparkSchema, PySparkType
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.base import AlterTable, RenameTable
 from ibis.expr.operations.udf import InputType
 from ibis.legacy.udf.vectorized import _coerce_to_series
@@ -565,7 +566,7 @@ class Backend(
             database does not exist
 
         """
-        sql = sge.Drop(
+        sql = Drop(
             kind="DATABASE",
             exists=force,
             this=sg.to_identifier(name, quoted=self.compiler.quoted),

--- a/ibis/backends/risingwave/__init__.py
+++ b/ibis/backends/risingwave/__init__.py
@@ -28,6 +28,7 @@ from ibis.backends import (
     NoExampleLoader,
 )
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.base import TRUE, C, ColGen
 from ibis.util import experimental
 
@@ -321,7 +322,7 @@ class Backend(
             expression=sg.parse_one(query, read=self.dialect),
             properties=sge.Properties(expressions=[sge.TemporaryProperty()]),
         )
-        drop_stmt = sge.Drop(kind="VIEW", this=sg.table(name), exists=True).sql(
+        drop_stmt = Drop(kind="VIEW", this=sg.table(name), exists=True).sql(
             self.dialect
         )
 
@@ -360,7 +361,7 @@ class Backend(
                 f"{self.name} does not support dropping a database in a different catalog"
             )
 
-        sql = sge.Drop(
+        sql = Drop(
             kind="SCHEMA",
             this=sg.table(name),
             exists=force,
@@ -377,7 +378,7 @@ class Backend(
         database: str | None = None,
         force: bool = False,
     ) -> None:
-        drop_stmt = sg.exp.Drop(
+        drop_stmt = Drop(
             kind="TABLE",
             this=sg.table(name, db=database, quoted=self.compiler.quoted),
             exists=force,
@@ -715,7 +716,7 @@ class Backend(
         force
             If `False`, an exception is raised if the view does not exist.
         """
-        src = sge.Drop(
+        src = Drop(
             this=sg.table(name, db=database, quoted=self.compiler.quoted),
             kind="MATERIALIZED VIEW",
             exists=force,
@@ -806,7 +807,7 @@ class Backend(
         force
             If `False`, an exception is raised if the source does not exist.
         """
-        src = sge.Drop(
+        src = Drop(
             this=sg.table(name, db=database, quoted=self.compiler.quoted),
             kind="SOURCE",
             exists=force,
@@ -897,7 +898,7 @@ class Backend(
         force
             If `False`, an exception is raised if the source does not exist.
         """
-        src = sge.Drop(
+        src = Drop(
             this=sg.table(name, db=database, quoted=self.compiler.quoted),
             kind="SINK",
             exists=force,

--- a/ibis/backends/singlestoredb/__init__.py
+++ b/ibis/backends/singlestoredb/__init__.py
@@ -23,6 +23,7 @@ from ibis.backends import (
     SupportsTempTables,
 )
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.singlestoredb import compiler
 
 if TYPE_CHECKING:
@@ -254,7 +255,7 @@ class Backend(
         >>> con.drop_database("my_database")  # doctest: +SKIP
         >>> con.drop_database("my_database", force=True)  # doctest: +SKIP
         """
-        sql = sge.Drop(
+        sql = Drop(
             kind="DATABASE", exists=force, this=sg.table(name, catalog=catalog)
         ).sql(self.dialect)
         with self.begin() as cur:
@@ -605,9 +606,7 @@ class Backend(
             if overwrite and temp:
                 # For temporary tables with overwrite, drop the existing table first
                 try:
-                    cur.execute(
-                        sge.Drop(kind="TABLE", this=this, exists=True).sql(dialect)
-                    )
+                    cur.execute(Drop(kind="TABLE", this=this, exists=True).sql(dialect))
                 except Exception:
                     # Ignore errors if table doesn't exist
                     pass
@@ -620,7 +619,7 @@ class Backend(
                 # Only use rename strategy for non-temporary tables
                 final_this = sg.table(name, catalog=database, quoted=quoted)
                 cur.execute(
-                    sge.Drop(kind="TABLE", this=final_this, exists=True).sql(dialect)
+                    Drop(kind="TABLE", this=final_this, exists=True).sql(dialect)
                 )
                 self.rename_table(temp_name, name)
 
@@ -654,7 +653,7 @@ class Backend(
         force
             Use IF EXISTS clause when dropping
         """
-        drop_stmt = sge.Drop(
+        drop_stmt = Drop(
             kind="TABLE",
             this=sg.table(name, db=database, quoted=self.compiler.quoted),
             exists=force,

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -34,6 +34,7 @@ from ibis.backends import (
 )
 from ibis.backends.snowflake.converter import SnowflakePandasData
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.base import STAR
 
 if TYPE_CHECKING:
@@ -677,7 +678,7 @@ $$ {defn["source"]} $$"""
             raise com.UnsupportedOperationError(
                 "Dropping the current catalog is not supported because its behavior is undefined"
             )
-        drop_stmt = sge.Drop(
+        drop_stmt = Drop(
             this=sg.to_identifier(name, quoted=self.compiler.quoted),
             kind="DATABASE",
             exists=force,
@@ -735,7 +736,7 @@ $$ {defn["source"]} $$"""
                 "Dropping the current database is not supported because its behavior is undefined"
             )
 
-        drop_stmt = sge.Drop(
+        drop_stmt = Drop(
             this=sg.table(name, db=catalog, quoted=self.compiler.quoted),
             kind="SCHEMA",
             exists=force,

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -14,6 +14,7 @@ import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis import util
 from ibis.backends import BaseBackend
+from ibis.backends.sql.compilers._compat import Drop
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping
@@ -269,7 +270,7 @@ class SQLBackend(BaseBackend):
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
 
-        src = sge.Drop(
+        src = Drop(
             this=sg.table(name, db=db, catalog=catalog, quoted=self.compiler.quoted),
             kind="VIEW",
             exists=force,
@@ -339,7 +340,7 @@ class SQLBackend(BaseBackend):
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
 
-        drop_stmt = sge.Drop(
+        drop_stmt = Drop(
             kind="TABLE",
             this=sg.table(name, db=db, catalog=catalog, quoted=self.compiler.quoted),
             exists=force,
@@ -801,7 +802,7 @@ class SQLBackend(BaseBackend):
 
     def _make_memtable_finalizer(self, name: str) -> Callable[..., None]:
         this = sg.table(name, quoted=self.compiler.quoted)
-        drop_stmt = sge.Drop(kind="TABLE", this=this, exists=True)
+        drop_stmt = Drop(kind="TABLE", this=this, exists=True)
         drop_sql = drop_stmt.sql(self.dialect)
 
         def finalizer(drop_sql=drop_sql, con=self.con) -> None:

--- a/ibis/backends/sql/compilers/_compat.py
+++ b/ibis/backends/sql/compilers/_compat.py
@@ -16,3 +16,9 @@ def _get_arg_name(expr_cls: type[sge.Expression], *args: str) -> str:
 # to keep the code backward compatible, we take the first valid arg name
 WITH_ARG = _get_arg_name(sge.Select, "with", "with_")
 EXCEPT_ARG = _get_arg_name(sge.Star, "except", "except_")
+DROP_ARG = _get_arg_name(sge.Drop, "this", "tables")
+
+
+def Drop(*, this, **kwargs):
+    return sge.Drop(**{DROP_ARG: [this] if DROP_ARG == "tables" else this}, **kwargs)
+

--- a/ibis/backends/sql/compilers/_compat.py
+++ b/ibis/backends/sql/compilers/_compat.py
@@ -21,3 +21,9 @@ DROP_ARG = _get_arg_name(sge.Drop, "this", "tables")
 
 def Drop(*, this, **kwargs):
     return sge.Drop(**{DROP_ARG: [this] if DROP_ARG == "tables" else this}, **kwargs)
+
+
+# sqlglot >= 30 split postgres's `?` top-level-key-existence operator out of
+# `JSONBContains`, which now generates the `JSONB_CONTAINS` containment
+# function instead of the operator
+JSONBContainsTopKey = getattr(sge, "JSONBContainsTopKey", sge.JSONBContains)

--- a/ibis/backends/sql/compilers/_compat.py
+++ b/ibis/backends/sql/compilers/_compat.py
@@ -21,4 +21,3 @@ DROP_ARG = _get_arg_name(sge.Drop, "this", "tables")
 
 def Drop(*, this, **kwargs):
     return sge.Drop(**{DROP_ARG: [this] if DROP_ARG == "tables" else this}, **kwargs)
-

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -234,8 +234,12 @@ class ImpalaCompiler(SQLGlotCompiler):
                 "strftime format string must be a literal; "
                 f"got: {type(op.format_str).__name__}"
             )
+        # use sqlglot's precomputed inverse: naively inverting TIME_MAPPING
+        # drops directives whose forward value carries a `strict` marker
         format_str = sg.time.format_time(
-            op.format_str.value, {v: k for k, v in Impala.TIME_MAPPING.items()}
+            op.format_str.value,
+            Impala.INVERSE_TIME_MAPPING,
+            Impala.INVERSE_TIME_TRIE,
         )
         return self.f.anon.from_unixtime(
             self.f.unix_timestamp(self.cast(arg, dt.string)), format_str

--- a/ibis/backends/sql/compilers/postgres.py
+++ b/ibis/backends/sql/compilers/postgres.py
@@ -15,6 +15,7 @@ import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.rules as rlz
+from ibis.backends.sql.compilers._compat import JSONBContainsTopKey
 from ibis.backends.sql.compilers.base import NULL, STAR, AggGen, SQLGlotCompiler
 from ibis.backends.sql.datatypes import PostgresType
 from ibis.backends.sql.dialects import Postgres
@@ -119,7 +120,6 @@ class PostgresCompiler(SQLGlotCompiler):
         ops.GeoWithin: "st_within",
         ops.GeoX: "st_x",
         ops.GeoY: "st_y",
-        ops.MapContains: "jsonb_contains",
         ops.RegexSearch: "regexp_like",
         ops.TimeFromHMS: "make_time",
         ops.RandomUUID: "gen_random_uuid",
@@ -480,7 +480,9 @@ $$""".format(
 
     def json_extract_path_text(self, op, arg, *rest):
         b = "b" * op.arg.dtype.binary
-        return self.f[f"json{b}_extract_path_text"](
+        # `anon` keeps sqlglot from rewriting this into the `->>` operator,
+        # which cannot express the variadic sentinel below
+        return self.f.anon[f"json{b}_extract_path_text"](
             arg,
             *rest,
             # this is apparently how you pass in no additional arguments to
@@ -560,13 +562,18 @@ $$""".format(
             .subquery()
         )
 
+    def visit_MapContains(self, op, *, arg, key):
+        # postgres spells "does this key exist" as the `?` operator; the
+        # jsonb_contains function tests containment of a whole jsonb value
+        return JSONBContainsTopKey(this=arg, expression=key)
+
     def visit_MapGet(self, op, *, arg, key, default):
         if op.dtype.is_null():
             return NULL
         else:
             return self.cast(
                 self.if_(
-                    self.f.jsonb_contains(arg, key),
+                    JSONBContainsTopKey(this=arg, expression=key),
                     self.f.jsonb_extract_path_text(arg, key),
                     default,
                 ),

--- a/ibis/backends/sql/compilers/risingwave.py
+++ b/ibis/backends/sql/compilers/risingwave.py
@@ -52,8 +52,6 @@ class RisingWaveCompiler(PostgresCompiler):
         ops.MapValues: "map_values",
     }
 
-    del SIMPLE_OPS[ops.MapContains]
-
     def to_sqlglot(
         self,
         expr: ir.Expr,

--- a/ibis/backends/sql/tests/test_compiler.py
+++ b/ibis/backends/sql/tests/test_compiler.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import pytest
 import sqlglot as sg
 
 import ibis
 from ibis import _
 from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.dialects import Trino
+
+# these tests exercise SQL compilation only and need no backend
+pytestmark = pytest.mark.core
 
 
 def test_window_with_row_number_compiles():
@@ -15,7 +19,7 @@ def test_window_with_row_number_compiles():
     expr = (
         ibis.memtable({"a": range(30)})
         .mutate(id=ibis.row_number())
-        .sample(fraction=0.25, seed=0)
+        .sample(0.25, seed=0)
         .mutate(is_test=_.id.isin(_.id))
         .filter(~_.is_test)
     )

--- a/ibis/backends/sql/tests/test_compiler.py
+++ b/ibis/backends/sql/tests/test_compiler.py
@@ -4,6 +4,7 @@ import sqlglot as sg
 
 import ibis
 from ibis import _
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.dialects import Trino
 
 
@@ -26,3 +27,9 @@ def test_transpile_join():
         "SELECT * FROM t1 JOIN t2 ON x = y", read="duckdb", write=Trino
     )
     assert "CROSS JOIN" not in result
+
+
+def test_drop_includes_the_table():
+    # GH #12101: sqlglot 30.18 renamed Drop's this kwarg to tables
+    stmt = Drop(kind="TABLE", this=sg.table("t", quoted=True), exists=True)
+    assert stmt.sql("duckdb") == 'DROP TABLE IF EXISTS "t"'

--- a/ibis/backends/sql/tests/test_compiler.py
+++ b/ibis/backends/sql/tests/test_compiler.py
@@ -8,9 +8,6 @@ from ibis import _
 from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.dialects import Trino
 
-# these tests exercise SQL compilation only and need no backend
-pytestmark = pytest.mark.core
-
 
 def test_window_with_row_number_compiles():
     # GH #8058: the add_order_by_to_empty_ranking_window_functions rule was
@@ -23,9 +20,12 @@ def test_window_with_row_number_compiles():
         .mutate(is_test=_.id.isin(_.id))
         .filter(~_.is_test)
     )
-    assert ibis.to_sql(expr)
+    # pin the dialect: letting `to_sql` pick one sets the global
+    # `ibis.options.default_backend`, which leaks into later tests
+    assert ibis.to_sql(expr, dialect="duckdb")
 
 
+@pytest.mark.core
 def test_transpile_join():
     (result,) = sg.transpile(
         "SELECT * FROM t1 JOIN t2 ON x = y", read="duckdb", write=Trino
@@ -33,6 +33,7 @@ def test_transpile_join():
     assert "CROSS JOIN" not in result
 
 
+@pytest.mark.core
 def test_drop_includes_the_table():
     # GH #12101: sqlglot 30.18 renamed Drop's this kwarg to tables
     stmt = Drop(kind="TABLE", this=sg.table("t", quoted=True), exists=True)

--- a/ibis/backends/sql/tests/test_datatypes.py
+++ b/ibis/backends/sql/tests/test_datatypes.py
@@ -16,6 +16,9 @@ from ibis.backends.sql.datatypes import (
     SqlglotType,
 )
 
+# these tests exercise SQL compilation only and need no backend
+pytestmark = pytest.mark.core
+
 
 def assert_dtype_roundtrip(ibis_type, sqlglot_expected=None):
     sqlglot_result = SqlglotType.from_ibis(ibis_type)
@@ -131,5 +134,10 @@ def test_unknown_repr():
         sge.DataType(this=sge.DataType.Type.USERDEFINED, kind='"MySchema"."MyEnum"')
     )
     result = str(dtype)
-    expected = 'unknown(DataType(this=Type.USERDEFINED, kind="MySchema"."MyEnum"))'
+    # sqlglot >= 30 renamed the `DataType.Type` enum to `DType`, and the enum's
+    # name leaks into the repr of the wrapped sqlglot expression
+    expected = (
+        f"unknown(DataType(this={sge.DataType.Type.USERDEFINED},"
+        ' kind="MySchema"."MyEnum"))'
+    )
     assert result == expected

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -23,6 +23,7 @@ from ibis.backends import (
     UrlFromPath,
 )
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.base import C
 from ibis.backends.sqlite.converter import SQLitePandasData
 from ibis.backends.sqlite.udf import ignore_nulls, register_all
@@ -534,15 +535,13 @@ class Backend(
 
                 if in_memory:
                     cur.execute(
-                        sge.Drop(kind="TABLE", this=obj.get_name(), exists=True).sql(
+                        Drop(kind="TABLE", this=obj.get_name(), exists=True).sql(
                             dialect
                         )
                     )
 
             if overwrite:
-                cur.execute(
-                    sge.Drop(kind="TABLE", this=table, exists=True).sql(dialect)
-                )
+                cur.execute(Drop(kind="TABLE", this=table, exists=True).sql(dialect))
                 # SQLite's ALTER TABLE statement doesn't support using a
                 # fully-qualified table reference after RENAME TO. Since we
                 # never rename between databases, we only need the table name
@@ -568,7 +567,7 @@ class Backend(
         database: str | None = None,
         force: bool = False,
     ) -> None:
-        drop_stmt = sg.exp.Drop(
+        drop_stmt = Drop(
             kind="TABLE",
             this=sg.table(name, catalog=database, quoted=self.compiler.quoted),
             exists=force,
@@ -589,7 +588,7 @@ class Backend(
 
         stmts = []
         if overwrite:
-            stmts.append(sge.Drop(kind="VIEW", this=view, exists=True).sql(self.name))
+            stmts.append(Drop(kind="VIEW", this=view, exists=True).sql(self.name))
         stmts.append(
             sge.Create(
                 this=view, kind="VIEW", replace=False, expression=self.compile(obj)

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -27,6 +27,7 @@ from ibis.backends import (
     NoExampleLoader,
 )
 from ibis.backends.sql import SQLBackend
+from ibis.backends.sql.compilers._compat import Drop
 from ibis.backends.sql.compilers.base import AlterTable, C, RenameTable
 
 if TYPE_CHECKING:
@@ -367,7 +368,7 @@ class Backend(
         self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         with self._safe_raw_sql(
-            sge.Drop(
+            Drop(
                 this=sg.table(name, catalog=catalog, quoted=self.compiler.quoted),
                 kind="SCHEMA",
                 exists=force,
@@ -497,9 +498,7 @@ class Backend(
             if overwrite:
                 # drop the original table
                 cur.execute(
-                    sge.Drop(kind="TABLE", this=orig_table_ref, exists=True).sql(
-                        self.name
-                    )
+                    Drop(kind="TABLE", this=orig_table_ref, exists=True).sql(self.name)
                 )
 
                 # rename the new table to the original table name

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -267,7 +267,7 @@ sortedcontainers==2.4.0
 soupsieve==2.8.3
 sphobjinv==2.3.1.3
 sqlalchemy==2.0.46
-sqlglot==28.9.0
+sqlglot==30.18.0
 sqlparams==6.2.0
 stack-data==0.6.3
 statsmodels==0.14.6

--- a/uv.lock
+++ b/uv.lock
@@ -1138,7 +1138,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -1211,7 +1211,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1679,7 +1679,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -3055,17 +3055,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e5/61/1810830e8b93c72dcd3c0f150c80a00c3deb229562d9423807ec92c3a539/ipython-8.38.0.tar.gz", hash = "sha256:9cfea8c903ce0867cc2f23199ed8545eb741f3a69420bfcf3743ad1cec856d39", size = 5513996, upload-time = "2026-01-05T10:59:06.901Z" }
 wheels = [
@@ -3083,17 +3083,17 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
@@ -3105,7 +3105,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -5674,7 +5674,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version < '3.11'" },
+    { name = "certifi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/10/a8480ea27ea4bbe896c168808854d00f2a9b49f95c0319ddcbba693c8a90/pyproj-3.7.1.tar.gz", hash = "sha256:60d72facd7b6b79853f19744779abcd3f804c4e0d4fa8815469db20c9f640a47", size = 226339, upload-time = "2025-02-16T04:28:46.621Z" }
 wheels = [
@@ -5723,7 +5723,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version >= '3.11'" },
+    { name = "certifi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/90/67bd7260b4ea9b8b20b4f58afef6c223ecb3abf368eb4ec5bc2cdef81b49/pyproj-3.7.2.tar.gz", hash = "sha256:39a0cf1ecc7e282d1d30f36594ebd55c9fae1fda8a2622cee5d100430628f88c", size = 226279, upload-time = "2025-08-14T12:05:42.18Z" }
 wheels = [
@@ -6621,10 +6621,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -6671,10 +6671,10 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -6724,7 +6724,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -6786,7 +6786,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/3e/9cca699f3486ce6bc12ff46dc2031f1ec8eb9ccc9a320fdaf925f1417426/scipy-1.17.0.tar.gz", hash = "sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e", size = 30396830, upload-time = "2026-01-10T21:34:23.009Z" }
 wheels = [
@@ -7121,11 +7121,11 @@ wheels = [
 
 [[package]]
 name = "sqlglot"
-version = "28.9.0"
+version = "30.18.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/72/cc50543a479a65f4ec24bef0e71529254686a1334c57cb1daebadfc29672/sqlglot-28.9.0.tar.gz", hash = "sha256:5648eaa2d038b5a0bc345f223f375315cfc6a27b2852d4eeaa1b8aaaabccdd2c", size = 5736988, upload-time = "2026-02-02T16:04:45.794Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/73/5b5ce3e23b3ded3ea1986c2c2991217460d5fd5161b3e00a8425f5dcb8a3/sqlglot-30.18.0.tar.gz", hash = "sha256:e57e1b205e341979d1df5b1212c1435c598a0437e4619e3f428b15d5bc3a5cc6", size = 6018496, upload-time = "2026-09-03T13:12:58.206Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/21/ee7d2798ff1f59cd5ca53063a728022da53552cbc0c63d05e120e9c9b794/sqlglot-28.9.0-py3-none-any.whl", hash = "sha256:044fbe85fd2dc0a9d8ea4adb2beefa7ff26fa2320849b08f5c5f3859d7973260", size = 595704, upload-time = "2026-02-02T16:04:43.531Z" },
+    { url = "https://files.pythonhosted.org/packages/08/9f/3dd2ec8dd84a33e0092f1c815267bc055073f9e833b93e389c59c10f62cc/sqlglot-30.18.0-py3-none-any.whl", hash = "sha256:ee0f9a9f3e2193e763c326e52dfb377b96fdb4292f6305c3ff2d9a220e71c601", size = 748788, upload-time = "2026-09-03T13:12:56.467Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description of changes

In `sqlglot` 30.18.0 ([tobymao/sqlglot#8229](https://github.com/tobymao/sqlglot/pull/8229)), `Drop`'s `this` argument was renamed to `tables`. Because unrecognized kwargs are silently ignored rather than raising, passing the old `this=` argument yields an empty `DROP TABLE IF EXISTS` statement with no table target, causing syntax errors downstream on every SQL backend:

```python
stmt = sge.Drop(kind="TABLE", this=sg.table("t"), exists=True)
stmt.sql("duckdb")
# Output in 30.18.0: 'DROP TABLE IF EXISTS'  <-- table name missing
```

Added a compatibility wrapper in `_compat.py` that inspects `sge.Drop.arg_types` to map `this` to `tables=[this]` on `sqlglot >= 30.18.0` while maintaining compatibility with older releases.

Tested against `30.17.0` and `30.18.0`.

Closes #12101
