### PR TITLE
fix(backends): make `Drop` statements compatible with sqlglot 30

### DIFF
--- a/ibis/backends/athena/__init__.py
+++ b/ibis/backends/athena/__init__.py
@@ -25,7 +25,7 @@ import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis import util
 from ibis.backends import CanCreateDatabase, NoExampleLoader, UrlFromPath
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.base import AlterTable, RenameTable
 
 if TYPE_CHECKING:
@@ -448,7 +448,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
 
     def _make_memtable_finalizer(self, name: str) -> Callable[..., None]:
         this = sg.table(name, quoted=self.compiler.quoted)
-        drop_stmt = sge.Drop(kind="TABLE", this=this, exists=True)
+        drop_stmt = drop_statement(kind="TABLE", this=this, exists=True)
         drop_sql = drop_stmt.sql(self.dialect)
         path = f"{self._memtable_volume_path}/{name}"
 
@@ -487,7 +487,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
         self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         name = sg.table(name, catalog=catalog, quoted=self.compiler.quoted)
-        sql = sge.Drop(this=name, kind="SCHEMA", exists=force)
+        sql = drop_statement(this=name, kind="SCHEMA", exists=force)
         with self._safe_raw_sql(sql, unload=False):
             pass
 
@@ -577,7 +577,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
             kind="VIEW",
             expression=sg.parse_one(query, dialect=dialect),
         )
-        drop_view = sge.Drop(
+        drop_view = drop_statement(
             kind="VIEW", this=sg.to_identifier(view_name, quoted=quoted)
         ).sql(dialect)
 

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -40,7 +40,7 @@ from ibis.backends.bigquery.client import (
     schema_from_bigquery_table,
 )
 from ibis.backends.bigquery.datatypes import BigQuerySchema
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -696,7 +696,7 @@ class Backend(
         cascade: bool = False,
     ) -> None:
         """Drop a BigQuery dataset."""
-        stmt = sge.Drop(
+        stmt = drop_statement(
             kind="SCHEMA",
             this=sg.table(name, db=catalog),
             exists=force,
@@ -1289,7 +1289,7 @@ class Backend(
     ) -> None:
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
-        stmt = sge.Drop(
+        stmt = drop_statement(
             kind="TABLE",
             this=sg.table(
                 name,
@@ -1332,7 +1332,7 @@ class Backend(
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
 
-        stmt = sge.Drop(
+        stmt = drop_statement(
             kind="VIEW",
             this=sg.table(
                 name,

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -33,7 +33,7 @@ from ibis.backends import (
     SupportsTempTables,
 )
 from ibis.backends.clickhouse.converter import ClickHousePandasData
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.base import C
 
 if TYPE_CHECKING:
@@ -543,7 +543,7 @@ class Backend(SupportsTempTables, SQLBackend, CanCreateDatabase, DirectExampleLo
     def drop_database(
         self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
-        src = sge.Drop(
+        src = drop_statement(
             this=sg.table(name, catalog=catalog), kind="DATABASE", exists=force
         )
         with self._safe_raw_sql(src):

--- a/ibis/backends/databricks/__init__.py
+++ b/ibis/backends/databricks/__init__.py
@@ -26,7 +26,7 @@ import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis import util
 from ibis.backends import CanCreateDatabase, PyArrowExampleLoader, UrlFromPath
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.base import STAR, AlterTable, RenameTable
 from ibis.backends.sql.datatypes import DatabricksType
 
@@ -234,7 +234,9 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
 
             if overwrite:
                 cur.execute(
-                    sge.Drop(kind="TABLE", this=final_table, exists=True).sql(dialect)
+                    drop_statement(kind="TABLE", this=final_table, exists=True).sql(
+                        dialect
+                    )
                 )
                 if temp:
                     cur.execute(
@@ -246,9 +248,9 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
                         ).sql(dialect)
                     )
                     cur.execute(
-                        sge.Drop(kind="TABLE", this=initial_table, exists=True).sql(
-                            dialect
-                        )
+                        drop_statement(
+                            kind="TABLE", this=initial_table, exists=True
+                        ).sql(dialect)
                     )
                 else:
                     cur.execute(
@@ -338,7 +340,9 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
             # clean up the temporary view
             with self.con.cursor() as cur:
                 cur.execute(
-                    sge.Drop(this=view_name, kind="VIEW", exists=True).sql(self.dialect)
+                    drop_statement(this=view_name, kind="VIEW", exists=True).sql(
+                        self.dialect
+                    )
                 )
 
         js = json.loads(out)
@@ -446,7 +450,9 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
         self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         name = sg.table(name, catalog=catalog, quoted=self.compiler.quoted)
-        with self._safe_raw_sql(sge.Drop(this=name, kind="SCHEMA", replace=force)):
+        with self._safe_raw_sql(
+            drop_statement(this=name, kind="SCHEMA", replace=force)
+        ):
             pass
 
     def list_tables(

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -31,7 +31,7 @@ from ibis.backends import (
     NoUrl,
     SupportsTempTables,
 )
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.base import C
 from ibis.common.dispatch import lazy_singledispatch
 from ibis.expr.operations.udf import InputType
@@ -385,7 +385,9 @@ class Backend(
         self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         db_name = sg.table(name, db=catalog)
-        with self._safe_raw_sql(sge.Drop(kind="SCHEMA", this=db_name, exists=force)):
+        with self._safe_raw_sql(
+            drop_statement(kind="SCHEMA", this=db_name, exists=force)
+        ):
             pass
 
     def list_tables(

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -31,7 +31,7 @@ from ibis.backends import (
     SupportsTempTables,
     UrlFromPath,
 )
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.base import STAR, AlterTable, C, RenameTable
 from ibis.expr.operations.udf import InputType
 
@@ -236,14 +236,16 @@ class Backend(
 
                 if in_memory:
                     cur.execute(
-                        sge.Drop(kind="VIEW", this=table.get_name(), exists=True).sql(
-                            dialect
-                        )
+                        drop_statement(
+                            kind="VIEW", this=table.get_name(), exists=True
+                        ).sql(dialect)
                     )
 
             if overwrite:
                 cur.execute(
-                    sge.Drop(kind="TABLE", this=final_table, exists=True).sql(dialect)
+                    drop_statement(kind="TABLE", this=final_table, exists=True).sql(
+                        dialect
+                    )
                 )
                 # TODO: This branching should be removed once DuckDB >=0.9.3 is
                 # our lower bound (there's an upstream bug in 0.9.2 that
@@ -260,9 +262,9 @@ class Backend(
                         ).sql(dialect)
                     )
                     cur.execute(
-                        sge.Drop(kind="TABLE", this=initial_table, exists=True).sql(
-                            dialect
-                        )
+                        drop_statement(
+                            kind="TABLE", this=initial_table, exists=True
+                        ).sql(dialect)
                     )
                 else:
                     cur.execute(
@@ -537,7 +539,9 @@ class Backend(
             )
 
         name = sg.table(name, catalog=catalog, quoted=self.compiler.quoted)
-        with self._safe_raw_sql(sge.Drop(this=name, kind="SCHEMA", replace=force)):
+        with self._safe_raw_sql(
+            drop_statement(this=name, kind="SCHEMA", replace=force)
+        ):
             pass
 
     @util.experimental

--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -518,3 +518,25 @@ def test_basic_enum_schema_inference(con, converter):
     t = con.table(name)
     assert t.e.type() == dt.string
     assert set(converter(t.e)) == {"a", "b"}
+
+
+def test_drop_view_round_trip(con):
+    """Regression test for #12108.
+
+    sqlglot 30 renamed `Drop.this` to `Drop.tables` and silently ignores the
+    unknown kwarg, so drop statements rendered a nameless
+    `DROP VIEW IF EXISTS`, which raises a syntax error on execute.
+    """
+    name = gen_name("drop_view_regression")
+    con.create_view(name, ibis.literal(1).name("x"))
+    con.drop_view(name)
+    assert name not in con.list_tables()
+
+
+def test_drop_table_round_trip(con):
+    """The table flavor of #12108: `drop_table` must keep its target name."""
+    name = gen_name("drop_table_regression")
+    con.create_table(name, pa.table({"x": [1, 2]}))
+    con.drop_table(name)
+    assert name not in con.list_tables()
+    con.drop_table(name, force=True)

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -20,7 +20,7 @@ import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis import util
 from ibis.backends import CanCreateDatabase, NoExampleLoader
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.base import STAR, C
 
 if TYPE_CHECKING:
@@ -316,15 +316,15 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
 
     def _clean_up_tmp_table(self, name: str) -> None:
         ident = sg.to_identifier(name, quoted=self.compiler.quoted)
-        drop_sql = sge.Drop(kind="TABLE", this=ident, exists=True, cascade=True)
+        drop_sql = drop_statement(kind="TABLE", this=ident, exists=True, cascade=True)
         with self._safe_raw_sql(drop_sql):
             pass
 
     def _make_memtable_finalizer(self, name: str) -> Callable[..., None]:
         ident = sg.to_identifier(name, quoted=self.compiler.quoted)
-        drop_sql = sge.Drop(kind="TABLE", this=ident, exists=True, cascade=True).sql(
-            self.dialect
-        )
+        drop_sql = drop_statement(
+            kind="TABLE", this=ident, exists=True, cascade=True
+        ).sql(self.dialect)
 
         def finalizer(con=self.con, drop_sql=drop_sql) -> None:
             # use try finally because sqlite3's cursor doesn't support the
@@ -424,7 +424,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
 
             if overwrite:
                 self.con.execute(
-                    sge.Drop(kind="TABLE", this=this, exists=True).sql(self.name)
+                    drop_statement(kind="TABLE", this=this, exists=True).sql(self.name)
                 )
                 self.con.execute(
                     f"RENAME TABLE {table_expr.sql(self.name)} TO {this.sql(self.name)}"

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -28,7 +28,7 @@ from ibis.backends.impala.udf import (
     wrap_uda,
     wrap_udf,
 )
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -380,7 +380,7 @@ class Backend(SQLBackend, HasCurrentDatabase, NoExampleLoader):
         create_sql = sge.Create(
             kind="VIEW", this=ident, exists=True, expression=query, dialect=self.dialect
         )
-        drop_sql = sge.Drop(kind="VIEW", this=ident, exists=True)
+        drop_sql = drop_statement(kind="VIEW", this=ident, exists=True)
 
         with self._safe_raw_sql(create_sql):
             pass

--- a/ibis/backends/materialize/__init__.py
+++ b/ibis/backends/materialize/__init__.py
@@ -12,6 +12,7 @@ import ibis
 import ibis.expr.operations as ops
 from ibis.backends.materialize.api import mz_now, mz_top_k
 from ibis.backends.postgres import Backend as PostgresBackend
+from ibis.backends.sql import drop_statement
 from ibis.backends.sql.compilers.materialize import MaterializeCompiler
 
 __all__ = ("Backend", "mz_now", "mz_top_k")
@@ -528,7 +529,9 @@ ORDER BY a.attnum ASC"""  # noqa: S608
 
         # Handle overwrite with RENAME (separate transaction)
         if overwrite:
-            drop_stmt = sge.Drop(kind="TABLE", this=this, exists=True).sql(dialect)
+            drop_stmt = drop_statement(kind="TABLE", this=this, exists=True).sql(
+                dialect
+            )
             rename_stmt = f"ALTER TABLE IF EXISTS {table_expr.sql(dialect)} RENAME TO {this_no_catalog.sql(dialect)}"
 
             with con.cursor() as cursor:
@@ -647,7 +650,7 @@ ORDER BY a.attnum ASC"""  # noqa: S608
         """
         # Note: sqlglot's 'catalog' parameter maps to Materialize's database
         # and sqlglot's 'db' parameter maps to Materialize's schema
-        drop_stmt = sge.Drop(
+        drop_stmt = drop_statement(
             this=sg.table(
                 name, catalog=database, db=schema, quoted=self.compiler.quoted
             ),
@@ -1421,7 +1424,7 @@ ORDER BY a.attnum ASC"""  # noqa: S608
         # and sqlglot's 'db' parameter maps to Materialize's schema
         sink_table = sg.table(name, catalog=database, db=schema, quoted=quoted)
 
-        drop_stmt = sge.Drop(
+        drop_stmt = drop_statement(
             this=sink_table,
             kind="SINK",
             exists=force,
@@ -1618,7 +1621,7 @@ ORDER BY a.attnum ASC"""  # noqa: S608
         # and sqlglot's 'db' parameter maps to Materialize's schema
         conn_table = sg.table(name, catalog=database, db=schema, quoted=quoted)
 
-        drop_stmt = sge.Drop(
+        drop_stmt = drop_statement(
             this=conn_table,
             kind="CONNECTION",
             exists=force,
@@ -1812,7 +1815,7 @@ ORDER BY a.attnum ASC"""  # noqa: S608
         # and sqlglot's 'db' parameter maps to Materialize's schema
         secret_table = sg.table(name, catalog=database, db=schema, quoted=quoted)
 
-        drop_stmt = sge.Drop(
+        drop_stmt = drop_statement(
             this=secret_table,
             kind="SECRET",
             exists=force,
@@ -2010,7 +2013,7 @@ ORDER BY a.attnum ASC"""  # noqa: S608
         quoted = self.compiler.quoted
         cluster_id = sg.to_identifier(name, quoted=quoted)
 
-        drop_stmt = sge.Drop(
+        drop_stmt = drop_statement(
             this=cluster_id,
             kind="CLUSTER",
             exists=force,
@@ -2293,7 +2296,7 @@ ORDER BY a.attnum ASC"""  # noqa: S608
         quoted = self.compiler.quoted
         idx_name = sg.table(name, quoted=quoted)
 
-        drop_cmd = sge.Drop(
+        drop_cmd = drop_statement(
             this=idx_name,
             kind="INDEX",
             exists=force,

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -29,7 +29,7 @@ from ibis.backends import (
     HasCurrentDatabase,
     PyArrowExampleLoader,
 )
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.base import STAR, C
 
 if TYPE_CHECKING:
@@ -477,7 +477,7 @@ GO"""
 
     def drop_catalog(self, name: str, /, *, force: bool = False) -> None:
         with self._safe_ddl(
-            sge.Drop(
+            drop_statement(
                 kind="DATABASE",
                 this=sg.to_identifier(name, quoted=self.compiler.quoted),
                 exists=force,
@@ -546,7 +546,7 @@ GO"""
                 )
 
             cur.execute(
-                sge.Drop(
+                drop_statement(
                     kind="SCHEMA",
                     exists=force,
                     this=sg.to_identifier(name, quoted=quoted),
@@ -723,7 +723,9 @@ GO"""
 
             if overwrite:
                 cur.execute(
-                    sge.Drop(kind="TABLE", this=this, exists=True).sql(self.dialect)
+                    drop_statement(kind="TABLE", this=this, exists=True).sql(
+                        self.dialect
+                    )
                 )
                 old = raw_table.sql(self.dialect)
                 new = raw_this.sql(self.dialect)

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -29,7 +29,7 @@ from ibis.backends import (
     PyArrowExampleLoader,
     SupportsTempTables,
 )
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.base import STAR, TRUE, C, RenameTable
 
 if TYPE_CHECKING:
@@ -241,7 +241,7 @@ class Backend(
     def drop_database(
         self, name: str, *, catalog: str | None = None, force: bool = False
     ) -> None:
-        sql = sge.Drop(
+        sql = drop_statement(
             kind="DATABASE", exists=force, this=sg.table(name, catalog=catalog)
         ).sql(self.name)
         with self.begin() as cur:
@@ -434,7 +434,9 @@ class Backend(
                 cur.execute(sge.Insert(this=table_expr, expression=query).sql(dialect))
 
             if overwrite:
-                cur.execute(sge.Drop(kind="TABLE", this=this, exists=True).sql(dialect))
+                cur.execute(
+                    drop_statement(kind="TABLE", this=this, exists=True).sql(dialect)
+                )
                 cur.execute(
                     sge.Alter(
                         kind="TABLE",

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -28,7 +28,7 @@ from ibis.backends import (
     HasCurrentDatabase,
     PyArrowExampleLoader,
 )
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.base import STAR, C
 
 if TYPE_CHECKING:
@@ -615,7 +615,7 @@ class Backend(
         ident = sg.to_identifier(name, quoted=self.compiler.quoted)
 
         truncate = sge.TruncateTable(expressions=[ident]).sql(dialect)
-        drop = sge.Drop(kind="TABLE", this=ident).sql(dialect)
+        drop = drop_statement(kind="TABLE", this=ident).sql(dialect)
 
         with self.begin() as bind:
             # global temporary tables cannot be dropped without first truncating them
@@ -637,7 +637,7 @@ class Backend(
         ident = sg.to_identifier(name, quoted=self.compiler.quoted)
 
         truncate = sge.TruncateTable(expressions=[ident]).sql(dialect)
-        drop = sge.Drop(kind="TABLE", this=ident).sql(dialect)
+        drop = drop_statement(kind="TABLE", this=ident).sql(dialect)
 
         def finalizer(con=self.con, name: str = name) -> None:
             cursor = con.cursor()

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -29,7 +29,7 @@ from ibis.backends import (
     PyArrowExampleLoader,
     SupportsTempTables,
 )
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.base import TRUE, C, ColGen
 
 if TYPE_CHECKING:
@@ -510,7 +510,7 @@ ORDER BY a.attnum ASC"""
             properties=sge.Properties(expressions=[sge.TemporaryProperty()]),
         ).sql(self.dialect)
 
-        drop_stmt = sge.Drop(kind="VIEW", this=sg.table(name), exists=True).sql(
+        drop_stmt = drop_statement(kind="VIEW", this=sg.table(name), exists=True).sql(
             self.dialect
         )
 
@@ -552,7 +552,7 @@ ORDER BY a.attnum ASC"""
                 f"{self.name} does not support dropping a database in a different catalog"
             )
 
-        sql = sge.Drop(
+        sql = drop_statement(
             kind="SCHEMA",
             this=sg.table(name),
             exists=force,
@@ -654,7 +654,9 @@ ORDER BY a.attnum ASC"""
             stmts.append(sge.Insert(this=table_expr, expression=query).sql(dialect))
 
         if overwrite:
-            stmts.append(sge.Drop(kind="TABLE", this=this, exists=True).sql(dialect))
+            stmts.append(
+                drop_statement(kind="TABLE", this=this, exists=True).sql(dialect)
+            )
             stmts.append(
                 f"ALTER TABLE IF EXISTS {table_expr.sql(dialect)} RENAME TO {this_no_catalog.sql(dialect)}"
             )

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -33,7 +33,7 @@ from ibis.backends import (
 )
 from ibis.backends.pyspark.converter import PySparkPandasData
 from ibis.backends.pyspark.datatypes import PySparkSchema, PySparkType
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.base import AlterTable, RenameTable
 from ibis.expr.operations.udf import InputType
 from ibis.legacy.udf.vectorized import _coerce_to_series
@@ -565,7 +565,7 @@ class Backend(
             database does not exist
 
         """
-        sql = sge.Drop(
+        sql = drop_statement(
             kind="DATABASE",
             exists=force,
             this=sg.to_identifier(name, quoted=self.compiler.quoted),

--- a/ibis/backends/risingwave/__init__.py
+++ b/ibis/backends/risingwave/__init__.py
@@ -27,7 +27,7 @@ from ibis.backends import (
     HasCurrentDatabase,
     NoExampleLoader,
 )
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.base import TRUE, C, ColGen
 from ibis.util import experimental
 
@@ -321,7 +321,7 @@ class Backend(
             expression=sg.parse_one(query, read=self.dialect),
             properties=sge.Properties(expressions=[sge.TemporaryProperty()]),
         )
-        drop_stmt = sge.Drop(kind="VIEW", this=sg.table(name), exists=True).sql(
+        drop_stmt = drop_statement(kind="VIEW", this=sg.table(name), exists=True).sql(
             self.dialect
         )
 
@@ -360,7 +360,7 @@ class Backend(
                 f"{self.name} does not support dropping a database in a different catalog"
             )
 
-        sql = sge.Drop(
+        sql = drop_statement(
             kind="SCHEMA",
             this=sg.table(name),
             exists=force,
@@ -715,7 +715,7 @@ class Backend(
         force
             If `False`, an exception is raised if the view does not exist.
         """
-        src = sge.Drop(
+        src = drop_statement(
             this=sg.table(name, db=database, quoted=self.compiler.quoted),
             kind="MATERIALIZED VIEW",
             exists=force,
@@ -806,7 +806,7 @@ class Backend(
         force
             If `False`, an exception is raised if the source does not exist.
         """
-        src = sge.Drop(
+        src = drop_statement(
             this=sg.table(name, db=database, quoted=self.compiler.quoted),
             kind="SOURCE",
             exists=force,
@@ -897,7 +897,7 @@ class Backend(
         force
             If `False`, an exception is raised if the source does not exist.
         """
-        src = sge.Drop(
+        src = drop_statement(
             this=sg.table(name, db=database, quoted=self.compiler.quoted),
             kind="SINK",
             exists=force,

--- a/ibis/backends/singlestoredb/__init__.py
+++ b/ibis/backends/singlestoredb/__init__.py
@@ -22,7 +22,7 @@ from ibis.backends import (
     PyArrowExampleLoader,
     SupportsTempTables,
 )
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.singlestoredb import compiler
 
 if TYPE_CHECKING:
@@ -254,7 +254,7 @@ class Backend(
         >>> con.drop_database("my_database")  # doctest: +SKIP
         >>> con.drop_database("my_database", force=True)  # doctest: +SKIP
         """
-        sql = sge.Drop(
+        sql = drop_statement(
             kind="DATABASE", exists=force, this=sg.table(name, catalog=catalog)
         ).sql(self.dialect)
         with self.begin() as cur:
@@ -606,7 +606,9 @@ class Backend(
                 # For temporary tables with overwrite, drop the existing table first
                 try:
                     cur.execute(
-                        sge.Drop(kind="TABLE", this=this, exists=True).sql(dialect)
+                        drop_statement(kind="TABLE", this=this, exists=True).sql(
+                            dialect
+                        )
                     )
                 except Exception:
                     # Ignore errors if table doesn't exist
@@ -620,7 +622,9 @@ class Backend(
                 # Only use rename strategy for non-temporary tables
                 final_this = sg.table(name, catalog=database, quoted=quoted)
                 cur.execute(
-                    sge.Drop(kind="TABLE", this=final_this, exists=True).sql(dialect)
+                    drop_statement(kind="TABLE", this=final_this, exists=True).sql(
+                        dialect
+                    )
                 )
                 self.rename_table(temp_name, name)
 
@@ -654,7 +658,7 @@ class Backend(
         force
             Use IF EXISTS clause when dropping
         """
-        drop_stmt = sge.Drop(
+        drop_stmt = drop_statement(
             kind="TABLE",
             this=sg.table(name, db=database, quoted=self.compiler.quoted),
             exists=force,

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -33,7 +33,7 @@ from ibis.backends import (
     SupportsTempTables,
 )
 from ibis.backends.snowflake.converter import SnowflakePandasData
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.base import STAR
 
 if TYPE_CHECKING:
@@ -677,7 +677,7 @@ $$ {defn["source"]} $$"""
             raise com.UnsupportedOperationError(
                 "Dropping the current catalog is not supported because its behavior is undefined"
             )
-        drop_stmt = sge.Drop(
+        drop_stmt = drop_statement(
             this=sg.to_identifier(name, quoted=self.compiler.quoted),
             kind="DATABASE",
             exists=force,
@@ -735,7 +735,7 @@ $$ {defn["source"]} $$"""
                 "Dropping the current database is not supported because its behavior is undefined"
             )
 
-        drop_stmt = sge.Drop(
+        drop_stmt = drop_statement(
             this=sg.table(name, db=catalog, quoted=self.compiler.quoted),
             kind="SCHEMA",
             exists=force,

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -26,6 +26,27 @@ if TYPE_CHECKING:
     from ibis.expr.schema import IntoSchema
 
 
+def drop_statement(
+    *,
+    kind: str,
+    this: str | sg.Expression,
+    exists: bool = False,
+    **kwargs: Any,
+) -> sge.Drop:
+    """Build a `DROP` statement, compatible with all supported sqlglot versions.
+
+    sqlglot 30 renamed `Drop.this` to `Drop.tables` (now a list) and silently
+    ignores unknown kwargs, so which argument carries the drop target depends
+    on the installed version.
+    """
+    from packaging.version import parse as vparse
+
+    if vparse(sg.__version__) >= vparse("30"):
+        target = this if isinstance(this, sge.Expression) else sg.to_identifier(this)
+        return sge.Drop(kind=kind, tables=[target], exists=exists, **kwargs)
+    return sge.Drop(kind=kind, this=this, exists=exists, **kwargs)
+
+
 class SQLBackend(BaseBackend):
     compiler: ClassVar[SQLGlotCompiler]
     name: ClassVar[str]
@@ -269,7 +290,7 @@ class SQLBackend(BaseBackend):
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
 
-        src = sge.Drop(
+        src = drop_statement(
             this=sg.table(name, db=db, catalog=catalog, quoted=self.compiler.quoted),
             kind="VIEW",
             exists=force,
@@ -339,7 +360,7 @@ class SQLBackend(BaseBackend):
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
 
-        drop_stmt = sge.Drop(
+        drop_stmt = drop_statement(
             kind="TABLE",
             this=sg.table(name, db=db, catalog=catalog, quoted=self.compiler.quoted),
             exists=force,
@@ -801,7 +822,7 @@ class SQLBackend(BaseBackend):
 
     def _make_memtable_finalizer(self, name: str) -> Callable[..., None]:
         this = sg.table(name, quoted=self.compiler.quoted)
-        drop_stmt = sge.Drop(kind="TABLE", this=this, exists=True)
+        drop_stmt = drop_statement(kind="TABLE", this=this, exists=True)
         drop_sql = drop_stmt.sql(self.dialect)
 
         def finalizer(drop_sql=drop_sql, con=self.con) -> None:

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -22,7 +22,7 @@ from ibis.backends import (
     SupportsTempTables,
     UrlFromPath,
 )
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.base import C
 from ibis.backends.sqlite.converter import SQLitePandasData
 from ibis.backends.sqlite.udf import ignore_nulls, register_all
@@ -534,14 +534,14 @@ class Backend(
 
                 if in_memory:
                     cur.execute(
-                        sge.Drop(kind="TABLE", this=obj.get_name(), exists=True).sql(
-                            dialect
-                        )
+                        drop_statement(
+                            kind="TABLE", this=obj.get_name(), exists=True
+                        ).sql(dialect)
                     )
 
             if overwrite:
                 cur.execute(
-                    sge.Drop(kind="TABLE", this=table, exists=True).sql(dialect)
+                    drop_statement(kind="TABLE", this=table, exists=True).sql(dialect)
                 )
                 # SQLite's ALTER TABLE statement doesn't support using a
                 # fully-qualified table reference after RENAME TO. Since we
@@ -589,7 +589,9 @@ class Backend(
 
         stmts = []
         if overwrite:
-            stmts.append(sge.Drop(kind="VIEW", this=view, exists=True).sql(self.name))
+            stmts.append(
+                drop_statement(kind="VIEW", this=view, exists=True).sql(self.name)
+            )
         stmts.append(
             sge.Create(
                 this=view, kind="VIEW", replace=False, expression=self.compile(obj)

--- a/ibis/backends/tests/test_drop_statement.py
+++ b/ibis/backends/tests/test_drop_statement.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+import sqlglot as sg
+import sqlglot.expressions as sge
+
+from ibis.backends.sql import drop_statement
+
+
+@pytest.mark.parametrize(
+    ("dialect", "kind", "this"),
+    [
+        ("postgres", "VIEW", sg.table("ibis_tmp")),
+        ("postgres", "SCHEMA", sg.table("myschema")),
+        ("duckdb", "VIEW", "my_temp_view"),
+        ("duckdb", "TABLE", sg.table("final_table")),
+        ("sqlite", "TABLE", "ibis_table"),
+        ("snowflake", "DATABASE", sg.to_identifier("mydb")),
+        ("trino", "SCHEMA", sg.table("myschema", catalog="cat")),
+    ],
+)
+@pytest.mark.parametrize("exists", [True, False])
+def test_drop_statement_preserves_target(dialect, kind, this, exists):
+    # sqlglot 30 renamed `Drop.this` to `Drop.tables` and silently ignores
+    # unknown kwargs, which previously rendered a nameless `DROP ... IF EXISTS`
+    stmt = drop_statement(kind=kind, this=this, exists=exists)
+    sql = stmt.sql(dialect)
+    target = this.sql(dialect) if isinstance(this, sge.Expression) else this
+    assert "DROP" in sql
+    assert kind in sql
+    assert target.strip("'\"") in sql
+
+
+def test_drop_statement_forwards_extra_kwargs():
+    stmt = drop_statement(
+        kind="TABLE", this=sg.to_identifier("t"), exists=True, cascade=True
+    ).sql("postgres")
+    assert "CASCADE" in stmt

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -26,7 +26,7 @@ from ibis.backends import (
     HasCurrentDatabase,
     NoExampleLoader,
 )
-from ibis.backends.sql import SQLBackend
+from ibis.backends.sql import SQLBackend, drop_statement
 from ibis.backends.sql.compilers.base import AlterTable, C, RenameTable
 
 if TYPE_CHECKING:
@@ -367,7 +367,7 @@ class Backend(
         self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         with self._safe_raw_sql(
-            sge.Drop(
+            drop_statement(
                 this=sg.table(name, catalog=catalog, quoted=self.compiler.quoted),
                 kind="SCHEMA",
                 exists=force,
@@ -497,7 +497,7 @@ class Backend(
             if overwrite:
                 # drop the original table
                 cur.execute(
-                    sge.Drop(kind="TABLE", this=orig_table_ref, exists=True).sql(
+                    drop_statement(kind="TABLE", this=orig_table_ref, exists=True).sql(
                         self.name
                     )
                 )


### PR DESCRIPTION
## Summary
sqlglot 30 renamed `Drop.this` to `Drop.tables` (now a list) and silently ignores unknown kwargs. Every `sge.Drop(..., this=...)` call site therefore rendered a nameless `DROP ...` under sqlglot 30 - e.g. `Table.sql()` on postgres executed `DROP VIEW IF EXISTS`, a bare syntax error. This fixes all of them, not just the five backends listed in the issue: the same shape appears in 55 call sites across 21 backend files.

## Root cause
`sqlglot>=23.4,!=26.32.0` has no upper bound, so users on sqlglot 30 hit call sites written against the pre-30 `Drop.this` API. sqlglot ignores unknown expression kwargs instead of raising, so the drop target silently disappears.

## Fix
- Add a `drop_statement` helper next to `SQLBackend` that picks the correct kwarg for the installed sqlglot version (`tables=[...]` on >= 30, `this=` otherwise; `packaging` is imported lazily since it is not a base dependency).
- Route all 55 `sge.Drop` call sites through it.
- No dependency floor bump: the helper keeps sqlglot 23.4+ working, and the lockfile (currently 28.9) is untouched so CI stays green. If you'd rather cover the >= 30 branch in CI, refreshing the lock is a one-liner - happy to include it.

## Tests
- `ibis/backends/tests/test_drop_statement.py`: rendering matrix over 7 dialects / 3 target shapes / exists / cascade - passes under both sqlglot 28.9 and 30.18.
- `ibis/backends/duckdb/tests/test_client.py::test_drop_view_round_trip` and `::test_drop_table_round_trip`: end-to-end regression - **fails on `main` under sqlglot 30.18** (verified), passes here.
- `uv run pytest ibis/backends/duckdb/tests/ ibis/backends/sqlite/tests/`: 165 passed, 2 failed - the 2 `test_decompile_tpch` failures are identical on `main` (pre-existing on Windows).
- `ruff check` / `ruff format --check`: clean.

Fixes #12108