### PR TITLE
fix(trino): pass negative array index directly without offset

### DIFF
--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -584,8 +584,13 @@ class TrinoCompiler(SQLGlotCompiler):
 
     visit_IntegerRange = visit_TimestampRange = visit_Range
 
-    def visit_ArrayIndex(self, op, *, arg, index):
-        return self.f.element_at(arg, index + 1)
+    def visit_ArrayIndex(self, op: ops.ArrayIndex, *, arg, index):
+        if isinstance(op.index, ops.Literal) and op.index.value is not None:
+            i = op.index.value
+            i += i >= 0
+        else:
+            i = self.if_(index >= 0, index + 1, index)
+        return self.f.element_at(arg, i)
 
     def visit_Cast(self, op, *, arg, to):
         from_ = op.arg.dtype

--- a/ibis/backends/sql/tests/test_compiler.py
+++ b/ibis/backends/sql/tests/test_compiler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 import sqlglot as sg
 
 import ibis
@@ -14,7 +15,7 @@ def test_window_with_row_number_compiles():
     expr = (
         ibis.memtable({"a": range(30)})
         .mutate(id=ibis.row_number())
-        .sample(fraction=0.25, seed=0)
+        .sample(0.25, seed=0)
         .mutate(is_test=_.id.isin(_.id))
         .filter(~_.is_test)
     )
@@ -26,3 +27,43 @@ def test_transpile_join():
         "SELECT * FROM t1 JOIN t2 ON x = y", read="duckdb", write=Trino
     )
     assert "CROSS JOIN" not in result
+
+
+@pytest.mark.parametrize(
+    ("index", "expected"),
+    [
+        (0, 'ELEMENT_AT("t0"."arr", 1)'),
+        (1, 'ELEMENT_AT("t0"."arr", 2)'),
+        (2, 'ELEMENT_AT("t0"."arr", 3)'),
+        (-1, 'ELEMENT_AT("t0"."arr", -1)'),
+        (-2, 'ELEMENT_AT("t0"."arr", -2)'),
+        (-3, 'ELEMENT_AT("t0"."arr", -3)'),
+    ],
+)
+def test_trino_array_index_literal(index, expected):
+    t = ibis.table({"arr": "array<string>"}, name="t")
+    sql = ibis.to_sql(t.select(res=t.arr[index]), dialect="trino")
+    assert expected in sql
+
+
+def test_trino_array_index_dynamic():
+    t = ibis.table({"arr": "array<string>", "idx": "int64"}, name="t")
+    sql = ibis.to_sql(t.select(res=t.arr[t.idx]), dialect="trino")
+    assert (
+        'ELEMENT_AT("t0"."arr", IF("t0"."idx" >= 0, "t0"."idx" + 1, "t0"."idx"))' in sql
+    )
+
+
+@pytest.mark.parametrize(
+    ("index", "expected"),
+    [
+        (0, 'ELEMENT_AT("t0"."arr", 1)'),
+        (1, 'ELEMENT_AT("t0"."arr", 2)'),
+        (-1, 'ELEMENT_AT("t0"."arr", -1)'),
+        (-2, 'ELEMENT_AT("t0"."arr", -2)'),
+    ],
+)
+def test_athena_array_index(index, expected):
+    t = ibis.table({"arr": "array<string>"}, name="t")
+    sql = ibis.to_sql(t.select(res=t.arr[index]), dialect="athena")
+    assert expected in sql


### PR DESCRIPTION
## Description of changes

Closes #12105

### Problem
On Trino and Athena backends, `TrinoCompiler.visit_ArrayIndex` compiled all array indices with an unconditional `+ 1` offset: `self.f.element_at(arg, index + 1)`.
While Trino uses 1-based indexing for non-negative indices (`arr[0]` -> `element_at(arr, 1)`), Trino's `element_at(array, index)` natively accepts negative indices counting backwards from the end (`-1` for the last element, `-2` for the second-to-last).
Adding `+ 1` to negative indices caused:
- `arr[-1]` to compile to `element_at(arr, 0)`, which fails at runtime with `INVALID_FUNCTION_ARGUMENT: SQL array indices start at 1`.
- `arr[-2]` to compile to `element_at(arr, -1)`, accessing the wrong element.

### Solution
1. In `TrinoCompiler.visit_ArrayIndex`:
   - For literal non-null integer indices: adjust index by adding 1 only when non-negative (`i += i >= 0`), passing negative literals directly through without offset (`-1` -> `-1`, `-2` -> `-2`).
   - For dynamic column/expression indices: compile with `self.if_(index >= 0, index + 1, index)`.
2. Added comprehensive unit tests in `ibis/backends/sql/tests/test_compiler.py` covering:
   - Positive, zero, and negative literal indices on Trino (`0 -> 1`, `1 -> 2`, `2 -> 3`, `-1 -> -1`, `-2 -> -2`, `-3 -> -3`).
   - Dynamic column index expressions on Trino (`IF("t0"."idx" >= 0, "t0"."idx" + 1, "t0"."idx")`).
   - Athena dialect inheritance tests (`0 -> 1`, `1 -> 2`, `-1 -> -1`, `-2 -> -2`).

### Verification
- `pytest ibis/backends/sql/tests/test_compiler.py` (13 passed).
- `pytest ibis/backends/trino/tests/test_datatypes.py` (38 passed).
- `ruff check` and `ruff format --check` passed cleanly.
