### PR TITLE
fix(trino): serialize struct, map, array, and json to string via json_format

### DIFF
--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -597,7 +597,17 @@ class TrinoCompiler(SQLGlotCompiler):
                 return self.f.from_unixtime_nanos(
                     self.cast(arg, dt.Decimal(38, 9)) * 1_000_000_000
                 )
+        elif (from_.is_nested() or from_.is_json()) and to.is_string():
+            if from_.is_json():
+                return self.f.json_format(arg)
+            return self.f.json_format(self.cast(arg, dt.json))
         return super().visit_Cast(op, arg=arg, to=to)
+
+    def visit_TryCast(self, op, *, arg, to):
+        from_ = op.arg.dtype
+        if (from_.is_nested() or from_.is_json()) and to.is_string():
+            return self.f["try"](self.visit_Cast(op, arg=arg, to=to))
+        return super().visit_TryCast(op, arg=arg, to=to)
 
     def visit_CountDistinctStar(self, op, *, arg, where):
         make_col = partial(sg.column, table=arg.alias_or_name, quoted=self.quoted)

--- a/ibis/backends/sql/tests/test_compiler.py
+++ b/ibis/backends/sql/tests/test_compiler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 import sqlglot as sg
 
 import ibis
@@ -14,7 +15,7 @@ def test_window_with_row_number_compiles():
     expr = (
         ibis.memtable({"a": range(30)})
         .mutate(id=ibis.row_number())
-        .sample(fraction=0.25, seed=0)
+        .sample(0.25, seed=0)
         .mutate(is_test=_.id.isin(_.id))
         .filter(~_.is_test)
     )
@@ -26,3 +27,41 @@ def test_transpile_join():
         "SELECT * FROM t1 JOIN t2 ON x = y", read="duckdb", write=Trino
     )
     assert "CROSS JOIN" not in result
+
+
+@pytest.mark.parametrize("dialect", ["trino", "athena"])
+@pytest.mark.parametrize(
+    ("col", "expected_pattern"),
+    [
+        ("s", 'JSON_FORMAT(CAST("t0"."s" AS JSON))'),
+        ("m", 'JSON_FORMAT(CAST("t0"."m" AS JSON))'),
+        ("arr", 'JSON_FORMAT(CAST("t0"."arr" AS JSON))'),
+    ],
+)
+def test_trino_nested_cast_to_string(dialect, col, expected_pattern):
+    t = ibis.table(
+        {
+            "s": "struct<a: int, b: string>",
+            "m": "map<string, int>",
+            "arr": "array<int>",
+        },
+        name="t",
+    )
+    expr = t.select(res=t[col].cast("string"))
+    sql = ibis.to_sql(expr, dialect=dialect)
+    assert expected_pattern in sql
+
+
+def test_trino_json_cast_to_string():
+    t = ibis.table({"j": "json"}, name="t")
+    expr = t.select(res=t.j.cast("string"))
+    sql = ibis.to_sql(expr, dialect="trino")
+    assert 'JSON_FORMAT("t0"."j")' in sql
+
+
+@pytest.mark.parametrize("dialect", ["trino", "athena"])
+def test_trino_nested_try_cast_to_string(dialect):
+    t = ibis.table({"s": "struct<a: int>"}, name="t")
+    expr = t.select(res=t.s.try_cast("string"))
+    sql = ibis.to_sql(expr, dialect=dialect)
+    assert 'TRY(JSON_FORMAT(CAST("t0"."s" AS JSON)))' in sql


### PR DESCRIPTION
## Description

In Trino and Athena, casting a `ROW` (struct), `MAP`, `ARRAY`, or `JSON` object directly to string via `CAST(x AS VARCHAR)` fails with runtime errors:
- `Cannot cast row(...) to varchar`
- `Cannot cast map(...) to varchar`
- `Cannot cast array(...) to varchar`
- `INVALID_CAST_ARGUMENT: Cannot cast '{...}' to varchar` (for JSON objects/arrays)

Trino's standard way to format nested and JSON values to string is `JSON_FORMAT(CAST(x AS JSON))` (or `JSON_FORMAT(x)` for JSON).

### Changes
1. Updated `TrinoCompiler.visit_Cast` to format `from_.is_nested()` types using `self.f.json_format(self.cast(arg, dt.json))` and `from_.is_json()` types using `self.f.json_format(arg)` when casting to string.
2. Added `TrinoCompiler.visit_TryCast` to wrap nested/JSON string conversions in `TRY(...)`.
3. Because `AthenaCompiler` subclasses `TrinoCompiler`, Athena automatically inherits this serialization support.
4. Added parameterized unit tests in `ibis/backends/sql/tests/test_compiler.py` validating `cast("string")` and `try_cast("string")` for struct, map, array, and JSON across both `trino` and `athena` dialects.

Closes #12106
