### PR TITLE
fix(sqlite, mysql, mssql): render boolean-to-string casts as 'true'/'false'

### DIFF
--- a/ibis/backends/sql/compilers/mssql.py
+++ b/ibis/backends/sql/compilers/mssql.py
@@ -61,6 +61,28 @@ def rewrite_rows_range_order_by_window(_, **kwargs):
     return _.copy(order_by=(_.func.arg,))
 
 
+def _boolean_to_string_case(arg: sge.Expression) -> sge.Case:
+    # A predicate cannot appear as a scalar CASE operand in T-SQL, so a
+    # predicate operand takes the searched form and a bit-valued operand the
+    # simple form (which evaluates it exactly once; an impure bit-valued
+    # operand must not be re-evaluated per branch). NULL matches neither
+    # branch of either form, so it stays NULL.
+    if isinstance(arg, (sge.Predicate, sge.Connector, sge.Not)):
+        return sge.Case(
+            ifs=[
+                sge.If(this=arg, true=sge.Literal.string("true")),
+                sge.If(this=sge.Not(this=arg), true=sge.Literal.string("false")),
+            ]
+        )
+    return sge.Case(
+        this=arg,
+        ifs=[
+            sge.If(this=sge.convert(1), true=sge.Literal.string("true")),
+            sge.If(this=sge.convert(0), true=sge.Literal.string("false")),
+        ],
+    )
+
+
 class MSSQLCompiler(SQLGlotCompiler):
     __slots__ = ()
 
@@ -423,22 +445,12 @@ class MSSQLCompiler(SQLGlotCompiler):
 
         if from_.is_boolean() and to.is_string():
             # MSSQL has no boolean type, so CAST(bool AS VARCHAR) renders
-            # '1'/'0' while other backends render 'true'/'false'. A bare BIT
-            # column is not a valid CASE condition in T-SQL, so compare
-            # against the underlying values instead. NULL matches neither
-            # branch and stays NULL.
-            return sge.Case(
-                ifs=[
-                    sge.If(
-                        this=sge.EQ(this=arg, expression=sge.convert(1)),
-                        true=sge.Literal.string("true"),
-                    ),
-                    sge.If(
-                        this=sge.EQ(this=arg, expression=sge.convert(0)),
-                        true=sge.Literal.string("false"),
-                    ),
-                ]
-            )
+            # '1'/'0' while other backends render 'true'/'false'. The simple
+            # CASE evaluates the operand exactly once (an impure operand must
+            # not be re-evaluated per branch) and compares against the
+            # underlying bit values; NULL matches neither branch, so it stays
+            # NULL.
+            return _boolean_to_string_case(arg)
         if to.is_boolean():
             # no such thing as a boolean in MSSQL
             return arg

--- a/ibis/backends/sql/compilers/mssql.py
+++ b/ibis/backends/sql/compilers/mssql.py
@@ -421,6 +421,24 @@ class MSSQLCompiler(SQLGlotCompiler):
     def visit_Cast(self, op, *, arg, to):
         from_ = op.arg.dtype
 
+        if from_.is_boolean() and to.is_string():
+            # MSSQL has no boolean type, so CAST(bool AS VARCHAR) renders
+            # '1'/'0' while other backends render 'true'/'false'. A bare BIT
+            # column is not a valid CASE condition in T-SQL, so compare
+            # against the underlying values instead. NULL matches neither
+            # branch and stays NULL.
+            return sge.Case(
+                ifs=[
+                    sge.If(
+                        this=sge.EQ(this=arg, expression=sge.convert(1)),
+                        true=sge.Literal.string("true"),
+                    ),
+                    sge.If(
+                        this=sge.EQ(this=arg, expression=sge.convert(0)),
+                        true=sge.Literal.string("false"),
+                    ),
+                ]
+            )
         if to.is_boolean():
             # no such thing as a boolean in MSSQL
             return arg

--- a/ibis/backends/sql/compilers/mysql.py
+++ b/ibis/backends/sql/compilers/mysql.py
@@ -113,13 +113,16 @@ class MySQLCompiler(SQLGlotCompiler):
         from_ = op.arg.dtype
         if from_.is_boolean() and to.is_string():
             # MySQL renders booleans as integers, so CAST(bool AS CHAR) renders
-            # '1'/'0' while other backends render 'true'/'false'. NULL falls
-            # through the CASE and stays NULL.
+            # '1'/'0' while other backends render 'true'/'false'. The simple
+            # CASE evaluates the operand exactly once (an impure operand such
+            # as rand() > 0.5 must not be re-evaluated per branch) and NULL
+            # matches neither branch, so it stays NULL.
             return sge.Case(
+                this=arg,
                 ifs=[
-                    sge.If(this=arg, true=sge.Literal.string("true")),
-                    sge.If(this=sge.Not(this=arg), true=sge.Literal.string("false")),
-                ]
+                    sge.If(this=sge.convert(1), true=sge.Literal.string("true")),
+                    sge.If(this=sge.convert(0), true=sge.Literal.string("false")),
+                ],
             )
         if (from_.is_json() or from_.is_string()) and to.is_json():
             # MariaDB does not support casting to JSON because it's an alias

--- a/ibis/backends/sql/compilers/mysql.py
+++ b/ibis/backends/sql/compilers/mysql.py
@@ -111,6 +111,16 @@ class MySQLCompiler(SQLGlotCompiler):
 
     def visit_Cast(self, op, *, arg, to):
         from_ = op.arg.dtype
+        if from_.is_boolean() and to.is_string():
+            # MySQL renders booleans as integers, so CAST(bool AS CHAR) renders
+            # '1'/'0' while other backends render 'true'/'false'. NULL falls
+            # through the CASE and stays NULL.
+            return sge.Case(
+                ifs=[
+                    sge.If(this=arg, true=sge.Literal.string("true")),
+                    sge.If(this=sge.Not(this=arg), true=sge.Literal.string("false")),
+                ]
+            )
         if (from_.is_json() or from_.is_string()) and to.is_json():
             # MariaDB does not support casting to JSON because it's an alias
             # for TEXT (except when casting of course!)

--- a/ibis/backends/sql/compilers/sqlite.py
+++ b/ibis/backends/sql/compilers/sqlite.py
@@ -106,13 +106,16 @@ class SQLiteCompiler(SQLGlotCompiler):
     def visit_Cast(self, op, *, arg, to) -> sge.Cast:
         if to.is_string() and op.arg.dtype.is_boolean():
             # SQLite stores booleans as integers, so CAST(bool AS TEXT) renders
-            # '1'/'0' while other backends render 'true'/'false'. NULL falls
-            # through the CASE and stays NULL.
+            # '1'/'0' while other backends render 'true'/'false'. The simple
+            # CASE evaluates the operand exactly once (an impure operand such
+            # as random() > 0.5 must not be re-evaluated per branch) and NULL
+            # matches neither branch, so it stays NULL.
             return sge.Case(
+                this=arg,
                 ifs=[
-                    sge.If(this=arg, true=sge.Literal.string("true")),
-                    sge.If(this=sge.Not(this=arg), true=sge.Literal.string("false")),
-                ]
+                    sge.If(this=sge.convert(1), true=sge.Literal.string("true")),
+                    sge.If(this=sge.convert(0), true=sge.Literal.string("false")),
+                ],
             )
         if to.is_timestamp():
             if to.timezone not in (None, "UTC"):

--- a/ibis/backends/sql/compilers/sqlite.py
+++ b/ibis/backends/sql/compilers/sqlite.py
@@ -104,6 +104,16 @@ class SQLiteCompiler(SQLGlotCompiler):
         return func(base, arg)
 
     def visit_Cast(self, op, *, arg, to) -> sge.Cast:
+        if to.is_string() and op.arg.dtype.is_boolean():
+            # SQLite stores booleans as integers, so CAST(bool AS TEXT) renders
+            # '1'/'0' while other backends render 'true'/'false'. NULL falls
+            # through the CASE and stays NULL.
+            return sge.Case(
+                ifs=[
+                    sge.If(this=arg, true=sge.Literal.string("true")),
+                    sge.If(this=sge.Not(this=arg), true=sge.Literal.string("false")),
+                ]
+            )
         if to.is_timestamp():
             if to.timezone not in (None, "UTC"):
                 raise com.UnsupportedOperationError(

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1909,6 +1909,15 @@ def test_cast(con, from_type, to_type, from_val, expected):
     assert result == expected
 
 
+def test_cast_computed_bool_to_string(con) -> None:
+    # A computed boolean (rather than a plain column) must also cast to the
+    # 'true'/'false' rendering, including on T-SQL where a predicate cannot
+    # appear as a scalar expression.
+    t = ibis.memtable({"a": [-1.0, 1.0, None]})
+    expr = (t.a > 0).cast("string").name("s")
+    assert con.execute(expr).tolist() == ["false", "true", None]
+
+
 @pytest.mark.notimpl(["oracle", "sqlite"])
 @pytest.mark.parametrize(
     ("from_val", "to_type", "expected"),

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1854,6 +1854,8 @@ def test_hexdigest(backend, alltypes):
         param("float", "int", 0.0, 0, id="float_to_int"),
         param("string", "int", "0", 0, id="string_to_int"),
         param("string", "float", "0", 0.0, id="string_to_float"),
+        param("bool", "string", True, "true", id="bool_to_string"),
+        param("bool", "string", False, "false", id="bool_to_string_false"),
         param(
             "array<int>",
             "array<string>",


### PR DESCRIPTION
fix(sqlite, mysql, mssql): render boolean-to-string casts as 'true'/'false'

## description

casting a boolean to string returned '1'/'0' on sqlite mysql and mssql while
duckdb polars and datafusion return 'true'/'false' so the same expression
gives different results depending on the backend

```python
import ibis

t = ibis.memtable({"b": [True, False, None]})
ibis.sqlite.connect().execute(t.b.cast("string"))
# main  ['1', '0', None]
# fix   ['true', 'false', None]
```

root cause per engine

- sqlite stores booleans as integers so `CAST` renders '1'/'0'
- mysql renders booleans as integers in `CAST(bool AS CHAR)`
- mssql has no boolean type and a bare `BIT` column is not a valid `CASE`
  condition in t-sql so there the fix compares against 1 and 0 explicitly

the fix adds a `visit_Cast` override in the three compilers that returns a
`CASE` with no `ELSE` so `NULL` input stays `NULL`

## test plan

- two new params in `test_cast` (`bool_to_string`, `bool_to_string_false`)
  they fail on main for sqlite and pass with the fix on duckdb sqlite polars
  and datafusion
- generated sql executed in docker containers, mariadb 12.3 and mssql 2022
  both return 'true' 'false' and `NULL`
- `pytest -m "duckdb or sqlite or polars or datafusion" ibis/backends/tests/test_generic.py ibis/backends/tests/test_sql.py` 866 passed
- `pytest -m core` 4429 passed
- ruff clean

one note on the expected value, the pandas oracle gives 'True'/'False'
capitalized which no sql backend matches so the test pins the sql rendering
'true'/'false' that three backends already produced

## issues closed

- none, found by running the same expression on several backends and
  comparing results, did not find an existing report
