### PR TITLE
fix(mssql): preserve sample standard deviation in STDEV transpilation

### DIFF
--- a/ibis/backends/sql/dialects.py
+++ b/ibis/backends/sql/dialects.py
@@ -360,7 +360,7 @@ class MSSQL(TSQL):
     class Generator(TSQL.Generator):
         TRANSFORMS = TSQL.Generator.TRANSFORMS.copy() | {
             sge.ApproxDistinct: rename_func("approx_count_distinct"),
-            sge.Stddev: rename_func("stdevp"),
+            sge.Stddev: rename_func("stdev"),
             sge.StddevPop: rename_func("stdevp"),
             sge.StddevSamp: rename_func("stdev"),
             sge.Variance: rename_func("var"),

--- a/ibis/backends/sql/tests/test_compiler.py
+++ b/ibis/backends/sql/tests/test_compiler.py
@@ -14,7 +14,7 @@ def test_window_with_row_number_compiles():
     expr = (
         ibis.memtable({"a": range(30)})
         .mutate(id=ibis.row_number())
-        .sample(fraction=0.25, seed=0)
+        .sample(0.25, seed=0)
         .mutate(is_test=_.id.isin(_.id))
         .filter(~_.is_test)
     )
@@ -26,3 +26,18 @@ def test_transpile_join():
         "SELECT * FROM t1 JOIN t2 ON x = y", read="duckdb", write=Trino
     )
     assert "CROSS JOIN" not in result
+
+
+def test_mssql_stddev_transpile():
+    from ibis.backends.sql.dialects import MSSQL
+
+    (stdev_result,) = sg.transpile(
+        "SELECT STDEV([x]) AS [s] FROM [t]", read=MSSQL, write=MSSQL
+    )
+    assert "STDEV([x])" in stdev_result
+    assert "STDEVP" not in stdev_result
+
+    (stdevp_result,) = sg.transpile(
+        "SELECT STDEVP([x]) AS [s] FROM [t]", read=MSSQL, write=MSSQL
+    )
+    assert "STDEVP([x])" in stdevp_result


### PR DESCRIPTION
## Description of changes

Closes #12057

### Problem
`ibis.backends.sql.dialects.MSSQL` previously mapped the bare `sge.Stddev` expression node to `stdevp`:
```python
sge.Stddev: rename_func("stdevp")
```
In standard SQL and T-SQL, `STDEV` computes the sample standard deviation ($s$), while `STDEVP` computes the population standard deviation ($\sigma$). Because `sge.Stddev` represents sample standard deviation, mapping it to `stdevp` caused same-dialect round-trip queries executed through `Backend.sql()` (or `sqlglot.transpile(..., read=MSSQL, write=MSSQL)`) to silently rewrite `SELECT STDEV(x)` into `SELECT STDEVP(x)`, altering statistical calculations from sample to population standard deviation.

### Solution
1. Updated `MSSQL.Generator.TRANSFORMS` in `ibis/backends/sql/dialects.py` to map `sge.Stddev` to `rename_func("stdev")`:
   - `sge.Stddev`: `rename_func("stdev")` (sample standard deviation)
   - `sge.StddevSamp`: `rename_func("stdev")` (sample standard deviation)
   - `sge.StddevPop`: `rename_func("stdevp")` (population standard deviation)
   - Matching the existing pattern for variance: `sge.Variance` -> `var`, `sge.VariancePop` -> `varp`.
2. Added `test_mssql_stddev_transpile` in `ibis/backends/sql/tests/test_compiler.py` verifying that both `STDEV` and `STDEVP` roundtrip through MSSQL transpilation without semantic alteration.

### Verification
- `pytest ibis/backends/sql/tests/test_compiler.py` passed (3/3 passed).
- `ruff check` and `ruff format` passed cleanly.
