### PR TITLE
feat(trino): support ISO 8601 string to timestamp cast via from_iso8601_timestamp

### DIFF
--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -597,7 +597,15 @@ class TrinoCompiler(SQLGlotCompiler):
                 return self.f.from_unixtime_nanos(
                     self.cast(arg, dt.Decimal(38, 9)) * 1_000_000_000
                 )
+        elif from_.is_string() and to.is_timestamp():
+            return self.cast(self.f.from_iso8601_timestamp(arg), to)
         return super().visit_Cast(op, arg=arg, to=to)
+
+    def visit_TryCast(self, op, *, arg, to):
+        from_ = op.arg.dtype
+        if from_.is_string() and to.is_timestamp():
+            return self.f["try"](self.cast(self.f.from_iso8601_timestamp(arg), to))
+        return super().visit_TryCast(op, arg=arg, to=to)
 
     def visit_CountDistinctStar(self, op, *, arg, where):
         make_col = partial(sg.column, table=arg.alias_or_name, quoted=self.quoted)

--- a/ibis/backends/sql/tests/test_compiler.py
+++ b/ibis/backends/sql/tests/test_compiler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 import sqlglot as sg
 
 import ibis
@@ -14,7 +15,7 @@ def test_window_with_row_number_compiles():
     expr = (
         ibis.memtable({"a": range(30)})
         .mutate(id=ibis.row_number())
-        .sample(fraction=0.25, seed=0)
+        .sample(0.25, seed=0)
         .mutate(is_test=_.id.isin(_.id))
         .filter(~_.is_test)
     )
@@ -26,3 +27,21 @@ def test_transpile_join():
         "SELECT * FROM t1 JOIN t2 ON x = y", read="duckdb", write=Trino
     )
     assert "CROSS JOIN" not in result
+
+
+@pytest.mark.parametrize("dialect", ["trino", "athena"])
+def test_trino_string_cast_to_timestamp(dialect):
+    t = ibis.table({"s": "string"}, name="t")
+    expr = t.select(res=t.s.cast("timestamp"))
+    sql = ibis.to_sql(expr, dialect=dialect)
+    assert 'CAST(FROM_ISO8601_TIMESTAMP("t0"."s") AS TIMESTAMP)' in sql
+
+    expr_tz = t.select(res=t.s.cast("timestamp('UTC')"))
+    sql_tz = ibis.to_sql(expr_tz, dialect=dialect)
+    assert (
+        'CAST(FROM_ISO8601_TIMESTAMP("t0"."s") AS TIMESTAMP WITH TIME ZONE)' in sql_tz
+    )
+
+    expr_try = t.select(res=t.s.try_cast("timestamp"))
+    sql_try = ibis.to_sql(expr_try, dialect=dialect)
+    assert 'TRY(CAST(FROM_ISO8601_TIMESTAMP("t0"."s") AS TIMESTAMP))' in sql_try


### PR DESCRIPTION
Fixes #12107.

Casting ISO 8601 strings (e.g. `'2018-05-02T15:00:00'`) with a `T` separator on Trino / Athena fails with `INVALID_CAST_ARGUMENT` when using a bare `CAST(x AS TIMESTAMP)`. This updates `TrinoCompiler.visit_Cast` and `visit_TryCast` to route string-to-timestamp casts through `from_iso8601_timestamp`, supporting both space-separated and ISO 8601 formatted strings across Trino and Athena dialects, and adds unit test coverage in `test_compiler.py`.
