### PR TITLE
fix(impala): avoid waiting on uninitialized cursor

### DIFF
--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -229,11 +229,11 @@ class Backend(SQLBackend, HasCurrentDatabase, NoExampleLoader):
                 util.log(q)
                 cursor.execute_async(q)
 
-            cursor._wait_to_finish()
+            if self.options:
+                cursor._wait_to_finish()
 
             util.log(query)
             cursor.execute_async(query)
-
             cursor._wait_to_finish()
         except (Exception, KeyboardInterrupt):
             cursor.cancel_operation()


### PR DESCRIPTION
# Description of changes

Guard the pre-query _wait_to_finish() call in the Ibis Impala backend so it only runs when session options have submitted a SET operation.

When no database or query options are configured, a fresh Impyla cursor has no previous operation. Calling _wait_to_finish() in that state attempts to access _last_operation.handle and raises an AttributeError.

The requested SQL query is still submitted and awaited normally when no session options are configured. Existing behavior is preserved when options are present.